### PR TITLE
Convert SQL queries from positional ? to named $parameters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ pnpm test:e2e                     # Playwright E2E tests
 - Use `getDb()` from `database.ts` for all SQL queries
 - `initDatabase()` called once in AuthWrapper on app startup
 - In-memory fallback auto-detected when not running in Tauri
-- Currently uses positional `?` placeholders; planned migration to named `$name` parameters (#67)
+- Use named `$name` parameters (with `Record<string, unknown>` bind values) instead of positional `?` placeholders
 
 ### Master-Detail Layout
 - MasterPanel (left, 260px): PetList or GeneEditor based on active tab

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1421,7 +1421,7 @@ dependencies = [
 
 [[package]]
 name = "gorgonetics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "log",
  "serde",

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -151,9 +151,9 @@ export async function importDatabase(
   let petsSkipped = 0;
 
   // Pre-compute SQL strings (invariant across iterations)
-  const genePlaceholders = GENE_COLUMNS.map(() => '?').join(', ');
+  const genePlaceholders = GENE_COLUMNS.map((col) => `$${col}`).join(', ');
   const geneSQL = `INSERT OR REPLACE INTO genes (${GENE_COLUMNS.join(', ')}) VALUES (${genePlaceholders})`;
-  const petPlaceholders = PET_COLUMNS.map(() => '?').join(', ');
+  const petPlaceholders = PET_COLUMNS.map((col) => `$${col}`).join(', ');
   const petSQL = `INSERT INTO pets (${PET_COLUMNS.join(', ')}) VALUES (${petPlaceholders})`;
 
   // Pre-fetch existing content hashes for merge dedup (avoids N+1 queries)
@@ -172,8 +172,9 @@ export async function importDatabase(
     }
 
     for (const gene of backup.data.genes) {
-      const values = GENE_COLUMNS.map((col) => gene[col] ?? null);
-      await db.execute(geneSQL, values);
+      const params: Record<string, unknown> = {};
+      for (const col of GENE_COLUMNS) params[col] = gene[col] ?? null;
+      await db.execute(geneSQL, params);
     }
 
     for (const pet of backup.data.pets) {
@@ -187,11 +188,11 @@ export async function importDatabase(
         genomeData = JSON.stringify(genomeData);
       }
 
-      const values = PET_COLUMNS.map((col) => {
-        if (col === 'genome_data') return genomeData;
-        return pet[col] ?? null;
-      });
-      await db.execute(petSQL, values);
+      const params: Record<string, unknown> = {};
+      for (const col of PET_COLUMNS) {
+        params[col] = col === 'genome_data' ? genomeData : (pet[col] ?? null);
+      }
+      await db.execute(petSQL, params);
       petsImported++;
     }
 

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -13,9 +13,11 @@ interface QueryResult {
   lastInsertId: number;
 }
 
+type BindValues = unknown[] | Record<string, unknown>;
+
 interface DatabaseAdapter {
-  select<T>(query: string, bindValues?: unknown[]): Promise<T>;
-  execute(query: string, bindValues?: unknown[]): Promise<QueryResult>;
+  select<T>(query: string, bindValues?: BindValues): Promise<T>;
+  execute(query: string, bindValues?: BindValues): Promise<QueryResult>;
   close(): Promise<void>;
 }
 
@@ -27,9 +29,21 @@ class InMemoryDatabase implements DatabaseAdapter {
   private userVersion = 0;
   private snapshot: { tables: string; autoIncrements: string; userVersion: number } | null = null;
 
-  async select<T>(query: string, bindValues: unknown[] = []): Promise<T> {
+  /** Convert $name parameters to positional ? so internal logic stays unchanged. */
+  private resolveParams(query: string, bindValues: BindValues = []): { query: string; values: unknown[] } {
+    if (Array.isArray(bindValues)) return { query, values: bindValues };
+    const values: unknown[] = [];
+    const resolved = query.replace(/\$(\w+)/g, (_, name) => {
+      values.push((bindValues as Record<string, unknown>)[name]);
+      return '?';
+    });
+    return { query: resolved, values };
+  }
+
+  async select<T>(query: string, bindValues: BindValues = []): Promise<T> {
+    const { query: q0, values } = this.resolveParams(query, bindValues);
     // Normalize multi-line SQL to single line for regex matching
-    const q = query.replace(/\s+/g, ' ').trim().toLowerCase();
+    const q = q0.replace(/\s+/g, ' ').trim().toLowerCase();
 
     // PRAGMA user_version (read)
     if (q.includes('pragma user_version')) {
@@ -41,7 +55,7 @@ class InMemoryDatabase implements DatabaseAdapter {
     if (countMatch) {
       const [, alias, table] = countMatch;
       const rows = this.getTable(table);
-      const filtered = this.applyWhere(rows, q, bindValues);
+      const filtered = this.applyWhere(rows, q, values);
       return [{ [alias]: filtered.length }] as T;
     }
 
@@ -50,7 +64,7 @@ class InMemoryDatabase implements DatabaseAdapter {
     if (distinctMatch) {
       const [, col, table] = distinctMatch;
       const rows = this.getTable(table);
-      const filtered = this.applyWhere(rows, q, bindValues);
+      const filtered = this.applyWhere(rows, q, values);
       const unique = [...new Set(filtered.map((r) => r[col]))].sort();
       return unique.map((v) => ({ [col]: v })) as T;
     }
@@ -60,7 +74,7 @@ class InMemoryDatabase implements DatabaseAdapter {
     if (selectMatch) {
       const table = selectMatch[1];
       const rows = this.getTable(table);
-      let filtered = this.applyWhere(rows, q, bindValues);
+      let filtered = this.applyWhere(rows, q, values);
 
       // ORDER BY
       const orderMatch = q.match(/order\s+by\s+(\w+)/);
@@ -73,8 +87,8 @@ class InMemoryDatabase implements DatabaseAdapter {
       const limitMatch = q.match(/limit\s+(\?)\s+offset\s+(\?)/);
       if (limitMatch) {
         const whereParamCount = q.match(/where/i) ? q.split('?').length - 1 - 2 : 0;
-        const limit = Number(bindValues[whereParamCount]);
-        const offset = Number(bindValues[whereParamCount + 1]);
+        const limit = Number(values[whereParamCount]);
+        const offset = Number(values[whereParamCount + 1]);
         filtered = filtered.slice(offset, offset + limit);
       }
 
@@ -84,8 +98,9 @@ class InMemoryDatabase implements DatabaseAdapter {
     return [] as T;
   }
 
-  async execute(query: string, bindValues: unknown[] = []): Promise<QueryResult> {
-    const q = query.replace(/\s+/g, ' ').trim();
+  async execute(query: string, bindValues: BindValues = []): Promise<QueryResult> {
+    const { query: q0, values: bindArr } = this.resolveParams(query, bindValues);
+    const q = q0.replace(/\s+/g, ' ').trim();
     const qLower = q.toLowerCase();
 
     // PRAGMA user_version = N (write)
@@ -145,7 +160,7 @@ class InMemoryDatabase implements DatabaseAdapter {
         const row: Record<string, unknown> = {};
         let paramIdx = 0;
         for (const col of cols) {
-          row[col] = bindValues[paramIdx++];
+          row[col] = bindArr[paramIdx++];
         }
 
         // Handle AUTOINCREMENT for 'id' column
@@ -194,7 +209,7 @@ class InMemoryDatabase implements DatabaseAdapter {
 
         // Parse WHERE conditions
         const whereSection = q.match(/where\s+(.+)$/i);
-        const whereParams = bindValues.slice(setParamCount);
+        const whereParams = bindArr.slice(setParamCount);
 
         let affected = 0;
         for (const row of rows) {
@@ -203,7 +218,7 @@ class InMemoryDatabase implements DatabaseAdapter {
             for (const clause of setClauses) {
               const [col] = clause.split('=').map((s) => s.trim());
               if (clause.includes('?')) {
-                row[col] = bindValues[paramIdx++];
+                row[col] = bindArr[paramIdx++];
               }
             }
             affected++;
@@ -220,7 +235,7 @@ class InMemoryDatabase implements DatabaseAdapter {
         const table = tableMatch[1].toLowerCase();
         const rows = this.getTable(table);
         const before = rows.length;
-        this.tables[table] = rows.filter((r) => !this.matchesWhere(r, qLower.split('where')[1] ?? '', bindValues));
+        this.tables[table] = rows.filter((r) => !this.matchesWhere(r, qLower.split('where')[1] ?? '', bindArr));
         return { rowsAffected: before - this.tables[table].length, lastInsertId: 0 };
       }
     }

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -26,8 +26,8 @@ export async function getAnimalTypes(): Promise<string[]> {
 export async function getChromosomes(animalType: string): Promise<string[]> {
   const db = getDb();
   const rows = await db.select<{ chromosome: string }[]>(
-    'SELECT DISTINCT chromosome FROM genes WHERE animal_type = ? ORDER BY chromosome',
-    [animalType],
+    'SELECT DISTINCT chromosome FROM genes WHERE animal_type = $animalType ORDER BY chromosome',
+    { animalType },
   );
   return rows.map((r) => r.chromosome);
 }
@@ -41,9 +41,9 @@ export async function getGenesByChromosome(animalType: string, chromosome: strin
     `SELECT animal_type, chromosome, gene, effectDominant, effectRecessive,
             appearance, breed, notes, created_at
      FROM genes
-     WHERE animal_type = ? AND chromosome = ?
+     WHERE animal_type = $animalType AND chromosome = $chromosome
      ORDER BY gene`,
-    [animalType, chromosome],
+    { animalType, chromosome },
   );
 }
 
@@ -55,8 +55,8 @@ export async function getGene(animalType: string, gene: string): Promise<Record<
   const rows = await db.select<Record<string, string>[]>(
     `SELECT animal_type, chromosome, gene, effectDominant, effectRecessive,
             appearance, breed, notes, created_at
-     FROM genes WHERE animal_type = ? AND gene = ?`,
-    [animalType, gene],
+     FROM genes WHERE animal_type = $animalType AND gene = $gene`,
+    { animalType, gene },
   );
   return rows.length > 0 ? rows[0] : null;
 }
@@ -69,8 +69,8 @@ export async function getGenesForAnimal(animalType: string): Promise<Record<stri
   return db.select(
     `SELECT animal_type, chromosome, gene, effectDominant, effectRecessive,
             appearance, breed, notes, created_at
-     FROM genes WHERE animal_type = ? ORDER BY chromosome, gene`,
-    [animalType],
+     FROM genes WHERE animal_type = $animalType ORDER BY chromosome, gene`,
+    { animalType },
   );
 }
 
@@ -80,22 +80,26 @@ export async function getGenesForAnimal(animalType: string): Promise<Record<stri
 export async function updateGene(animalType: string, gene: string, updates: Record<string, string>): Promise<boolean> {
   const db = getDb();
   const setClauses: string[] = [];
-  const values: unknown[] = [];
+  const params: Record<string, unknown> = {};
 
   for (const [field, value] of Object.entries(updates)) {
     if (!['animal_type', 'gene', 'created_at'].includes(field)) {
-      setClauses.push(`${field} = ?`);
-      values.push(value);
+      setClauses.push(`${field} = $${field}`);
+      params[field] = value;
     }
   }
 
   if (setClauses.length === 0) return false;
 
-  setClauses.push('updated_at = ?');
-  values.push(now());
-  values.push(animalType, gene);
+  setClauses.push('updated_at = $updated_at');
+  params.updated_at = now();
+  params.w_animal_type = animalType;
+  params.w_gene = gene;
 
-  await db.execute(`UPDATE genes SET ${setClauses.join(', ')} WHERE animal_type = ? AND gene = ?`, values);
+  await db.execute(
+    `UPDATE genes SET ${setClauses.join(', ')} WHERE animal_type = $w_animal_type AND gene = $w_gene`,
+    params,
+  );
   return true;
 }
 
@@ -135,19 +139,19 @@ export async function upsertGene(
   await db.execute(
     `INSERT OR REPLACE INTO genes
      (animal_type, chromosome, gene, effectDominant, effectRecessive, appearance, breed, notes, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [
-      animalType,
+     VALUES ($animal_type, $chromosome, $gene, $effectDominant, $effectRecessive, $appearance, $breed, $notes, $created_at, $updated_at)`,
+    {
+      animal_type: animalType,
       chromosome,
       gene,
-      data.effectDominant ?? 'None',
-      data.effectRecessive ?? 'None',
-      data.appearance ?? 'None',
-      data.breed ?? '',
-      data.notes ?? '',
-      ts,
-      ts,
-    ],
+      effectDominant: data.effectDominant ?? 'None',
+      effectRecessive: data.effectRecessive ?? 'None',
+      appearance: data.appearance ?? 'None',
+      breed: data.breed ?? '',
+      notes: data.notes ?? '',
+      created_at: ts,
+      updated_at: ts,
+    },
   );
 }
 

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -94,25 +94,26 @@ export async function getAllPets(options?: {
 }): Promise<{ items: Pet[]; total: number }> {
   const db = getDb();
   const conditions: string[] = [];
-  const params: unknown[] = [];
 
+  const bindParams: Record<string, unknown> = {};
   if (options?.species) {
-    conditions.push('species = ?');
-    params.push(options.species);
+    conditions.push('species = $species');
+    bindParams.species = options.species;
   }
 
   const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
 
   // Get total count
-  const countRows = await db.select<{ cnt: number }[]>(`SELECT COUNT(*) as cnt FROM pets${where}`, params);
+  const countRows = await db.select<{ cnt: number }[]>(`SELECT COUNT(*) as cnt FROM pets${where}`, bindParams);
   const total = countRows[0].cnt;
 
   // Get paginated results
   let query = `SELECT * FROM pets${where} ORDER BY name`;
-  const selectParams = [...params];
+  const selectParams = { ...bindParams };
   if (options?.limit !== undefined) {
-    query += ` LIMIT ? OFFSET ?`;
-    selectParams.push(options.limit, options.offset ?? 0);
+    query += ' LIMIT $limit OFFSET $offset';
+    selectParams.limit = options.limit;
+    selectParams.offset = options.offset ?? 0;
   }
 
   const rows = await db.select<Record<string, unknown>[]>(query, selectParams);
@@ -126,7 +127,7 @@ export async function getAllPets(options?: {
  */
 export async function getPet(petId: number): Promise<Pet | null> {
   const db = getDb();
-  const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE id = ?', [petId]);
+  const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE id = $id', { id: petId });
   return rows.length > 0 ? enrichPet(rows[0]) : null;
 }
 
@@ -182,27 +183,28 @@ export async function uploadPet(
      (name, species, gender, breeder, content_hash, genome_data, notes,
       created_at, updated_at,
       intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
-             ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [
-      petName,
-      genome.genome_type,
+     VALUES ($name, $species, $gender, $breeder, $content_hash, $genome_data, $notes,
+             $created_at, $updated_at,
+             $intelligence, $toughness, $friendliness, $ruggedness, $enthusiasm, $virility, $ferocity, $temperament)`,
+    {
+      name: petName,
+      species: genome.genome_type,
       gender,
-      genome.breeder,
-      contentHash,
-      genomeJson,
-      notes ?? '',
-      ts,
-      ts,
-      defaults.intelligence ?? 50,
-      defaults.toughness ?? 50,
-      defaults.friendliness ?? 50,
-      defaults.ruggedness ?? 50,
-      defaults.enthusiasm ?? 50,
-      defaults.virility ?? 50,
-      defaults.ferocity ?? 50,
-      defaults.temperament ?? 50,
-    ],
+      breeder: genome.breeder,
+      content_hash: contentHash,
+      genome_data: genomeJson,
+      notes: notes ?? '',
+      created_at: ts,
+      updated_at: ts,
+      intelligence: defaults.intelligence ?? 50,
+      toughness: defaults.toughness ?? 50,
+      friendliness: defaults.friendliness ?? 50,
+      ruggedness: defaults.ruggedness ?? 50,
+      enthusiasm: defaults.enthusiasm ?? 50,
+      virility: defaults.virility ?? 50,
+      ferocity: defaults.ferocity ?? 50,
+      temperament: defaults.temperament ?? 50,
+    },
   );
 
   return {
@@ -236,7 +238,7 @@ const UPDATABLE_COLUMNS = new Set([
 export async function updatePet(petId: number, updates: Record<string, unknown>): Promise<boolean> {
   const db = getDb();
   const setClauses: string[] = [];
-  const values: unknown[] = [];
+  const params: Record<string, unknown> = {};
 
   // Flatten nested `attributes` object into top-level fields
   const flat: Record<string, unknown> = {};
@@ -250,22 +252,17 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
 
   for (const [field, value] of Object.entries(flat)) {
     if (!UPDATABLE_COLUMNS.has(field)) continue;
-    if (field === 'genome_data') {
-      setClauses.push(`${field} = ?`);
-      values.push(typeof value === 'string' ? value : JSON.stringify(value));
-    } else {
-      setClauses.push(`${field} = ?`);
-      values.push(value);
-    }
+    setClauses.push(`${field} = $${field}`);
+    params[field] = field === 'genome_data' && typeof value !== 'string' ? JSON.stringify(value) : value;
   }
 
   if (setClauses.length === 0) return false;
 
-  setClauses.push('updated_at = ?');
-  values.push(now());
-  values.push(petId);
+  setClauses.push('updated_at = $updated_at');
+  params.updated_at = now();
+  params.w_id = petId;
 
-  await db.execute(`UPDATE pets SET ${setClauses.join(', ')} WHERE id = ?`, values);
+  await db.execute(`UPDATE pets SET ${setClauses.join(', ')} WHERE id = $w_id`, params);
   return true;
 }
 
@@ -274,7 +271,7 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
  */
 export async function deletePet(petId: number): Promise<boolean> {
   const db = getDb();
-  const result = await db.execute('DELETE FROM pets WHERE id = ?', [petId]);
+  const result = await db.execute('DELETE FROM pets WHERE id = $id', { id: petId });
   return result.rowsAffected > 0;
 }
 
@@ -283,7 +280,9 @@ export async function deletePet(petId: number): Promise<boolean> {
  */
 export async function findPetByHash(contentHash: string): Promise<Pet | null> {
   const db = getDb();
-  const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE content_hash = ?', [contentHash]);
+  const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE content_hash = $hash', {
+    hash: contentHash,
+  });
   return rows.length > 0 ? enrichPet(rows[0]) : null;
 }
 

--- a/tests/e2e/backup.spec.js
+++ b/tests/e2e/backup.spec.js
@@ -45,7 +45,7 @@ async function deleteFirstPet(page) {
     const { getDb } = await import('/src/lib/services/database.ts');
     const db = getDb();
     const pets = await db.select('SELECT * FROM pets LIMIT 1');
-    await db.execute('DELETE FROM pets WHERE id = ?', [pets[0].id]);
+    await db.execute('DELETE FROM pets WHERE id = $id', { id: pets[0].id });
     return pets[0].name;
   });
 }


### PR DESCRIPTION
## Summary
- Converts all SQL queries to use named `$name` parameters with `Record<string, unknown>` bind values
- `DatabaseAdapter` interface now accepts `BindValues` (array or Record)
- `InMemoryDatabase` resolves `$name` → `?` at entry point via `resolveParams()`, keeping all internal matching logic unchanged
- All queries in `geneService.ts`, `petService.ts`, `backupService.ts` converted
- Dynamic update queries (`updatePet`, `updateGene`) use field names as parameter names
- AGENTS.md directive updated

Closes #67

## Before / After

```sql
-- Before
SELECT * FROM pets WHERE id = ?           -- [petId]
INSERT INTO pets (name, species) VALUES (?, ?)  -- [name, species]

-- After  
SELECT * FROM pets WHERE id = $id         -- { id: petId }
INSERT INTO pets (name, species) VALUES ($name, $species)  -- { name, species }
```

## Test plan
- [x] `pnpm lint:ci` — 0 warnings, 0 errors
- [x] `pnpm test:e2e` — 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)