### PR TITLE
Add GCP e2-micro deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,9 @@ GORGONETICS_LOAD_SAMPLE_DATA=false
 GORGONETICS_MAX_UPLOAD_BYTES=5242880
 # Port override (used by Railway, Fly.io, Render — leave unset for default 8000).
 # PORT=8000
+
+# ---------------------------------------------------------------------------
+# DuckDB memory limit — set on constrained VMs to prevent OOM.
+# Examples: "256MB", "512MB". Leave empty for default (80% of RAM).
+# ---------------------------------------------------------------------------
+# DUCKDB_MEMORY_LIMIT=256MB

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -22,6 +22,7 @@ services:
       - GORGONETICS_DATA_PATH=/app/data
       - GORGONETICS_LOAD_SAMPLE_DATA=false
       - GORGONETICS_CONCURRENT_ACCESS=true
+      - DUCKDB_MEMORY_LIMIT=${DUCKDB_MEMORY_LIMIT:-}
     volumes:
       - gorgonetics_data:/app/data
 

--- a/scripts/deploy-gcp.sh
+++ b/scripts/deploy-gcp.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Deploy Gorgonetics to a GCP e2-micro VM.
+#
+# Usage (on the VM):
+#   ./deploy-gcp.sh                          # uses defaults
+#   GORGONETICS_IMAGE=ghcr.io/user/repo:v2 ./deploy-gcp.sh
+#
+# Prerequisites:
+#   - Docker installed and running
+#   - /opt/gorgonetics/.env populated with production env vars
+#   - Data disk mounted at /mnt/gorgonetics-data with docker-data/ subdirectory
+
+set -euo pipefail
+
+IMAGE="${GORGONETICS_IMAGE:-ghcr.io/jlopezpena/gorgonetics:latest}"
+CONTAINER_NAME="gorgonetics"
+ENV_FILE="${GORGONETICS_ENV_FILE:-/opt/gorgonetics/.env}"
+DATA_DIR="${GORGONETICS_DATA_DIR:-/mnt/gorgonetics-data/docker-data}"
+
+echo "==> Pulling $IMAGE"
+docker pull "$IMAGE"
+
+echo "==> Stopping existing container (if any)"
+docker stop "$CONTAINER_NAME" 2>/dev/null || true
+docker rm "$CONTAINER_NAME" 2>/dev/null || true
+
+echo "==> Starting container"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --restart always \
+  --env-file "$ENV_FILE" \
+  -p 80:8000 \
+  -v "$DATA_DIR":/app/data \
+  "$IMAGE"
+
+echo "==> Waiting for health check..."
+for i in $(seq 1 30); do
+  if curl -sf http://localhost/health > /dev/null 2>&1; then
+    echo "==> Application is healthy!"
+    docker image prune -f
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "==> ERROR: Health check failed after 60 seconds"
+docker logs "$CONTAINER_NAME" --tail 50
+exit 1

--- a/src/gorgonetics/ducklake_database.py
+++ b/src/gorgonetics/ducklake_database.py
@@ -8,6 +8,7 @@ catalog database backends (PostgreSQL, MySQL, SQLite, DuckDB).
 import hashlib
 import json
 import logging
+import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -79,6 +80,11 @@ class DuckLakeGeneDatabase:
         """Establish connection to DuckDB and install required extensions."""
         try:
             self.conn = duckdb.connect()
+
+            # Constrain DuckDB memory on small VMs (default: no limit)
+            memory_limit = os.environ.get("DUCKDB_MEMORY_LIMIT")
+            if memory_limit:
+                self.conn.execute(f"SET memory_limit = '{memory_limit}'")
 
             # Install and load DuckLake extension
             self.conn.execute("INSTALL ducklake")


### PR DESCRIPTION
## Summary
- Add configurable `DUCKDB_MEMORY_LIMIT` env var to prevent OOM on constrained VMs (e2-micro has only 1GB RAM; DuckDB defaults to claiming 80%)
- Add `scripts/deploy-gcp.sh` for deploying to a GCP e2-micro VM with persistent data disk
- Update `docker-compose.prod.yml` and `.env.example` with the new variable

## Deployment Architecture
- **GCP e2-micro** (free tier): 1GB RAM, 10GB boot disk + 10GB separate data disk
- **Persistence**: Separate persistent disk with `auto-delete=no` survives VM deletion
- **Memory**: DuckDB capped at 256MB + 1GB swap as safety net
- **Container**: Existing Docker image via GHCR, bind-mounted data directory

## Test plan
- [x] All 96 tests pass
- [x] Ruff lint + format clean
- [x] Type checker clean (pre-existing warnings only)
- [ ] Manual: build Docker image, run with `DUCKDB_MEMORY_LIMIT=256MB`, verify memory stays bounded
- [ ] Manual: deploy to GCP e2-micro following the plan in `.claude/plans/fancy-twirling-sky.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)