### PR TITLE
Extract shared isTauri() utility

### DIFF
--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -4,6 +4,8 @@
  * Falls back to an in-memory store when running outside Tauri (e.g., Playwright tests).
  */
 
+import { isTauri } from '$lib/utils/environment.js';
+
 let db: DatabaseAdapter | null = null;
 
 interface QueryResult {
@@ -230,16 +232,6 @@ class InMemoryDatabase implements DatabaseAdapter {
       }
     }
     return true;
-  }
-}
-
-// --- Detect Tauri context ---
-
-function isTauri(): boolean {
-  try {
-    return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
-  } catch {
-    return false;
   }
 }
 

--- a/src/lib/services/fileService.ts
+++ b/src/lib/services/fileService.ts
@@ -4,13 +4,7 @@
  * Falls back to browser APIs when running outside Tauri (tests).
  */
 
-function isTauri(): boolean {
-  try {
-    return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
-  } catch {
-    return false;
-  }
-}
+import { isTauri } from '$lib/utils/environment.js';
 
 async function pickFile(title: string, filterName: string, extensions: string[]): Promise<string | null> {
   if (isTauri()) {

--- a/src/lib/utils/environment.ts
+++ b/src/lib/utils/environment.ts
@@ -1,0 +1,10 @@
+/**
+ * Detect whether the app is running inside a Tauri native shell.
+ */
+export function isTauri(): boolean {
+  try {
+    return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated `isTauri()` function into `src/lib/utils/environment.ts`
- Replaces local definitions in `database.ts` and `fileService.ts` with shared import

Closes #65

## Test plan
- [x] `pnpm lint:ci` — 0 warnings, 0 errors
- [x] `pnpm test:e2e` — 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)