### PR TITLE
Add settings system with auto-breed-filter for horses

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 import { initDatabase } from '$lib/services/database.js';
 import { loadDemoPetsIfNeeded, populateGenesIfNeeded } from '$lib/services/demoService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
+import { settingsActions } from '$lib/stores/settings.js';
 
 const { children } = $props();
 let ready = $state(false);
@@ -12,6 +13,7 @@ onMount(async () => {
   await runMigrations();
   await populateGenesIfNeeded();
   await loadDemoPetsIfNeeded();
+  await settingsActions.load();
   ready = true;
 });
 </script>

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -1,0 +1,208 @@
+<script>
+import { settings, settingsActions } from '$lib/stores/settings.js';
+
+let open = $state(false);
+
+function toggle() {
+  open = !open;
+}
+
+function close() {
+  open = false;
+}
+
+async function toggleSetting(key) {
+  const current = $settings[key];
+  await settingsActions.update(key, !current);
+}
+</script>
+
+<button class="settings-toggle" onclick={toggle} title="Settings">
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+    <circle cx="12" cy="12" r="3"/>
+  </svg>
+</button>
+
+{#if open}
+  <div class="overlay" onclick={close}>
+    <div class="modal" onclick={(e) => e.stopPropagation()}>
+      <div class="modal-header">
+        <h3>Settings</h3>
+        <button class="close-btn" onclick={close}>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/>
+            <line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="modal-body">
+        <div class="settings-section">
+          <h4>Horse Visualization</h4>
+
+          <label class="setting-row">
+            <div class="setting-info">
+              <span class="setting-name">Auto-select breed filter</span>
+              <span class="setting-desc">When viewing a Horse pet, automatically filter genes to that pet's breed</span>
+            </div>
+            <button
+              class="toggle"
+              class:toggle-on={$settings['horse.autoSelectBreedFilter']}
+              onclick={() => toggleSetting('horse.autoSelectBreedFilter')}
+              role="switch"
+              aria-checked={$settings['horse.autoSelectBreedFilter']}
+            >
+              <span class="toggle-thumb"></span>
+            </button>
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .settings-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #6b7280;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .settings-toggle:hover {
+    background: #f3f4f6;
+    color: #374151;
+  }
+
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 200;
+  }
+
+  .modal {
+    background: #ffffff;
+    border-radius: 12px;
+    max-width: 480px;
+    width: 90%;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+  }
+
+  .modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px 20px;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .modal-header h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: #111827;
+  }
+
+  .close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: #6b7280;
+    cursor: pointer;
+  }
+
+  .close-btn:hover {
+    background: #f3f4f6;
+    color: #374151;
+  }
+
+  .modal-body {
+    padding: 16px 20px 20px;
+  }
+
+  .settings-section h4 {
+    font-size: 12px;
+    font-weight: 600;
+    color: #6b7280;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 12px;
+  }
+
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 0;
+    cursor: pointer;
+  }
+
+  .setting-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .setting-name {
+    font-size: 14px;
+    font-weight: 500;
+    color: #111827;
+  }
+
+  .setting-desc {
+    font-size: 12px;
+    color: #6b7280;
+    line-height: 1.4;
+  }
+
+  .toggle {
+    position: relative;
+    width: 44px;
+    height: 24px;
+    border: none;
+    border-radius: 12px;
+    background: #d1d5db;
+    cursor: pointer;
+    transition: background 0.2s;
+    flex-shrink: 0;
+    padding: 0;
+  }
+
+  .toggle-on {
+    background: #3b82f6;
+  }
+
+  .toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+    transition: transform 0.2s;
+  }
+
+  .toggle-on .toggle-thumb {
+    transform: translateX(20px);
+  }
+</style>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -2,6 +2,7 @@
 import logoImg from '$lib/assets/logo.png';
 import { activeTab, appState } from '$lib/stores/pets.js';
 import DataMenu from './DataMenu.svelte';
