### PR TITLE
Update docs for public repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ pnpm tauri:dev                    # Launch native app (Vite + Tauri)
 pnpm dev                          # Frontend dev server only (port 5174)
 
 # Quality (MUST pass before committing)
-pnpm run lint:ci                  # ESLint (zero warnings)
+pnpm run lint:ci                  # Biome (zero errors)
 cargo check                       # Rust compilation (run from src-tauri/)
 
 # Tests
@@ -124,7 +124,7 @@ Output: `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/Gorgonetics
 
 ### Quality Gates (enforced by CI)
 ```bash
-pnpm run lint:ci                  # ESLint zero warnings
+pnpm run lint:ci                  # Biome zero errors
 cargo check                       # Rust compilation
 pnpm test:e2e                     # Playwright E2E tests
 ```

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Gorgonetics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,31 @@
 # Gorgonetics
 
-[![CI](https://github.com/jlopezpena/Gorgonetics/workflows/CI/badge.svg)](https://github.com/jlopezpena/Gorgonetics/actions/workflows/ci.yml)
+[![CI](https://github.com/gorgonetics/Gorgonetics/workflows/CI/badge.svg)](https://github.com/gorgonetics/Gorgonetics/actions/workflows/ci.yml)
 
-A native desktop app for genetic breeding analysis in [Project Gorgon](https://projectgorgon.com). View, edit, and analyze pet genome data with an interactive gene visualization grid.
+A native desktop app for genetic breeding analysis in [Project Gorgon](https://projectgorgon.com). Upload, visualize, and edit pet genome data with an interactive gene visualization grid.
 
 Built with **Tauri v2** (Rust) + **Svelte 5** (SvelteKit) + **TypeScript** + **SQLite**.
+
+**[Website & Downloads](https://gorgonetics.github.io/Gorgonetics/)**
 
 ## Features
 
 - Upload and manage pet genome files (.txt format from Project Gorgon)
 - Interactive gene visualization grid with attribute/appearance views
+- Attribute stats summary with counts and breakdowns
 - Edit gene effects (dominant/recessive) per chromosome
 - Species-specific attribute configuration (BeeWasp, Horse)
 - Export gene data as JSON
 - Native file dialogs, SQLite database, single-binary distribution
+- All data stored locally — no accounts, no cloud, no tracking
 
-## Quick Start
+## Download
+
+Pre-built installers for macOS, Windows, and Linux are available on the [releases page](https://github.com/gorgonetics/Gorgonetics/releases).
+
+See the [website](https://gorgonetics.github.io/Gorgonetics/) for detailed installation instructions.
+
+## Development
 
 ### Prerequisites
 
@@ -43,8 +53,6 @@ This starts the Vite dev server and opens the Tauri window.
 pnpm tauri:build      # Build production app (.app/.dmg on macOS)
 ```
 
-## Development
-
 ### Commands
 
 | Command | Description |
@@ -53,7 +61,9 @@ pnpm tauri:build      # Build production app (.app/.dmg on macOS)
 | `pnpm dev` | Frontend dev server only (port 5174) |
 | `pnpm build` | Build frontend (static site) |
 | `pnpm tauri:build` | Build production native app |
+| `pnpm tauri:build:windows` | Cross-compile Windows installer from macOS |
 | `pnpm run lint:ci` | Biome lint check |
+| `pnpm run lint:fix` | Auto-fix formatting and lint issues |
 | `pnpm test:e2e` | Playwright E2E tests |
 | `pnpm test:e2e:headed` | E2E tests with visible browser |
 
@@ -81,7 +91,7 @@ tests/e2e/          Playwright E2E tests
 - **Database**: SQLite via tauri-plugin-sql
 - **Icons**: Lucide Svelte
 - **Testing**: Playwright
-- **Linting**: ESLint
+- **Linting**: Biome
 
 ## Species & Data
 


### PR DESCRIPTION
## Summary
- Fix CI badge URL to point to `gorgonetics` org (was `jlopezpena`)
- Fix linter references: ESLint -> Biome in README and AGENTS.md (matching actual tooling)
- Add MIT LICENSE file (was referenced in README but missing from repo)
- Add links to GitHub Pages site and releases page for end users
- Add download section with link to releases
- Add `lint:fix` and `tauri:build:windows` commands to the commands table

## Test plan
- [ ] Verify CI badge renders correctly on the README
- [ ] Verify LICENSE file is recognized by GitHub (shows in repo sidebar)
- [ ] Verify links to GitHub Pages site and releases work

🤖 Generated with [Claude Code](https://claude.com/claude-code)