### PR TITLE
refactor: migrate pet tags to junction table

### DIFF
--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -60,7 +60,6 @@ const PET_COLUMNS = [
   'ferocity',
   'temperament',
   'sort_order',
-  'tags',
 ];
 
 // --- Export ---
@@ -99,6 +98,12 @@ export async function exportDatabase(options: ExportOptions): Promise<ExportResu
     if (options.includePets) {
       zip.file('pets.json', JSON.stringify(petsExport));
       petCount = petsExport.length;
+
+      // Export pet tags from junction table, keyed by content_hash for portability
+      const tagRows = await db.select<{ content_hash: string; tag: string }[]>(
+        'SELECT p.content_hash, pt.tag FROM pet_tags pt JOIN pets p ON pt.pet_id = p.id ORDER BY p.content_hash, pt.tag',
+      );
+      zip.file('pet_tags.json', JSON.stringify(tagRows));
     }
   }
 
@@ -244,8 +249,6 @@ async function importGenesAndPets(
         const params: Record<string, unknown> = {};
         for (const col of PET_COLUMNS) {
           if (col === 'genome_data') params[col] = genomeData;
-          else if (col === 'tags')
-            params[col] = typeof pet[col] === 'string' ? pet[col] : JSON.stringify(pet[col] ?? []);
           else if (col === 'sort_order') params[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
           else params[col] = pet[col] ?? null;
         }
@@ -281,6 +284,57 @@ async function importFromZip(fileData: Uint8Array, options: ImportOptions): Prom
   }
 
   const result = await importGenesAndPets(genes, pets, options);
+
+  // Import pet tags into junction table
+  if (options.includePets) {
+    const db = getDb();
+    const allPets = await db.select<{ id: number; content_hash: string }[]>('SELECT id, content_hash FROM pets');
+    const hashToId = new Map(allPets.map((p) => [p.content_hash, p.id]));
+
+    if (options.mode === 'replace') {
+      await db.execute('DELETE FROM pet_tags');
+    }
+
+    const petTagsFile = zip.file('pet_tags.json');
+    if (petTagsFile) {
+      // New format: pet_tags.json with { content_hash, tag } rows
+      const tagRows = JSON.parse(await petTagsFile.async('string')) as { content_hash: string; tag: string }[];
+      for (const row of tagRows) {
+        const petId = hashToId.get(row.content_hash);
+        if (petId) {
+          await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
+            pet_id: petId,
+            tag: row.tag,
+          });
+        }
+      }
+    } else if (pets) {
+      // Backward compat: v6 backups with tags as JSON array on each pet
+      for (const pet of pets) {
+        const petId = hashToId.get(pet.content_hash as string);
+        if (!petId) continue;
+        let tags: unknown[] = [];
+        if (Array.isArray(pet.tags)) tags = pet.tags;
+        else if (typeof pet.tags === 'string') {
+          try {
+            const parsed = JSON.parse(pet.tags);
+            if (Array.isArray(parsed)) tags = parsed;
+          } catch {
+            /* skip */
+          }
+        }
+        for (const tag of tags) {
+          if (typeof tag === 'string' && tag.trim()) {
+            await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
+              pet_id: petId,
+              tag: tag.trim().toLowerCase(),
+            });
+          }
+        }
+      }
+    }
+  }
+
   let imagesImported = 0;
   let imagesSkipped = 0;
 

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -299,13 +299,18 @@ async function importFromZip(fileData: Uint8Array, options: ImportOptions): Prom
     const petTagsFile = zip.file('pet_tags.json');
     if (petTagsFile) {
       // New format: pet_tags.json with { content_hash, tag } rows
-      const tagRows = JSON.parse(await petTagsFile.async('string')) as { content_hash: string; tag: string }[];
+      const tagRows = JSON.parse(await petTagsFile.async('string')) as unknown[];
       for (const row of tagRows) {
-        const petId = hashToId.get(row.content_hash);
+        if (!row || typeof row !== 'object') continue;
+        const record = row as Record<string, unknown>;
+        if (typeof record.content_hash !== 'string' || typeof record.tag !== 'string') continue;
+        const normalized = record.tag.trim().toLowerCase();
+        if (!normalized) continue;
+        const petId = hashToId.get(record.content_hash);
         if (petId) {
           await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
             pet_id: petId,
-            tag: row.tag.trim().toLowerCase(),
+            tag: normalized,
           });
         }
       }

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -285,12 +285,13 @@ async function importFromZip(fileData: Uint8Array, options: ImportOptions): Prom
 
   const result = await importGenesAndPets(genes, pets, options);
 
