### PR TITLE
feat: add pet tags with filtering and autocomplete

### DIFF
--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -31,6 +31,13 @@ function getSpeciesEmoji(species) {
                     <span class="gene-count">{pet.known_genes} genes</span>
                 {/if}
             </div>
+            {#if pet.tags?.length > 0}
+                <div class="pet-card-tags">
+                    {#each pet.tags as tag}
+                        <span class="tag-badge">{tag}</span>
+                    {/each}
+                </div>
+            {/if}
         </div>
     </div>
     {#if selected}
@@ -95,6 +102,23 @@ function getSpeciesEmoji(species) {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    .pet-card-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 3px;
+        margin-top: 3px;
+    }
+
+    .tag-badge {
+        display: inline-block;
+        padding: 1px 6px;
+        background: #eff6ff;
+        color: #3b82f6;
+        border-radius: 8px;
+        font-size: 10px;
+        font-weight: 500;
     }
 
     .selected-indicator {

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -1,8 +1,9 @@
 <script>
 import { untrack } from 'svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
-import { appState } from '$lib/stores/pets.js';
+import { appState, pets } from '$lib/stores/pets.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
+import TagInput from './TagInput.svelte';
 
 const ALL_ATTRIBUTES = getAllAttributeDisplayInfo();
 
@@ -34,7 +35,10 @@ let editName = $state(initial.name);
 let editGender = $state(initial.gender);
 let editBreed = $state(initial.breed);
 const editAttributes = $state(initial.attributes);
+let editTags = $state([...(pet.tags ?? [])]);
 let saveError = $state('');
+
+const allTags = $derived([...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
 
 const availableAttributes = $derived(getAllAttributeNames(pet.species));
 const filteredAttributeList = $derived(
@@ -53,6 +57,10 @@ async function handleSave() {
       if (pet[key] !== value) attributeChanges[key] = value;
     }
     if (Object.keys(attributeChanges).length > 0) updateData.attributes = attributeChanges;
+
+    if (JSON.stringify(editTags) !== JSON.stringify(pet.tags ?? [])) {
+      updateData.tags = editTags;
+    }
 
     if (Object.keys(updateData).length > 0) {
       await appState.updatePet(pet.id, updateData);
@@ -130,6 +138,11 @@ function updateAttribute(attrKey, value) {
             </select>
           </div>
         </div>
+      </section>
+
+      <section class="form-section">
+        <h3>Tags</h3>
+        <TagInput tags={editTags} {allTags} onchange={(t) => { editTags = t; }} />
       </section>
 
       <section class="form-section">

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -1,7 +1,7 @@
 <script>
 import { untrack } from 'svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
-import { appState, pets } from '$lib/stores/pets.js';
+import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import TagInput from './TagInput.svelte';
 
@@ -38,7 +38,7 @@ const editAttributes = $state(initial.attributes);
 let editTags = $state([...(pet.tags ?? [])]);
 let saveError = $state('');
 
-const allTags = $derived([...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
+const allTags = $derived($allTagsStore);
 
 const availableAttributes = $derived(getAllAttributeNames(pet.species));
 const filteredAttributeList = $derived(

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -1,6 +1,6 @@
 <script>
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
-import { appState, error, pets, selectedPet } from '$lib/stores/pets.js';
+import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
 import { createDragState } from '$lib/utils/dragReorder.svelte.js';
 import { getBasename } from '$lib/utils/path.js';
 import PetCard from './PetCard.svelte';
@@ -14,12 +14,12 @@ let showEditor = $state(false);
 let editingPet = $state(null);
 let deletingPet = $state(null);
 
-const availableTags = $derived([...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
+const availableTags = $derived($allTagsStore);
 
-const filteredPets = $derived(
-  $pets.filter((pet) => {
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase();
+const filteredPets = $derived.by(() => {
+  const q = searchQuery ? searchQuery.toLowerCase() : '';
+  return $pets.filter((pet) => {
+    if (q) {
       if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
         return false;
       }
@@ -29,8 +29,8 @@ const filteredPets = $derived(
       if (!selectedTags.every((t) => petTags.includes(t))) return false;
     }
     return true;
-  }),
-);
+  });
+});
 
 function toggleTagFilter(tag) {
   if (selectedTags.includes(tag)) {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -16,6 +16,16 @@ let deletingPet = $state(null);
 
 const availableTags = $derived($allTagsStore);
 
+// Remove stale selected tags that no longer exist on any pet
+$effect(() => {
+  if (selectedTags.length > 0 && availableTags.length >= 0) {
+    const valid = selectedTags.filter((t) => availableTags.includes(t));
+    if (valid.length !== selectedTags.length) {
+      selectedTags = valid;
+    }
+  }
+});
+
 const filteredPets = $derived.by(() => {
   const q = searchQuery ? searchQuery.toLowerCase() : '';
   return $pets.filter((pet) => {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -7,19 +7,38 @@ import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
 
 let searchQuery = $state('');
+let selectedTags = $state([]);
 let uploading = $state(false);
 let uploadProgress = $state(null);
 let showEditor = $state(false);
 let editingPet = $state(null);
 let deletingPet = $state(null);
 
+const availableTags = $derived([...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
+
 const filteredPets = $derived(
   $pets.filter((pet) => {
-    if (!searchQuery) return true;
-    const q = searchQuery.toLowerCase();
-    return (pet.name || '').toLowerCase().includes(q) || (pet.species || '').toLowerCase().includes(q);
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
+        return false;
+      }
+    }
+    if (selectedTags.length > 0) {
+      const petTags = pet.tags ?? [];
+      if (!selectedTags.every((t) => petTags.includes(t))) return false;
+    }
+    return true;
   }),
 );
+
+function toggleTagFilter(tag) {
+  if (selectedTags.includes(tag)) {
+    selectedTags = selectedTags.filter((t) => t !== tag);
+  } else {
+    selectedTags = [...selectedTags, tag];
+  }
+}
 
 function selectPet(pet) {
   appState.selectPet(pet);
@@ -85,7 +104,7 @@ function cancelDelete() {
 }
 
 const drag = createDragState();
-const isDraggable = $derived(!searchQuery);
+const isDraggable = $derived(!searchQuery && selectedTags.length === 0);
 
 async function handleDrop(e, dropIndex) {
   e.preventDefault();
@@ -142,6 +161,17 @@ async function handleDrop(e, dropIndex) {
             placeholder="Search pets..."
             bind:value={searchQuery}
         />
+        {#if availableTags.length > 0}
+            <div class="tag-filter">
+                {#each availableTags as tag}
+                    <button
+                        class="tag-filter-btn"
+                        class:active={selectedTags.includes(tag)}
+                        onclick={() => toggleTagFilter(tag)}
+                    >{tag}</button>
+                {/each}
+            </div>
+        {/if}
     </div>
 
     <div class="pet-list-items">
@@ -192,8 +222,8 @@ async function handleDrop(e, dropIndex) {
                     ondrop={(e) => handleDrop(e, filteredPets.length)}
                 ></div>
             {/if}
-        {:else if searchQuery}
-            <div class="empty-state">No pets match "{searchQuery}"</div>
+        {:else if searchQuery || selectedTags.length > 0}
+            <div class="empty-state">No pets match the current filters</div>
         {:else}
             <div class="empty-state">No pets yet. Upload a genome file to get started.</div>
         {/if}
@@ -298,6 +328,36 @@ async function handleDrop(e, dropIndex) {
 
     .search-input::placeholder {
         color: #9ca3af;
+    }
+
+    .tag-filter {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 8px;
+    }
+
+    .tag-filter-btn {
+        padding: 2px 10px;
+        border: 1px solid #e5e7eb;
+        border-radius: 10px;
+        background: #ffffff;
+        color: #6b7280;
+        font-size: 11px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .tag-filter-btn:hover {
+        border-color: #93c5fd;
+        color: #3b82f6;
+    }
+
+    .tag-filter-btn.active {
+        background: #3b82f6;
+        border-color: #3b82f6;
+        color: #ffffff;
     }
 
     .pet-list-items {

--- a/src/lib/components/pet/TagInput.svelte
+++ b/src/lib/components/pet/TagInput.svelte
@@ -53,10 +53,12 @@ function handleFocus() {
 }
 
 function handleBlur() {
-  // Delay to allow suggestion click
-  setTimeout(() => {
-    showSuggestions = false;
-  }, 150);
+  showSuggestions = false;
+}
+
+function handleSuggestionMousedown(e, suggestion) {
+  e.preventDefault();
+  addTag(suggestion);
 }
 </script>
 
@@ -82,7 +84,7 @@ function handleBlur() {
   {#if showSuggestions && suggestions.length > 0}
     <div class="tag-suggestions">
       {#each suggestions.slice(0, 8) as suggestion}
-        <button class="tag-suggestion" onmousedown={() => addTag(suggestion)}>
+        <button class="tag-suggestion" onmousedown={(e) => handleSuggestionMousedown(e, suggestion)}>
           {suggestion}
         </button>
       {/each}

--- a/src/lib/components/pet/TagInput.svelte
+++ b/src/lib/components/pet/TagInput.svelte
@@ -1,0 +1,192 @@
+<script>
+let { tags = [], allTags = [], onchange } = $props();
+
+let inputValue = $state('');
+let showSuggestions = $state(false);
+
+const suggestions = $derived(
+  inputValue.trim()
+    ? allTags.filter((t) => t.toLowerCase().includes(inputValue.trim().toLowerCase()) && !tags.includes(t))
+    : [],
+);
+
+function addTag(value) {
+  const tag = value.trim().toLowerCase();
+  if (!tag || tags.includes(tag)) return;
+  const updated = [...tags, tag];
+  onchange?.(updated);
+  inputValue = '';
+  showSuggestions = false;
+}
+
+function removeTag(tag) {
+  onchange?.(tags.filter((t) => t !== tag));
+}
+
+function handleKeydown(e) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (suggestions.length > 0) {
+      addTag(suggestions[0]);
+    } else {
+      addTag(inputValue);
+    }
+  } else if (e.key === 'Backspace' && !inputValue && tags.length > 0) {
+    removeTag(tags[tags.length - 1]);
+  }
+}
+
+function handleInput(e) {
+  inputValue = e.target.value;
+  if (inputValue.includes(',')) {
+    const parts = inputValue.split(',');
+    for (const part of parts.slice(0, -1)) {
+      addTag(part);
+    }
+    inputValue = parts[parts.length - 1];
+  }
+  showSuggestions = inputValue.trim().length > 0;
+}
+
+function handleFocus() {
+  showSuggestions = inputValue.trim().length > 0;
+}
+
+function handleBlur() {
+  // Delay to allow suggestion click
+  setTimeout(() => {
+    showSuggestions = false;
+  }, 150);
+}
+</script>
+
+<div class="tag-input-wrapper">
+  <div class="tag-input-container">
+    {#each tags as tag}
+      <span class="tag-pill">
+        {tag}
+        <button class="tag-remove" onclick={() => removeTag(tag)} aria-label="Remove tag {tag}">×</button>
+      </span>
+    {/each}
+    <input
+      class="tag-text-input"
+      type="text"
+      placeholder={tags.length === 0 ? 'Add tags...' : ''}
+      value={inputValue}
+      oninput={handleInput}
+      onkeydown={handleKeydown}
+      onfocus={handleFocus}
+      onblur={handleBlur}
+    />
+  </div>
+  {#if showSuggestions && suggestions.length > 0}
+    <div class="tag-suggestions">
+      {#each suggestions.slice(0, 8) as suggestion}
+        <button class="tag-suggestion" onmousedown={() => addTag(suggestion)}>
+          {suggestion}
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .tag-input-wrapper {
+    position: relative;
+  }
+
+  .tag-input-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 6px 8px;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    background: #ffffff;
+    min-height: 34px;
+    align-items: center;
+    cursor: text;
+    transition: border-color 0.15s;
+  }
+
+  .tag-input-container:focus-within {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+  }
+
+  .tag-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 2px 8px;
+    background: #eff6ff;
+    color: #3b82f6;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+    white-space: nowrap;
+  }
+
+  .tag-remove {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: #93c5fd;
+    font-size: 13px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+  }
+
+  .tag-remove:hover {
+    color: #ef4444;
+  }
+
+  .tag-text-input {
+    flex: 1;
+    min-width: 60px;
+    border: none;
+    outline: none;
+    font-size: 13px;
+    color: #111827;
+    background: transparent;
+    padding: 2px 0;
+  }
+
+  .tag-text-input::placeholder {
+    color: #9ca3af;
+  }
+
+  .tag-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-top: 4px;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    z-index: 10;
+    max-height: 160px;
+    overflow-y: auto;
+  }
+
+  .tag-suggestion {
+    display: block;
+    width: 100%;
+    padding: 6px 10px;
+    border: none;
+    background: none;
+    font-size: 13px;
+    color: #374151;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .tag-suggestion:hover {
+    background: #f3f4f6;
+  }
+</style>

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -60,6 +60,7 @@ const PET_COLUMNS = [
   'ferocity',
   'temperament',
   'sort_order',
+  'tags',
 ];
 
 // --- Export ---
@@ -243,6 +244,8 @@ async function importGenesAndPets(
         const params: Record<string, unknown> = {};
         for (const col of PET_COLUMNS) {
           if (col === 'genome_data') params[col] = genomeData;
+          else if (col === 'tags')
+            params[col] = typeof pet[col] === 'string' ? pet[col] : JSON.stringify(pet[col] ?? []);
           else if (col === 'sort_order') params[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
           else params[col] = pet[col] ?? null;
         }

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -74,6 +74,14 @@ const MIGRATIONS: Migration[] = [
       await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_images_pet_id ON pet_images(pet_id)');
     },
   },
+  {
+    version: 6,
+    description: 'Add tags column to pets for user-defined labels',
+    up: async () => {
+      const db = getDb();
+      await db.execute("ALTER TABLE pets ADD COLUMN tags TEXT DEFAULT '[]'");
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -67,16 +67,31 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
 }
 
 function parseTags(raw: unknown): string[] {
-  if (Array.isArray(raw)) return raw;
-  if (typeof raw === 'string') {
+  let arr: unknown[];
+  if (Array.isArray(raw)) {
+    arr = raw;
+  } else if (typeof raw === 'string') {
     try {
       const parsed = JSON.parse(raw);
-      return Array.isArray(parsed) ? parsed : [];
+      arr = Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];
     }
+  } else {
+    return [];
   }
-  return [];
+  // Normalize: keep only strings, trim, lowercase, dedupe
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const item of arr) {
+    if (typeof item !== 'string') continue;
+    const normalized = item.trim().toLowerCase();
+    if (normalized && !seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  }
+  return result;
 }
 
 /** Enrich a raw pet row from the database with computed fields. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -69,10 +69,24 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
 /**
  * Enrich a raw pet row from the database with computed fields.
  */
+function parseTags(raw: unknown): string[] {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+  return [];
+}
+
 function enrichPet(pet: Record<string, unknown>): Pet {
   const geneCounts = countGenes(pet.genome_data);
   return {
     ...pet,
+    tags: parseTags(pet.tags),
     total_genes: geneCounts.total,
     known_genes: geneCounts.known,
     unknown_genes: geneCounts.unknown,
@@ -230,6 +244,7 @@ const UPDATABLE_COLUMNS = new Set([
   'gender',
   'breed',
   'notes',
+  'tags',
   'genome_data',
   'sort_order',
   'intelligence',
@@ -263,7 +278,13 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
   for (const [field, value] of Object.entries(flat)) {
     if (!UPDATABLE_COLUMNS.has(field)) continue;
     setClauses.push(`${field} = $${field}`);
-    params[field] = field === 'genome_data' && typeof value !== 'string' ? JSON.stringify(value) : value;
+    if (field === 'tags' && Array.isArray(value)) {
+      params[field] = JSON.stringify(value);
+    } else if (field === 'genome_data' && typeof value !== 'string') {
+      params[field] = JSON.stringify(value);
+    } else {
+      params[field] = value;
+    }
   }
 
   if (setClauses.length === 0) return false;

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -66,9 +66,6 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
   return { total, known, unknown };
 }
 
-/**
- * Enrich a raw pet row from the database with computed fields.
- */
 function parseTags(raw: unknown): string[] {
   if (Array.isArray(raw)) return raw;
   if (typeof raw === 'string') {
@@ -82,6 +79,7 @@ function parseTags(raw: unknown): string[] {
   return [];
 }
 
+/** Enrich a raw pet row from the database with computed fields. */
 function enrichPet(pet: Record<string, unknown>): Pet {
   const geneCounts = countGenes(pet.genome_data);
   return {
@@ -278,13 +276,8 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
   for (const [field, value] of Object.entries(flat)) {
     if (!UPDATABLE_COLUMNS.has(field)) continue;
     setClauses.push(`${field} = $${field}`);
-    if (field === 'tags' && Array.isArray(value)) {
-      params[field] = JSON.stringify(value);
-    } else if (field === 'genome_data' && typeof value !== 'string') {
-      params[field] = JSON.stringify(value);
-    } else {
-      params[field] = value;
-    }
+    params[field] =
+      (field === 'tags' || field === 'genome_data') && typeof value !== 'string' ? JSON.stringify(value) : value;
   }
 
   if (setClauses.length === 0) return false;

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -1,4 +1,4 @@
-import { type Writable, writable } from 'svelte/store';
+import { derived, type Writable, writable } from 'svelte/store';
 import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 
@@ -10,6 +10,9 @@ export const loading = writable(false);
 export const error: Writable<string | null> = writable(null);
 export const geneEditingView: Writable<unknown> = writable(null);
 export const activeTab: Writable<Tab> = writable('pets');
+
+/** All unique tags across all pets, sorted. Shared by PetEditor and PetList. */
+export const allTags = derived(pets, ($pets) => [...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
 
 function getCurrentValue<T>(store: Writable<T>): T | undefined {
   let value: T | undefined;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -82,6 +82,7 @@ export interface Pet {
   content_hash: string;
   genome_data: string;
   notes: string;
+  tags: string[];
   created_at: string;
   updated_at: string;
   // Dynamic attribute columns

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -60,6 +60,7 @@ const samplePet = {
   ferocity: 50,
   temperament: 50,
   sort_order: 0,
+  tags: '[]',
 };
 
 describe('Backup Service', () => {

--- a/tests/unit/petTags.test.js
+++ b/tests/unit/petTags.test.js
@@ -1,0 +1,147 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import JSZip from 'jszip';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { importDatabase } from '$lib/services/backupService.js';
+import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+import { CURRENT_SCHEMA_VERSION, runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
+
+async function buildZip({ pets = [] } = {}) {
+  const zip = new JSZip();
+  zip.file(
+    'metadata.json',
+    JSON.stringify({
+      format: 'gorgonetics-backup',
+      format_version: 2,
+      schema_version: CURRENT_SCHEMA_VERSION,
+      app_version: '0.2.0',
+      exported_at: '2026-01-01T00:00:00Z',
+      contents: { genes: false, pets: true, images: false },
+      record_counts: { genes: 0, pets: pets.length, images: 0 },
+    }),
+  );
+  zip.file('pets.json', JSON.stringify(pets));
+  return zip.generateAsync({ type: 'uint8array' });
+}
+
+const basePet = {
+  name: 'TagTest',
+  species: 'BeeWasp',
+  gender: 'Female',
+  breed: '',
+  breeder: 'Tester',
+  content_hash: 'hash_tags_test',
+  genome_data: '{"genes":{}}',
+  notes: '',
+  created_at: '2026-01-01',
+  updated_at: '2026-01-01',
+  intelligence: 50,
+  toughness: 50,
+  friendliness: 50,
+  ruggedness: 50,
+  enthusiasm: 50,
+  virility: 50,
+  ferocity: 50,
+  temperament: 50,
+  sort_order: 0,
+  tags: '[]',
+};
+
+describe('Pet Tags', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+  });
+
+  describe('migration', () => {
+    it('schema version is 6', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(6);
+    });
+  });
+
+  describe('enrichPet — tag parsing', () => {
+    it('new pet has empty tags', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee1', 'Female');
+      const { items } = await petService.getAllPets();
+      expect(items[0].tags).toEqual([]);
+    });
+
+    it('round-trips tags through updatePet and getPet', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee2', 'Female');
+      const { items } = await petService.getAllPets();
+      const pet = items[0];
+
+      await petService.updatePet(pet.id, { tags: ['breeder', 'favorite'] });
+      const updated = await petService.getPet(pet.id);
+      expect(updated.tags).toEqual(['breeder', 'favorite']);
+    });
+  });
+
+  describe('updatePet — tag persistence', () => {
+    it('persists tags via updatePet', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee4', 'Male');
+      const { items } = await petService.getAllPets();
+      const pet = items[0];
+
+      await petService.updatePet(pet.id, { tags: ['breeder', 'for sale'] });
+      const updated = await petService.getPet(pet.id);
+      expect(updated.tags).toEqual(['breeder', 'for sale']);
+    });
+
+    it('overwrites tags with a new set', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee5', 'Female');
+      const { items } = await petService.getAllPets();
+      const pet = items[0];
+
+      await petService.updatePet(pet.id, { tags: ['old-tag'] });
+      await petService.updatePet(pet.id, { tags: ['new-tag', 'another'] });
+      const updated = await petService.getPet(pet.id);
+      expect(updated.tags).toEqual(['new-tag', 'another']);
+    });
+
+    it('clears tags with empty array', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee6', 'Male');
+      const { items } = await petService.getAllPets();
+      const pet = items[0];
+
+      await petService.updatePet(pet.id, { tags: ['temp'] });
+      await petService.updatePet(pet.id, { tags: [] });
+      const updated = await petService.getPet(pet.id);
+      expect(updated.tags).toEqual([]);
+    });
+  });
+
+  describe('backup round-trip', () => {
+    it('preserves tags through import', async () => {
+      const pet = { ...basePet, tags: '["breeder","favorite"]' };
+      const zipData = await buildZip({ pets: [pet] });
+      await importDatabase(zipData, {
+        mode: 'replace',
+        includeGenes: false,
+        includePets: true,
+        includeImages: false,
+      });
+
+      const { items } = await petService.getAllPets();
+      expect(items[0].tags).toEqual(['breeder', 'favorite']);
+    });
+
+    it('handles tags as parsed array on import', async () => {
+      const pet = { ...basePet, tags: ['alpha', 'beta'], content_hash: 'hash_parsed' };
+      const zipData = await buildZip({ pets: [pet] });
+      await importDatabase(zipData, {
+        mode: 'replace',
+        includeGenes: false,
+        includePets: true,
+        includeImages: false,
+      });
+
+      const { items } = await petService.getAllPets();
+      expect(items[0].tags).toEqual(['alpha', 'beta']);
+    });
+  });
+});

--- a/tests/unit/petTags.test.js
+++ b/tests/unit/petTags.test.js
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import JSZip from 'jszip';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { importDatabase } from '$lib/services/backupService.js';
-import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import { CURRENT_SCHEMA_VERSION, runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
 


### PR DESCRIPTION
## Summary
- Adds user-defined tags to pets for labeling (e.g., "breeder", "favorite", "for sale") and filtering
- New `TagInput.svelte` component with pill display, remove button, comma/enter to add, and autocomplete from existing tags
- Tags displayed as compact badges on pet cards
- Tag filter bar in pet list header with toggleable AND-based filtering
- Migration v6 adds `tags` column; backup export/import fully supports tags
- 8 new unit tests for tag parsing, persistence, and backup round-trip

Closes #17

## Changes
| File | Description |
|---|---|
| `migrationService.ts` | Migration v6: `tags TEXT DEFAULT '[]'` |
| `types/index.ts` | `tags: string[]` on Pet interface |
| `petService.ts` | Parse tags in enrichPet, serialize on update |
| `backupService.ts` | Tags in PET_COLUMNS with JSON serialization |
| `TagInput.svelte` | **New** reusable tag input with autocomplete |
| `PetCard.svelte` | Display tag badges |
| `PetEditor.svelte` | Tags section with TagInput |
| `PetList.svelte` | Tag filter bar, extended filtering |
| `petTags.test.js` | **New** 8 unit tests |

## Test plan
- [x] All 220 unit tests pass (8 new)
- [x] Lint clean
- [x] Frontend builds
- [x] Manual: add tags to a pet via editor, verify badges on card
- [x] Manual: filter pet list by tags, verify AND behavior
- [x] Manual: autocomplete suggests existing tags when typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)