### PR TITLE
Disable download links until new binaries available

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -350,8 +350,7 @@
     <h1>Gorgonetics</h1>
     <nav>
       <a href="#features">Features</a>
-      <a href="#downloads">Downloads</a>
-      <a href="#install">Install</a>
+      <a href="#downloads">Download</a>
       <a href="https://github.com/gorgonetics/Gorgonetics">GitHub</a>
     </nav>
   </div>
@@ -364,7 +363,7 @@
       <h2>Pet Breeding Genetics<br>for Project Gorgon</h2>
       <p>A free desktop app to upload, visualize, and edit pet genome data. Understand your pets' genetics and breed smarter.</p>
       <div class="hero-buttons">
-        <a href="#downloads" class="btn btn-primary">Download</a>
+        <a href="https://github.com/gorgonetics/Gorgonetics/releases" class="btn btn-primary">Releases</a>
         <a href="https://github.com/gorgonetics/Gorgonetics" class="btn btn-secondary">View Source</a>
       </div>
     </div>
@@ -425,69 +424,19 @@
   <section class="downloads" id="downloads">
     <div class="container">
       <h3>Download</h3>
-      <p class="subtitle">Latest release: <strong>v0.1.0</strong></p>
-      <div class="download-grid">
-        <div class="download-card">
-          <h4>macOS</h4>
-          <div class="dl-links">
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_0.1.0_aarch64.dmg">Gorgonetics_0.1.0_aarch64.dmg</a>
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_aarch64.app.tar.gz">Gorgonetics_aarch64.app.tar.gz</a>
-          </div>
-          <div class="install-note">
-            Apple Silicon (M1/M2/M3). Open the <code>.dmg</code> and drag to Applications. On first launch, right-click &rarr; Open to bypass Gatekeeper.
-          </div>
-        </div>
-        <div class="download-card">
-          <h4>Windows</h4>
-          <div class="dl-links">
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_0.1.0_x64-setup.exe">Gorgonetics_0.1.0_x64-setup.exe</a>
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_0.1.0_x64_en-US.msi">Gorgonetics_0.1.0_x64_en-US.msi</a>
-          </div>
-          <div class="install-note">
-            64-bit Windows 10+. Run the installer &mdash; it will install to Program Files and create a Start Menu shortcut. Windows may show a SmartScreen warning for unsigned apps; click "More info" &rarr; "Run anyway".
-          </div>
-        </div>
-        <div class="download-card">
-          <h4>Linux</h4>
-          <div class="dl-links">
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_0.1.0_amd64.AppImage">Gorgonetics_0.1.0_amd64.AppImage</a>
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics_0.1.0_amd64.deb">Gorgonetics_0.1.0_amd64.deb</a>
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.0/Gorgonetics-0.1.0-1.x86_64.rpm">Gorgonetics-0.1.0-1.x86_64.rpm</a>
-          </div>
-          <div class="install-note">
-            x86_64 Linux. AppImage: <code>chmod +x</code> and run. Deb: <code>sudo dpkg -i *.deb</code>. RPM: <code>sudo rpm -i *.rpm</code>.
-          </div>
-        </div>
+      <p class="subtitle">New binaries coming soon &mdash; check back shortly.</p>
+      <div class="note-box" style="max-width: 600px; margin: 0 auto;">
+        Pre-built installers for macOS, Windows, and Linux will be available on the
+        <a href="https://github.com/gorgonetics/Gorgonetics/releases">GitHub Releases page</a>.
       </div>
     </div>
   </section>
 
   <section class="install" id="install">
     <div class="container">
-      <h3>Installation Guide</h3>
+      <h3>Getting Started</h3>
       <div class="install-steps">
-        <h4>macOS</h4>
-        <ol>
-          <li>Download the <code>.dmg</code> file above</li>
-          <li>Open the <code>.dmg</code> and drag <strong>Gorgonetics</strong> into your Applications folder</li>
-          <li>On first launch, macOS will block the app because it's unsigned. Right-click the app &rarr; <strong>Open</strong>, then click <strong>Open</strong> in the dialog</li>
-          <li>Alternatively, go to System Settings &rarr; Privacy &amp; Security and click "Open Anyway"</li>
-        </ol>
-
-        <h4>Windows</h4>
-        <ol>
-          <li>Download the <code>.exe</code> installer above</li>
-          <li>Run the installer &mdash; it will guide you through the setup</li>
-          <li>If Windows SmartScreen shows a warning, click <strong>"More info"</strong> then <strong>"Run anyway"</strong></li>
-          <li>Launch from the Start Menu or desktop shortcut</li>
-        </ol>
-
-        <h4>Linux</h4>
-        <ol>
-          <li><strong>AppImage</strong> (any distro): Download, run <code>chmod +x Gorgonetics_*.AppImage</code>, then execute it</li>
-          <li><strong>Debian/Ubuntu</strong>: <code>sudo dpkg -i Gorgonetics_*_amd64.deb</code></li>
-          <li><strong>Fedora/RHEL</strong>: <code>sudo rpm -i Gorgonetics-*.x86_64.rpm</code></li>
-        </ol>
+        <p>Gorgonetics is available for <strong>macOS</strong>, <strong>Windows</strong>, and <strong>Linux</strong>. Download the installer for your platform from the <a href="https://github.com/gorgonetics/Gorgonetics/releases">releases page</a> when available.</p>
 
         <div class="note-box">
           <strong>Note:</strong> Gorgonetics stores all data locally in a SQLite database. No account or internet connection is required. On first launch, the app loads demo gene templates and sample pets so you can explore immediately.


### PR DESCRIPTION
## Summary
- Replace per-platform download cards with a "coming soon" notice linking to GitHub Releases
- Simplify install section to a short paragraph
- Hero button now links directly to the releases page

## Context
The v0.1.0 CI-built binaries didn't work properly and action credits are exhausted. Binaries will be manually uploaded once ready.

## Test plan
- [ ] Verify the site renders the "coming soon" notice instead of broken download links
- [ ] Verify the releases page link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)