### PR TITLE
Fix gene grid highlighting to match stats table counts

### DIFF
--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -748,7 +748,7 @@ function isGeneVisible(chromosome, gene, geneAnalysis) {
 }
 
 function getContextualAnalysis(species, geneId, geneAnalysis) {
-  if (selectedAttributes.length !== 1 || currentView !== 'attribute') {
+  if (selectedAttributes.length !== 1 || currentView !== 'attribute' || geneAnalysis.type === 'inactive-breed') {
     return geneAnalysis;
   }
   const attr = selectedAttributes[0];


### PR DESCRIPTION
## Summary
- When selecting an attribute (e.g. Temperament) in the stats panel, the grid was highlighting genes that only *potentially* affect that attribute (via the inactive allele), not genes that *actively* affect it
- For example, a Dominant gene with active effect Virility- would show highlighted when Temperament was selected because its recessive allele has Temperament+
- Now the grid filter uses the gene's active effect attribute, matching the stats table counts exactly

## Test plan
- [ ] Select a single attribute (e.g. Temperament) in the stats panel
- [ ] Count highlighted positive/negative genes in the grid — should match the +N-M in the stats table
- [ ] Verify beewasp filtering still works correctly
- [ ] Verify appearance view filtering is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)