### PR TITLE
Fix useOptionalChain Biome warnings

### DIFF
--- a/src/lib/components/GeneEditingView.svelte
+++ b/src/lib/components/GeneEditingView.svelte
@@ -174,7 +174,7 @@ function toggleDropdown(geneId, field, event) {
     setTimeout(() => {
       const trigger = event.target;
       const dropdown = trigger.nextElementSibling;
-      if (dropdown && dropdown.classList.contains('dropdown')) {
+      if (dropdown?.classList.contains('dropdown')) {
         const rect = trigger.getBoundingClientRect();
         const dropdownHeight = dropdown.offsetHeight;
         const viewportHeight = window.innerHeight;

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -379,7 +379,7 @@ function getGeneEffect(species, geneId, geneType) {
 
   const speciesKey = normalizeSpecies(species);
 
-  const geneData = geneEffectsDB[speciesKey] && geneEffectsDB[speciesKey][geneId];
+  const geneData = geneEffectsDB[speciesKey]?.[geneId];
 
   if (!geneData) {
     return 'No gene data found';
@@ -407,11 +407,10 @@ function getGeneAppearance(species, geneId) {
 
   const speciesKey = normalizeSpecies(species);
 
-  const geneData = geneEffectsDB[speciesKey] && geneEffectsDB[speciesKey][geneId];
+  const geneData = geneEffectsDB[speciesKey]?.[geneId];
 
   if (
-    !geneData ||
-    !geneData.appearance ||
+    !geneData?.appearance ||
     geneData.appearance === 'None' ||
     geneData.appearance.includes('String for me to fill')
   ) {
@@ -818,7 +817,7 @@ async function updateVisualization() {
 }
 
 async function createGeneVisualization() {
-  if (!currentPet || !currentPet.genes) {
+  if (!currentPet?.genes) {
     // Reset to empty state with proper structure
     headerStructure = null;
     chromosomeData = [];


### PR DESCRIPTION
## Summary
- Replaces `foo && foo.bar` patterns with `foo?.bar` optional chaining in 2 Svelte components
- Eliminates all 5 `useOptionalChain` Biome warnings (lint now reports 0 warnings, down from 5)

Closes #38

## Test plan
- [x] `pnpm lint:ci` — 0 warnings, 0 errors
- [x] `pnpm test:e2e` — 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)