### PR TITLE
Fix InMemoryDatabase ORDER BY: multi-column, DESC, numeric sort

### DIFF
--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -100,12 +100,12 @@ class InMemoryDatabase implements DatabaseAdapter {
       const rows = this.getTable(table);
       let filtered = this.applyWhere(rows, q, values);
 
-      // ORDER BY — supports multi-column, ASC/DESC, numeric vs string comparison
+      // Replicate SQLite sort semantics so tests get deterministic ordering for pagination and display
       const orderByMatch = q.match(/order\s+by\s+(.+?)(?:\s+limit\b|\s*$)/i);
       if (orderByMatch) {
         const columns = orderByMatch[1].split(',').map((part) => {
           const tokens = part.trim().split(/\s+/);
-          const col = tokens[0];
+          const col = tokens[0].replace(/^\w+\./, ''); // strip table prefix (e.g., pi.created_at -> created_at)
           const desc = tokens.length > 1 && tokens[1].toLowerCase() === 'desc';
           return { col, desc };
         });

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -100,11 +100,29 @@ class InMemoryDatabase implements DatabaseAdapter {
       const rows = this.getTable(table);
       let filtered = this.applyWhere(rows, q, values);
 
-      // ORDER BY
-      const orderMatch = q.match(/order\s+by\s+(\w+)/);
-      if (orderMatch) {
-        const col = orderMatch[1];
-        filtered.sort((a, b) => String(a[col] ?? '').localeCompare(String(b[col] ?? '')));
+      // ORDER BY — supports multi-column, ASC/DESC, numeric vs string comparison
+      const orderByMatch = q.match(/order\s+by\s+(.+?)(?:\s+limit\b|\s*$)/i);
+      if (orderByMatch) {
+        const columns = orderByMatch[1].split(',').map((part) => {
+          const tokens = part.trim().split(/\s+/);
+          const col = tokens[0];
+          const desc = tokens.length > 1 && tokens[1].toLowerCase() === 'desc';
+          return { col, desc };
+        });
+        filtered.sort((a, b) => {
+          for (const { col, desc } of columns) {
+            const av = a[col];
+            const bv = b[col];
+            let cmp: number;
+            if (typeof av === 'number' && typeof bv === 'number') {
+              cmp = av - bv;
+            } else {
+              cmp = String(av ?? '').localeCompare(String(bv ?? ''));
+            }
+            if (cmp !== 0) return desc ? -cmp : cmp;
+          }
+          return 0;
+        });
       }
 
       // LIMIT/OFFSET

--- a/tests/unit/database.test.js
+++ b/tests/unit/database.test.js
@@ -99,6 +99,74 @@ describe('Database', () => {
     expect(rows[0].effectDominant).toBe('Toughness+');
   });
 
+  describe('ORDER BY', () => {
+    const INSERT_PET = `INSERT INTO pets (name, species, gender, content_hash, genome_data, toughness, created_at, updated_at)
+       VALUES ($name, $species, $gender, $content_hash, $genome_data, $toughness, $created_at, $updated_at)`;
+
+    function petParams(name, hash, toughness = 50) {
+      return {
+        name,
+        species: 'BeeWasp',
+        gender: 'Male',
+        content_hash: hash,
+        genome_data: '{}',
+        toughness,
+        created_at: '2024-01-01',
+        updated_at: '2024-01-01',
+      };
+    }
+
+    it('sorts ascending by default', async () => {
+      const db = getDb();
+      await db.execute(INSERT_PET, petParams('Charlie', 'h3'));
+      await db.execute(INSERT_PET, petParams('Alice', 'h1'));
+      await db.execute(INSERT_PET, petParams('Bob', 'h2'));
+
+      const rows = await db.select('SELECT * FROM pets ORDER BY name');
+      expect(rows.map((r) => r.name)).toEqual(['Alice', 'Bob', 'Charlie']);
+    });
+
+    it('sorts descending with DESC', async () => {
+      const db = getDb();
+      await db.execute(INSERT_PET, petParams('Charlie', 'h3'));
+      await db.execute(INSERT_PET, petParams('Alice', 'h1'));
+      await db.execute(INSERT_PET, petParams('Bob', 'h2'));
+
+      const rows = await db.select('SELECT * FROM pets ORDER BY name DESC');
+      expect(rows.map((r) => r.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+    });
+
+    it('sorts numerically for number columns', async () => {
+      const db = getDb();
+      await db.execute(INSERT_PET, petParams('A', 'h1', 10));
+      await db.execute(INSERT_PET, petParams('B', 'h2', 2));
+      await db.execute(INSERT_PET, petParams('C', 'h3', 100));
+
+      const rows = await db.select('SELECT * FROM pets ORDER BY toughness');
+      expect(rows.map((r) => r.toughness)).toEqual([2, 10, 100]);
+    });
+
+    it('supports multi-column ORDER BY', async () => {
+      const db = getDb();
+      await db.execute(INSERT_PET, petParams('Bob', 'h1', 50));
+      await db.execute(INSERT_PET, petParams('Alice', 'h2', 50));
+      await db.execute(INSERT_PET, petParams('Charlie', 'h3', 30));
+
+      const rows = await db.select('SELECT * FROM pets ORDER BY toughness, name');
+      expect(rows.map((r) => r.name)).toEqual(['Charlie', 'Alice', 'Bob']);
+    });
+
+    it('supports mixed ASC/DESC in multi-column ORDER BY', async () => {
+      const db = getDb();
+      await db.execute(INSERT_PET, petParams('Bob', 'h1', 50));
+      await db.execute(INSERT_PET, petParams('Alice', 'h2', 50));
+      await db.execute(INSERT_PET, petParams('Charlie', 'h3', 30));
+
+      const rows = await db.select('SELECT * FROM pets ORDER BY toughness, name DESC');
+      expect(rows.map((r) => r.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+    });
+  });
+
   it('deletes rows', async () => {
     const db = getDb();
     await db.execute(


### PR DESCRIPTION
## Summary
- `InMemoryDatabase.select()` ORDER BY now supports multi-column sorting, ASC/DESC modifiers, and numeric comparison
- Previously only sorted by the first column, always ascending, using string comparison (so `10 < 2` and `DESC` was ignored)
- This caused test/production ordering divergence for queries like `ORDER BY sort_order, created_at DESC`

## Changes
- Rewrote ORDER BY parsing to extract comma-separated columns with optional DESC/ASC modifiers
- Sort comparator checks `typeof` to use numeric comparison for numbers, string for everything else
- 5 new unit tests covering: ascending default, DESC, numeric sort, multi-column, mixed ASC/DESC

Closes #86

## Test Plan
- [x] 137 unit tests pass (5 new ORDER BY tests)
- [x] 65 E2E tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)