### PR TITLE
Fix dependabot: use npm ecosystem instead of pnpm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary
- Change `package-ecosystem` from `pnpm` to `npm` — `pnpm` is not a valid value; `npm` covers npm/pnpm/yarn

## Test plan
- [ ] Dependabot config validates without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)