### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorgonetics",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.1",
   "description": "Gorgon genetics breeding tool for Project Gorgon",
   "type": "module",
   "private": true,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gorgonetics"
-version = "0.1.0"
+version = "0.1.1"
 description = "Gorgonetics - Pet Genetics Breeding Tool"
 authors = ["Javier Lopez Pena"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Gorgonetics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.gorgonetics.app",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0 to 0.1.1 in all three config files:
  - `package.json` (was 0.1.0-alpha.1)
  - `src-tauri/tauri.conf.json` (was 0.1.0)
  - `src-tauri/Cargo.toml` (was 0.1.0)

Ensures build artifacts are named `Gorgonetics_0.1.1_*` going forward.

## Test plan
- [ ] `pnpm tauri:build` produces files named with 0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)