### PR TITLE
Drop macOS x64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,6 @@ jobs:
           - platform: macos-latest
             target: aarch64-apple-darwin
             label: macOS-arm64
-          - platform: macos-13
-            target: x86_64-apple-darwin
-            label: macOS-x64
           - platform: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             label: Linux-x64


### PR DESCRIPTION
GitHub no longer provides macOS x64 runners (`macos-13` was the last). Remove the x86_64-apple-darwin target from the release workflow, keeping only arm64.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>