### PR TITLE
Add Windows cross-compilation support from macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,32 @@ pnpm test:e2e:ui                  # Playwright UI mode
 
 # Build
 pnpm tauri:build                  # Production app bundle (.app/.dmg)
+pnpm tauri:build:windows          # Cross-compile Windows installer from macOS/Linux
 pnpm build                        # Frontend only (static site)
 ```
+
+### Cross-Compiling for Windows
+
+Build Windows `.exe` installers from macOS or Linux without a Windows machine or CI.
+
+**Prerequisites** (one-time setup):
+```bash
+brew install nsis llvm            # macOS (use apt on Linux)
+rustup target add x86_64-pc-windows-msvc
+cargo install --locked cargo-xwin
+```
+
+**Build**:
+```bash
+pnpm tauri:build:windows
+```
+
+Output: `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/Gorgonetics_*_x64-setup.exe`
+
+**Notes**:
+- First build downloads the Windows SDK (~1 GB, cached for subsequent builds)
+- Produces NSIS installer only (MSI requires a Windows host)
+- Code signing is skipped — use `bundler > windows > sign_command` in `tauri.conf.json` to configure external signing
 
 ## Code Standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ pnpm test:e2e                # Playwright E2E tests (30 tests)
 pnpm test:e2e:headed         # With visible browser
 ```
 
-### Rust Compilation Check
+### Build
 ```bash
-cd src-tauri && cargo check   # Verify Rust compiles
+cd src-tauri && cargo check        # Verify Rust compiles
+pnpm tauri:build                   # macOS production bundle (.app/.dmg)
+pnpm tauri:build:windows           # Cross-compile Windows NSIS installer from macOS
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
+    "tauri:build:windows": "PATH=\"/opt/homebrew/opt/llvm/bin:$PATH\" tauri build --runner cargo-xwin --target x86_64-pc-windows-msvc",
     "generate:templates": "node scripts/generate-gene-templates.js",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "gorgonetics"
-version = "0.1.0-alpha.1"
+version = "0.1.0"
 dependencies = [
  "log",
  "serde",


### PR DESCRIPTION
## Summary
- Add `pnpm tauri:build:windows` script for cross-compiling Windows NSIS installers from macOS using `cargo-xwin`
- Document prerequisites (NSIS, LLVM, cargo-xwin, Windows Rust target) and usage in AGENTS.md
- Update CLAUDE.md build section with new commands

## Test plan
- [x] Ran `pnpm tauri:build:windows` successfully — produced `Gorgonetics_0.1.0_x64-setup.exe` (2.7 MB NSIS installer)
- [ ] Verify installer runs on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)