### PR TITLE
Wrap database import in BEGIN/COMMIT transaction

### DIFF
--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -150,21 +150,11 @@ export async function importDatabase(
   let petsImported = 0;
   let petsSkipped = 0;
 
-  if (mode === 'replace') {
-    await db.execute('DELETE FROM pets');
-    await db.execute('DELETE FROM genes');
-  }
-
   // Pre-compute SQL strings (invariant across iterations)
   const genePlaceholders = GENE_COLUMNS.map(() => '?').join(', ');
   const geneSQL = `INSERT OR REPLACE INTO genes (${GENE_COLUMNS.join(', ')}) VALUES (${genePlaceholders})`;
   const petPlaceholders = PET_COLUMNS.map(() => '?').join(', ');
   const petSQL = `INSERT INTO pets (${PET_COLUMNS.join(', ')}) VALUES (${petPlaceholders})`;
-
-  for (const gene of backup.data.genes) {
-    const values = GENE_COLUMNS.map((col) => gene[col] ?? null);
-    await db.execute(geneSQL, values);
-  }
 
   // Pre-fetch existing content hashes for merge dedup (avoids N+1 queries)
   let existingHashes: Set<string> | null = null;
@@ -173,23 +163,42 @@ export async function importDatabase(
     existingHashes = new Set(rows.map((r) => r.content_hash));
   }
 
-  for (const pet of backup.data.pets) {
-    if (existingHashes?.has(pet.content_hash)) {
-      petsSkipped++;
-      continue;
+  // Wrap all writes in a transaction for atomicity and performance
+  await db.execute('BEGIN');
+  try {
+    if (mode === 'replace') {
+      await db.execute('DELETE FROM pets');
+      await db.execute('DELETE FROM genes');
     }
 
-    let genomeData = pet.genome_data;
-    if (typeof genomeData === 'object' && genomeData !== null) {
-      genomeData = JSON.stringify(genomeData);
+    for (const gene of backup.data.genes) {
+      const values = GENE_COLUMNS.map((col) => gene[col] ?? null);
+      await db.execute(geneSQL, values);
     }
 
-    const values = PET_COLUMNS.map((col) => {
-      if (col === 'genome_data') return genomeData;
-      return pet[col] ?? null;
-    });
-    await db.execute(petSQL, values);
-    petsImported++;
+    for (const pet of backup.data.pets) {
+      if (existingHashes?.has(pet.content_hash)) {
+        petsSkipped++;
+        continue;
+      }
+
+      let genomeData = pet.genome_data;
+      if (typeof genomeData === 'object' && genomeData !== null) {
+        genomeData = JSON.stringify(genomeData);
+      }
+
+      const values = PET_COLUMNS.map((col) => {
+        if (col === 'genome_data') return genomeData;
+        return pet[col] ?? null;
+      });
+      await db.execute(petSQL, values);
+      petsImported++;
+    }
+
+    await db.execute('COMMIT');
+  } catch (error) {
+    await db.execute('ROLLBACK');
+    throw error;
   }
 
   return { genes: backup.data.genes.length, pets: petsImported, skipped: petsSkipped };

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -25,6 +25,7 @@ class InMemoryDatabase implements DatabaseAdapter {
   private tables: Record<string, Record<string, unknown>[]> = {};
   private autoIncrements: Record<string, number> = {};
   private userVersion = 0;
+  private snapshot: { tables: string; autoIncrements: string; userVersion: number } | null = null;
 
   async select<T>(query: string, bindValues: unknown[] = []): Promise<T> {
     // Normalize multi-line SQL to single line for regex matching
@@ -91,6 +92,29 @@ class InMemoryDatabase implements DatabaseAdapter {
     const pragmaMatch = qLower.match(/pragma\s+user_version\s*=\s*(\d+)/);
     if (pragmaMatch) {
       this.userVersion = Number.parseInt(pragmaMatch[1], 10);
+      return { rowsAffected: 0, lastInsertId: 0 };
+    }
+
+    // Transaction control
+    if (qLower === 'begin' || qLower === 'begin transaction') {
+      this.snapshot = {
+        tables: JSON.stringify(this.tables),
+        autoIncrements: JSON.stringify(this.autoIncrements),
+        userVersion: this.userVersion,
+      };
+      return { rowsAffected: 0, lastInsertId: 0 };
+    }
+    if (qLower === 'commit') {
+      this.snapshot = null;
+      return { rowsAffected: 0, lastInsertId: 0 };
+    }
+    if (qLower === 'rollback') {
+      if (this.snapshot) {
+        this.tables = JSON.parse(this.snapshot.tables);
+        this.autoIncrements = JSON.parse(this.snapshot.autoIncrements);
+        this.userVersion = this.snapshot.userVersion;
+        this.snapshot = null;
+      }
       return { rowsAffected: 0, lastInsertId: 0 };
     }
 


### PR DESCRIPTION
## Summary
- Import operations are now wrapped in `BEGIN`/`COMMIT` for atomicity — if any INSERT fails, `ROLLBACK` restores the database to its pre-import state
- Eliminates per-statement fsync overhead from SQLite's implicit auto-commit
- Adds `BEGIN`/`COMMIT`/`ROLLBACK` support to `InMemoryDatabase` via JSON snapshot/restore, so transactions work identically in E2E tests

Closes #66

## Test plan
- [x] `pnpm lint:ci` — 0 warnings, 0 errors
- [x] `pnpm test:e2e` — 57 tests pass (including import round-trip tests that exercise the transaction path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)