### PR TITLE
Fix download links to match 0.1.1 artifact filenames

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -429,8 +429,8 @@
         <div class="download-card">
           <h4>macOS</h4>
           <div class="dl-links">
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_0.1.0_aarch64.dmg">Gorgonetics_0.1.0_aarch64.dmg</a>
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_aarch64.app.tar.gz">Gorgonetics_aarch64.app.tar.gz</a>
+            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_0.1.1_aarch64.dmg">Gorgonetics_0.1.1_aarch64.dmg</a>
+            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_0.1.1_aarch64.app.tar.gz">Gorgonetics_0.1.1_aarch64.app.tar.gz</a>
           </div>
           <div class="install-note">
             Apple Silicon (M1/M2/M3). Open the <code>.dmg</code> and drag to Applications. On first launch, right-click &rarr; Open to bypass Gatekeeper.
@@ -439,7 +439,7 @@
         <div class="download-card">
           <h4>Windows</h4>
           <div class="dl-links">
-            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_0.1.0_x64-setup.exe">Gorgonetics_0.1.0_x64-setup.exe</a>
+            <a href="https://github.com/gorgonetics/Gorgonetics/releases/download/v0.1.1/Gorgonetics_0.1.1_x64-setup.exe">Gorgonetics_0.1.1_x64-setup.exe</a>
           </div>
           <div class="install-note">
             64-bit Windows 10+. Run the installer &mdash; it will install to Program Files and create a Start Menu shortcut. Windows may show a SmartScreen warning for unsigned apps; click "More info" &rarr; "Run anyway".


### PR DESCRIPTION
## Summary
- Fix download URLs and link text to reference `0.1.1` filenames instead of `0.1.0`
- The previous PR merged before the filename fix commit landed

## Test plan
- [ ] All three download links resolve to actual release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)