+import SettingsModal from './SettingsModal.svelte';
 
 function switchTab(tab) {
   appState.switchTab(tab);
@@ -31,6 +32,7 @@ function switchTab(tab) {
         </button>
     </div>
     <DataMenu />
+    <SettingsModal />
     </div>
 </header>
 

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -2,7 +2,7 @@
 import { onDestroy } from 'svelte';
 import GeneStatsTable from '$lib/components/gene/GeneStatsTable.svelte';
 import GeneVisualizer from '$lib/components/gene/GeneVisualizer.svelte';
-
+import { settings } from '$lib/stores/settings.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 
 const { pet } = $props();
@@ -13,8 +13,38 @@ let statsOpen = $state(false);
 let drawerWidth = $state(320);
 let stats = $state(null);
 let breedFilter = $state('');
+let autoBreed = $state(false);
 
 const isHorse = $derived(pet?.species?.toLowerCase() === 'horse');
+const petHasKnownBreed = $derived(isHorse && pet?.breed && HORSE_BREEDS[pet.breed]);
+
+// Initialize autoBreed from setting when a new pet is loaded
+$effect(() => {
+  const _petId = pet?.id; // track pet changes
+  autoBreed = !!$settings['horse.autoSelectBreedFilter'];
+});
+
+// Apply the breed filter whenever autoBreed or pet changes
+$effect(() => {
+  if (autoBreed && petHasKnownBreed) {
+    breedFilter = pet.breed;
+  }
+  if (geneVisualizerRef) {
+    geneVisualizerRef.setBreedFilter(breedFilter);
+  }
+});
+
+function toggleAutoBreed() {
+  autoBreed = !autoBreed;
+  if (autoBreed && petHasKnownBreed) {
+    breedFilter = pet.breed;
+  } else {
+    breedFilter = '';
+  }
+  if (geneVisualizerRef) {
+    geneVisualizerRef.setBreedFilter(breedFilter);
+  }
+}
 
 function setBreedFilter(fullName) {
   breedFilter = breedFilter === fullName ? '' : fullName;
@@ -108,9 +138,13 @@ onDestroy(() => {
             {#if isHorse}
                 <div class="breed-filter">
                     <span class="breed-label">Breed:</span>
-                    <button class="breed-btn" class:active={breedFilter === ''} onclick={() => setBreedFilter('')}>All</button>
+                    {#if petHasKnownBreed}
+                        <button class="breed-btn auto-btn" class:active={autoBreed} onclick={toggleAutoBreed} title="Auto-select pet's breed">Auto</button>
+                        <span class="breed-divider"></span>
+                    {/if}
+                    <button class="breed-btn" class:active={!autoBreed && breedFilter === ''} disabled={autoBreed} onclick={() => setBreedFilter('')}>All</button>
                     {#each Object.entries(HORSE_BREEDS) as [name, abbrev]}
-                        <button class="breed-btn" class:active={breedFilter === name} onclick={() => setBreedFilter(name)} title={name}>{abbrev}</button>
+                        <button class="breed-btn" class:active={!autoBreed && breedFilter === name} disabled={autoBreed} onclick={() => setBreedFilter(name)} title={name}>{abbrev}</button>
                     {/each}
                 </div>
             {/if}
@@ -257,6 +291,25 @@ onDestroy(() => {
         background: #3b82f6;
         border-color: #3b82f6;
         color: #ffffff;
+    }
+
+    .breed-btn:disabled {
+        opacity: 0.4;
+        cursor: default;
+        pointer-events: none;
+    }
+
+    .auto-btn.active {
+        background: #22c55e;
+        border-color: #22c55e;
+        color: #ffffff;
+    }
+
+    .breed-divider {
+        width: 1px;
+        height: 16px;
+        background: #d1d5db;
+        margin: 0 2px;
     }
 
     .view-controls {

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -24,6 +24,20 @@ const MIGRATIONS: Migration[] = [
       // No-op: tables are created by initDatabase()
     },
   },
+  {
+    version: 2,
+    description: 'Add settings table for user preferences',
+    up: async () => {
+      const db = getDb();
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          updated_at TEXT
+        )
+      `);
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -1,0 +1,63 @@
+/**
+ * User settings service for Gorgonetics.
+ * Key-value store backed by the settings SQLite table.
+ * Each setting has a typed default; missing keys fall back to defaults.
+ */
+
+import { getDb } from './database.js';
+
+const SETTING_DEFAULTS: Record<string, unknown> = {
+  'horse.autoSelectBreedFilter': true,
+};
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export function getDefaultSettings(): Record<string, unknown> {
+  return { ...SETTING_DEFAULTS };
+}
+
+export async function getSetting<T = unknown>(key: string): Promise<T> {
+  const db = getDb();
+  const rows = await db.select<{ value: string }[]>('SELECT value FROM settings WHERE key = $key', { key });
+  if (rows.length === 0) {
+    return SETTING_DEFAULTS[key] as T;
+  }
+  try {
+    return JSON.parse(rows[0].value) as T;
+  } catch {
+    return rows[0].value as T;
+  }
+}
+
+export async function setSetting(key: string, value: unknown): Promise<void> {
+  const db = getDb();
+  const serialized = JSON.stringify(value);
+  const ts = now();
+  await db.execute('DELETE FROM settings WHERE key = $key', { key });
+  await db.execute('INSERT INTO settings (key, value, updated_at) VALUES ($key, $value, $updated_at)', {
+    key,
+    value: serialized,
+    updated_at: ts,
+  });
+}
+
+export async function getAllSettings(): Promise<Record<string, unknown>> {
+  const db = getDb();
+  const rows = await db.select<{ key: string; value: string }[]>('SELECT key, value FROM settings');
+  const result = { ...SETTING_DEFAULTS };
+  for (const row of rows) {
+    try {
+      result[row.key] = JSON.parse(row.value);
+    } catch {
+      result[row.key] = row.value;
+    }
+  }
+  return result;
+}
+
+export async function resetSetting(key: string): Promise<void> {
+  const db = getDb();
+  await db.execute('DELETE FROM settings WHERE key = $key', { key });
+}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,0 +1,21 @@
+/**
+ * Reactive settings store for Gorgonetics.
+ * Loaded once at startup, updated synchronously when settings change.
+ */
+
+import { writable } from 'svelte/store';
+import { getAllSettings, getDefaultSettings, setSetting } from '$lib/services/settingsService.js';
+
+export const settings = writable<Record<string, unknown>>(getDefaultSettings());
+
+export const settingsActions = {
+  async load() {
+    const all = await getAllSettings();
+    settings.set(all);
+  },
+
+  async update(key: string, value: unknown) {
+    await setSetting(key, value);
+    settings.update((s) => ({ ...s, [key]: value }));
+  },
+};

--- a/tests/e2e/backup.spec.js
+++ b/tests/e2e/backup.spec.js
@@ -95,7 +95,7 @@ test.describe('Database Backup – Export & Import', () => {
 
     expect(backup.petCount).toBe(2);
     expect(backup.geneCount).toBeGreaterThan(0);
-    expect(backup.schemaVersion).toBe(1);
+    expect(backup.schemaVersion).toBe(2);
   });
 
   test('export and import (replace) round-trips correctly', async ({ page }) => {


### PR DESCRIPTION
## Summary
Adds a user preferences infrastructure and the first setting: automatic breed filter selection for Horse pets.

### Settings system
- SQLite `settings` table via migration v2 (key-value storage with JSON-serialized values)
- `settingsService.ts` with typed defaults, `getSetting`/`setSetting`/`getAllSettings`/`resetSetting` API
- Reactive Svelte store (`settings.ts`) loaded once at startup
- Settings modal accessible via gear icon in TopBar

### Auto-breed-filter
- **"Auto" toggle button** in the breed filter bar (green when active, with divider separating it from manual buttons)
- When **on**: automatically filters genes to the pet's breed; manual breed buttons are greyed out/disabled
- When **off**: clears filter to "All" and re-enables manual breed selection
- Initial state on pet load is driven by the `horse.autoSelectBreedFilter` setting (default: true)
- Only appears when the horse has a known breed set

### UI
- Gear icon + Settings modal in TopBar (next to DataMenu)
- Toggle switch for the auto-breed-filter preference with description text
- Extensible for future settings

## Test plan
- [x] `pnpm lint:ci` — 0 diagnostics
- [x] `pnpm test:e2e` — 57 tests pass
- [x] Visual: Settings modal opens/closes, toggle works
- [x] Visual: Horse pet auto-selects Standardbred breed filter on load
- [x] Visual: Manual breed buttons are greyed out when Auto is on
- [ ] Manual: Toggle Auto off → buttons re-enable, filter clears to All
- [ ] Manual: Change setting in modal → next horse pet load reflects the change
- [ ] Manual: BeeWasp pet — no breed filter bar, no Auto button

🤖 Generated with [Claude Code](https://claude.com/claude-code)