+  // Build pet hash-to-id map (shared by tag and image import)
+  const db = getDb();
+  const allPets = await db.select<{ id: number; content_hash: string }[]>('SELECT id, content_hash FROM pets');
+  const hashToId = new Map(allPets.map((p) => [p.content_hash, p.id]));
+
   // Import pet tags into junction table
   if (options.includePets) {
-    const db = getDb();
-    const allPets = await db.select<{ id: number; content_hash: string }[]>('SELECT id, content_hash FROM pets');
-    const hashToId = new Map(allPets.map((p) => [p.content_hash, p.id]));
-
     if (options.mode === 'replace') {
       await db.execute('DELETE FROM pet_tags');
     }
@@ -304,7 +305,7 @@ async function importFromZip(fileData: Uint8Array, options: ImportOptions): Prom
         if (petId) {
           await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
             pet_id: petId,
-            tag: row.tag,
+            tag: row.tag.trim().toLowerCase(),
           });
         }
       }
@@ -343,12 +344,8 @@ async function importFromZip(fileData: Uint8Array, options: ImportOptions): Prom
     const petImagesFile = zip.file('images/pet_images.json');
     if (petImagesFile && isTauri()) {
       const { writeFile, mkdir, BaseDirectory } = await import('@tauri-apps/plugin-fs');
-      const db = getDb();
 
       const imageRecords = JSON.parse(await petImagesFile.async('string')) as Record<string, unknown>[];
-
-      const allPets = await db.select<{ id: number; content_hash: string }[]>('SELECT id, content_hash FROM pets');
-      const hashToId = new Map(allPets.map((p) => [p.content_hash, p.id]));
 
       // Pre-fetch existing images for merge dedup
       let existingImageKeys: Set<string> | null = null;

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -190,7 +190,7 @@ class InMemoryDatabase implements DatabaseAdapter {
 
     // INSERT
     if (qLower.startsWith('insert')) {
-      const tableMatch = q.match(/insert\s+(?:or\s+replace\s+)?into\s+(\w+)\s*\(([^)]+)\)/i);
+      const tableMatch = q.match(/insert\s+(?:or\s+(?:replace|ignore)\s+)?into\s+(\w+)\s*\(([^)]+)\)/i);
       if (tableMatch) {
         const table = tableMatch[1].toLowerCase();
         const cols = tableMatch[2].split(',').map((c) => c.trim());
@@ -227,6 +227,18 @@ class InMemoryDatabase implements DatabaseAdapter {
           if (existingIdx >= 0) {
             this.tables[table][existingIdx] = row;
             return { rowsAffected: 1, lastInsertId: Number(row.id) };
+          }
+        }
+
+        // INSERT OR IGNORE — skip if duplicate exists (check pet_id+tag or other unique combos)
+        if (qLower.includes('or ignore')) {
+          const isDuplicate = this.tables[table].some(
+            (r) =>
+              (row.pet_id !== undefined && r.pet_id === row.pet_id && r.tag === row.tag) ||
+              (row.id !== undefined && r.id === row.id),
+          );
+          if (isDuplicate) {
+            return { rowsAffected: 0, lastInsertId: 0 };
           }
         }
 

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -82,6 +82,46 @@ const MIGRATIONS: Migration[] = [
       await db.execute("ALTER TABLE pets ADD COLUMN tags TEXT DEFAULT '[]'");
     },
   },
+  {
+    version: 7,
+    description: 'Migrate pet tags from JSON column to junction table',
+    up: async () => {
+      const db = getDb();
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS pet_tags (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          pet_id INTEGER NOT NULL,
+          tag TEXT NOT NULL,
+          UNIQUE(pet_id, tag),
+          FOREIGN KEY (pet_id) REFERENCES pets(id) ON DELETE CASCADE
+        )
+      `);
+      await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_tags_tag ON pet_tags(tag)');
+      await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_tags_pet_id ON pet_tags(pet_id)');
+
+      // Migrate existing JSON tags into junction table
+      const rows = await db.select<{ id: number; tags: string }[]>(
+        "SELECT id, tags FROM pets WHERE tags IS NOT NULL AND tags != '[]'",
+      );
+      for (const row of rows) {
+        try {
+          const tags = JSON.parse(row.tags);
+          if (Array.isArray(tags)) {
+            for (const tag of tags) {
+              if (typeof tag === 'string' && tag.trim()) {
+                await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
+                  pet_id: row.id,
+                  tag: tag.trim().toLowerCase(),
+                });
+              }
+            }
+          }
+        } catch {
+          // Skip rows with invalid JSON
+        }
+      }
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -66,40 +66,12 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
   return { total, known, unknown };
 }
 
-function parseTags(raw: unknown): string[] {
-  let arr: unknown[];
-  if (Array.isArray(raw)) {
-    arr = raw;
-  } else if (typeof raw === 'string') {
-    try {
-      const parsed = JSON.parse(raw);
-      arr = Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  } else {
-    return [];
-  }
-  // Normalize: keep only strings, trim, lowercase, dedupe
-  const seen = new Set<string>();
-  const result: string[] = [];
-  for (const item of arr) {
-    if (typeof item !== 'string') continue;
-    const normalized = item.trim().toLowerCase();
-    if (normalized && !seen.has(normalized)) {
-      seen.add(normalized);
-      result.push(normalized);
-    }
-  }
-  return result;
-}
-
 /** Enrich a raw pet row from the database with computed fields. */
-function enrichPet(pet: Record<string, unknown>): Pet {
+function enrichPet(pet: Record<string, unknown>, tags: string[] = []): Pet {
   const geneCounts = countGenes(pet.genome_data);
   return {
     ...pet,
-    tags: parseTags(pet.tags),
+    tags,
     total_genes: geneCounts.total,
     known_genes: geneCounts.known,
     unknown_genes: geneCounts.unknown,
@@ -107,6 +79,27 @@ function enrichPet(pet: Record<string, unknown>): Pet {
     readonly: false,
     is_demo: false,
   } as Pet;
+}
+
+async function loadTagsMap(petIds: number[]): Promise<Map<number, string[]>> {
+  if (petIds.length === 0) return new Map();
+  const db = getDb();
+  const rows = await db.select<{ pet_id: number; tag: string }[]>('SELECT pet_id, tag FROM pet_tags ORDER BY tag');
+  const map = new Map<number, string[]>();
+  for (const row of rows) {
+    const arr = map.get(row.pet_id);
+    if (arr) arr.push(row.tag);
+    else map.set(row.pet_id, [row.tag]);
+  }
+  return map;
+}
+
+async function loadTagsForPet(petId: number): Promise<string[]> {
+  const db = getDb();
+  const rows = await db.select<{ tag: string }[]>('SELECT tag FROM pet_tags WHERE pet_id = $pet_id ORDER BY tag', {
+    pet_id: petId,
+  });
+  return rows.map((r) => r.tag);
 }
 
 /**
@@ -142,7 +135,8 @@ export async function getAllPets(options?: {
   }
 
   const rows = await db.select<Record<string, unknown>[]>(query, selectParams);
-  const items = rows.map(enrichPet);
+  const tagsMap = await loadTagsMap(rows.map((r) => r.id as number));
+  const items = rows.map((r) => enrichPet(r, tagsMap.get(r.id as number) ?? []));
 
   return { items, total };
 }
@@ -153,7 +147,9 @@ export async function getAllPets(options?: {
 export async function getPet(petId: number): Promise<Pet | null> {
   const db = getDb();
   const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE id = $id', { id: petId });
-  return rows.length > 0 ? enrichPet(rows[0]) : null;
+  if (rows.length === 0) return null;
+  const tags = await loadTagsForPet(petId);
+  return enrichPet(rows[0], tags);
 }
 
 /**
@@ -257,7 +253,6 @@ const UPDATABLE_COLUMNS = new Set([
   'gender',
   'breed',
   'notes',
-  'tags',
   'genome_data',
   'sort_order',
   'intelligence',
@@ -278,9 +273,13 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
   const setClauses: string[] = [];
   const params: Record<string, unknown> = {};
 
+  // Extract tags for junction table handling
+  const newTags = updates.tags as string[] | undefined;
+
   // Flatten nested `attributes` object into top-level fields
   const flat: Record<string, unknown> = {};
   for (const [field, value] of Object.entries(updates)) {
+    if (field === 'tags') continue;
     if (field === 'attributes' && typeof value === 'object' && value !== null) {
       Object.assign(flat, value);
     } else {
@@ -291,18 +290,39 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
   for (const [field, value] of Object.entries(flat)) {
     if (!UPDATABLE_COLUMNS.has(field)) continue;
     setClauses.push(`${field} = $${field}`);
-    params[field] =
-      (field === 'tags' || field === 'genome_data') && typeof value !== 'string' ? JSON.stringify(value) : value;
+    params[field] = field === 'genome_data' && typeof value !== 'string' ? JSON.stringify(value) : value;
   }
 
-  if (setClauses.length === 0) return false;
+  let changed = false;
 
-  setClauses.push('updated_at = $updated_at');
-  params.updated_at = now();
-  params.w_id = petId;
+  if (setClauses.length > 0) {
+    setClauses.push('updated_at = $updated_at');
+    params.updated_at = now();
+    params.w_id = petId;
+    await db.execute(`UPDATE pets SET ${setClauses.join(', ')} WHERE id = $w_id`, params);
+    changed = true;
+  }
 
-  await db.execute(`UPDATE pets SET ${setClauses.join(', ')} WHERE id = $w_id`, params);
-  return true;
+  if (newTags !== undefined) {
+    await setTagsForPet(petId, newTags);
+    changed = true;
+  }
+
+  return changed;
+}
+
+async function setTagsForPet(petId: number, tags: string[]): Promise<void> {
+  const db = getDb();
+  await db.execute('DELETE FROM pet_tags WHERE pet_id = $pet_id', { pet_id: petId });
+  for (const tag of tags) {
+    const normalized = tag.trim().toLowerCase();
+    if (normalized) {
+      await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
+        pet_id: petId,
+        tag: normalized,
+      });
+    }
+  }
 }
 
 /**
@@ -326,7 +346,9 @@ export async function findPetByHash(contentHash: string): Promise<Pet | null> {
   const rows = await db.select<Record<string, unknown>[]>('SELECT * FROM pets WHERE content_hash = $hash', {
     hash: contentHash,
   });
-  return rows.length > 0 ? enrichPet(rows[0]) : null;
+  if (rows.length === 0) return null;
+  const tags = await loadTagsForPet(rows[0].id as number);
+  return enrichPet(rows[0], tags);
 }
 
 /**

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -81,9 +81,14 @@ function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
   } as Pet;
 }
 
-async function loadTagsMap(): Promise<Map<number, string[]>> {
+async function loadTagsForPets(petIds: number[]): Promise<Map<number, string[]>> {
+  if (petIds.length === 0) return new Map();
   const db = getDb();
-  const rows = await db.select<{ pet_id: number; tag: string }[]>('SELECT pet_id, tag FROM pet_tags ORDER BY tag');
+  const placeholders = petIds.map(() => '?').join(', ');
+  const rows = await db.select<{ pet_id: number; tag: string }[]>(
+    `SELECT pet_id, tag FROM pet_tags WHERE pet_id IN (${placeholders}) ORDER BY tag`,
+    petIds,
+  );
   const map = new Map<number, string[]>();
   for (const row of rows) {
     const arr = map.get(row.pet_id);
@@ -134,7 +139,7 @@ export async function getAllPets(options?: {
   }
 
   const rows = await db.select<Record<string, unknown>[]>(query, selectParams);
-  const tagsMap = await loadTagsMap();
+  const tagsMap = await loadTagsForPets(rows.map((r) => r.id as number));
   const items = rows.map((r) => enrichPet(r, tagsMap.get(r.id as number) ?? []));
 
   return { items, total };
@@ -304,6 +309,12 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
 
   if (newTags !== undefined) {
     await setTagsForPet(petId, newTags);
+    if (setClauses.length === 0) {
+      await db.execute('UPDATE pets SET updated_at = $updated_at WHERE id = $w_id', {
+        updated_at: now(),
+        w_id: petId,
+      });
+    }
     changed = true;
   }
 
@@ -312,15 +323,22 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
 
 async function setTagsForPet(petId: number, tags: string[]): Promise<void> {
   const db = getDb();
-  await db.execute('DELETE FROM pet_tags WHERE pet_id = $pet_id', { pet_id: petId });
-  for (const tag of tags) {
-    const normalized = tag.trim().toLowerCase();
-    if (normalized) {
-      await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
-        pet_id: petId,
-        tag: normalized,
-      });
+  await db.execute('BEGIN');
+  try {
+    await db.execute('DELETE FROM pet_tags WHERE pet_id = $pet_id', { pet_id: petId });
+    for (const tag of tags) {
+      const normalized = tag.trim().toLowerCase();
+      if (normalized) {
+        await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
+          pet_id: petId,
+          tag: normalized,
+        });
+      }
     }
+    await db.execute('COMMIT');
+  } catch (error) {
+    await db.execute('ROLLBACK');
+    throw error;
   }
 }
 

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -67,7 +67,7 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
 }
 
 /** Enrich a raw pet row from the database with computed fields. */
-function enrichPet(pet: Record<string, unknown>, tags: string[] = []): Pet {
+function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
   const geneCounts = countGenes(pet.genome_data);
   return {
     ...pet,
@@ -81,8 +81,7 @@ function enrichPet(pet: Record<string, unknown>, tags: string[] = []): Pet {
   } as Pet;
 }
 
-async function loadTagsMap(petIds: number[]): Promise<Map<number, string[]>> {
-  if (petIds.length === 0) return new Map();
+async function loadTagsMap(): Promise<Map<number, string[]>> {
   const db = getDb();
   const rows = await db.select<{ pet_id: number; tag: string }[]>('SELECT pet_id, tag FROM pet_tags ORDER BY tag');
   const map = new Map<number, string[]>();
@@ -135,7 +134,7 @@ export async function getAllPets(options?: {
   }
 
   const rows = await db.select<Record<string, unknown>[]>(query, selectParams);
-  const tagsMap = await loadTagsMap(rows.map((r) => r.id as number));
+  const tagsMap = await loadTagsMap();
   const items = rows.map((r) => enrichPet(r, tagsMap.get(r.id as number) ?? []));
 
   return { items, total };

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -60,7 +60,6 @@ const samplePet = {
   ferocity: 50,
   temperament: 50,
   sort_order: 0,
-  tags: '[]',
 };
 
 describe('Backup Service', () => {

--- a/tests/unit/petTags.test.js
+++ b/tests/unit/petTags.test.js
@@ -9,7 +9,7 @@ import * as petService from '$lib/services/petService.js';
 
 const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
 
-async function buildZip({ pets = [] } = {}) {
+async function buildZip({ pets = [], petTags = null } = {}) {
   const zip = new JSZip();
   zip.file(
     'metadata.json',
@@ -24,6 +24,9 @@ async function buildZip({ pets = [] } = {}) {
     }),
   );
   zip.file('pets.json', JSON.stringify(pets));
+  if (petTags) {
+    zip.file('pet_tags.json', JSON.stringify(petTags));
+  }
   return zip.generateAsync({ type: 'uint8array' });
 }
 
@@ -47,10 +50,9 @@ const basePet = {
   ferocity: 50,
   temperament: 50,
   sort_order: 0,
-  tags: '[]',
 };
 
-describe('Pet Tags', () => {
+describe('Pet Tags (junction table)', () => {
   beforeEach(async () => {
     await closeDatabase();
     await initDatabase();
@@ -58,12 +60,12 @@ describe('Pet Tags', () => {
   });
 
   describe('migration', () => {
-    it('schema version is 6', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(6);
+    it('schema version is 7', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBe(7);
     });
   });
 
-  describe('enrichPet — tag parsing', () => {
+  describe('tag operations via petService', () => {
     it('new pet has empty tags', async () => {
       await petService.uploadPet(SAMPLE_BEEWASP, 'Bee1', 'Female');
       const { items } = await petService.getAllPets();
@@ -79,11 +81,9 @@ describe('Pet Tags', () => {
       const updated = await petService.getPet(pet.id);
       expect(updated.tags).toEqual(['breeder', 'favorite']);
     });
-  });
 
-  describe('updatePet — tag persistence', () => {
     it('persists tags via updatePet', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee4', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee3', 'Male');
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -93,18 +93,18 @@ describe('Pet Tags', () => {
     });
 
     it('overwrites tags with a new set', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee5', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee4', 'Female');
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
       await petService.updatePet(pet.id, { tags: ['old-tag'] });
       await petService.updatePet(pet.id, { tags: ['new-tag', 'another'] });
       const updated = await petService.getPet(pet.id);
-      expect(updated.tags).toEqual(['new-tag', 'another']);
+      expect(updated.tags).toEqual(['another', 'new-tag']);
     });
 
     it('clears tags with empty array', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee6', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee5', 'Male');
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -113,12 +113,25 @@ describe('Pet Tags', () => {
       const updated = await petService.getPet(pet.id);
       expect(updated.tags).toEqual([]);
     });
+
+    it('normalizes tags to lowercase and trims', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee6', 'Female');
+      const { items } = await petService.getAllPets();
+      const pet = items[0];
+
+      await petService.updatePet(pet.id, { tags: ['  Breeder  ', 'FAVORITE'] });
+      const updated = await petService.getPet(pet.id);
+      expect(updated.tags).toEqual(['breeder', 'favorite']);
+    });
   });
 
   describe('backup round-trip', () => {
-    it('preserves tags through import', async () => {
-      const pet = { ...basePet, tags: '["breeder","favorite"]' };
-      const zipData = await buildZip({ pets: [pet] });
+    it('preserves tags through import (new pet_tags.json format)', async () => {
+      const petTags = [
+        { content_hash: 'hash_tags_test', tag: 'breeder' },
+        { content_hash: 'hash_tags_test', tag: 'favorite' },
+      ];
+      const zipData = await buildZip({ pets: [basePet], petTags });
       await importDatabase(zipData, {
         mode: 'replace',
         includeGenes: false,
@@ -130,8 +143,8 @@ describe('Pet Tags', () => {
       expect(items[0].tags).toEqual(['breeder', 'favorite']);
     });
 
-    it('handles tags as parsed array on import', async () => {
-      const pet = { ...basePet, tags: ['alpha', 'beta'], content_hash: 'hash_parsed' };
+    it('backward compat: imports tags from v6 JSON field on pets', async () => {
+      const pet = { ...basePet, tags: '["alpha","beta"]', content_hash: 'hash_v6' };
       const zipData = await buildZip({ pets: [pet] });
       await importDatabase(zipData, {
         mode: 'replace',
@@ -142,6 +155,20 @@ describe('Pet Tags', () => {
 
       const { items } = await petService.getAllPets();
       expect(items[0].tags).toEqual(['alpha', 'beta']);
+    });
+
+    it('backward compat: handles tags as parsed array on import', async () => {
+      const pet = { ...basePet, tags: ['gamma', 'delta'], content_hash: 'hash_parsed' };
+      const zipData = await buildZip({ pets: [pet] });
+      await importDatabase(zipData, {
+        mode: 'replace',
+        includeGenes: false,
+        includePets: true,
+        includeImages: false,
+      });
+
+      const { items } = await petService.getAllPets();
+      expect(items[0].tags).toEqual(['delta', 'gamma']);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Migrates pet tags from a JSON array column (`tags TEXT`) to a proper `pet_tags` junction table with `UNIQUE(pet_id, tag)` constraint and indexes
- Tags are now read/written via dedicated SQL queries instead of JSON parse/serialize
- Backup export produces `pet_tags.json` keyed by `content_hash`; import has backward compatibility with v6 JSON-on-pet format
- Adds `INSERT OR IGNORE` support to the in-memory test database adapter

Closes #114

## Changes
| File | Description |
|---|---|
| `migrationService.ts` | Migration v7: create `pet_tags` table, migrate existing JSON data |
| `petService.ts` | Read tags via `loadTagsMap`/`loadTagsForPet`, write via `setTagsForPet` (DELETE+INSERT), remove `parseTags` |
| `backupService.ts` | Export `pet_tags.json`, import with v6 backward compat, remove `tags` from `PET_COLUMNS` |
| `database.ts` | In-memory adapter: support `INSERT OR IGNORE` |
| `petTags.test.js` | Updated for junction table + new backup format + backward compat tests |
| `backupService.test.js` | Remove `tags` from samplePet fixture |

## Test plan
- [x] All 222 unit tests pass
- [x] Lint clean
- [x] Frontend builds
- [ ] Manual: existing tagged pets survive the migration
- [ ] Manual: add/remove tags, verify they persist after reload
- [ ] Manual: export backup, verify `pet_tags.json` in zip
- [ ] Manual: import v6 backup with JSON tags, verify they appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)