### PR TITLE
feat: full keyboard navigation and font scaling (#87, #89)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -186,6 +186,40 @@ textarea {
   background: #f3f4f6;
 }
 
+/* --- Global focus-visible styles --- */
+:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+/* Suppress outline for mouse clicks on interactive elements */
+button:focus:not(:focus-visible),
+[role="button"]:focus:not(:focus-visible),
+a:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+select:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* Skip-to-content link */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  padding: 8px 16px;
+  background: #3b82f6;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 10000;
+  transition: top 0.15s;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 .checkbox-row {
   display: flex;
   align-items: flex-start;

--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -63,7 +63,17 @@ function handleMouseLeave(event) {
 function handleKeydown(event) {
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault();
-    handleMouseEnter(event);
+    if (!gene) return;
+    // Use element bounding rect for tooltip positioning since KeyboardEvent has no clientX/Y
+    const rect = event.currentTarget.getBoundingClientRect();
+    const syntheticEvent = { clientX: rect.left + rect.width / 2, clientY: rect.top };
+    dispatch('tooltip-show', {
+      event: syntheticEvent,
+      geneId: gene.id,
+      geneType: gene.type,
+      chromosome,
+      effect: geneAnalysis?.effect || '',
+    });
   } else if (event.key === 'Escape') {
     dispatch('tooltip-hide', { event });
   }

--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -59,6 +59,20 @@ function handleMouseEnter(event) {
 function handleMouseLeave(event) {
   dispatch('tooltip-hide', { event });
 }
+
+function handleKeydown(event) {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    handleMouseEnter(event);
+  } else if (event.key === 'Escape') {
+    dispatch('tooltip-hide', { event });
+  }
+}
+
+function handleBlur(event) {
+  dispatch('tooltip-hide', { event });
+}
+
 const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVisible));
 </script>
 
@@ -71,8 +85,11 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
         data-effect={geneAnalysis?.effect || ""}
         onmouseenter={handleMouseEnter}
         onmouseleave={handleMouseLeave}
+        onkeydown={handleKeydown}
+        onblur={handleBlur}
         role="button"
         tabindex="0"
+        aria-label="Gene {gene.id}{geneAnalysis?.effect ? ': ' + geneAnalysis.effect : ''}"
     >
         {#if gene.type === "?"}
             <span class="gene-unknown-symbol" title="Unknown gene">?</span>

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -964,12 +964,13 @@ function handleGridKeydown(e) {
   if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
 
   const container = e.currentTarget;
-  const cells = Array.from(container.querySelectorAll('.gene-cell[tabindex="0"]'));
-  const current = cells.indexOf(document.activeElement);
+  const cells = Array.from(container.querySelectorAll('.gene-cell[role="button"]'));
+  const activeCell = document.activeElement?.closest('.gene-cell');
+  const current = cells.indexOf(activeCell);
   if (current < 0) return;
 
-  const row = document.activeElement.closest('tr');
-  const cols = row ? row.querySelectorAll('.gene-cell[tabindex="0"]').length : 1;
+  const row = activeCell?.closest('tr');
+  const cols = row ? row.querySelectorAll('.gene-cell[role="button"]').length : 1;
   handleGridNavigation(cells, current, e, cols);
 }
 

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -12,6 +12,7 @@ import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { blockLetter } from '$lib/services/genomeParser.js';
 import { getPetGenome } from '$lib/services/petService.js';
 import { EFFECT_COLORS } from '$lib/theme/gene-colors.js';
+import { handleGridNavigation } from '$lib/utils/keyboard.js';
 import GeneCell from './GeneCell.svelte';
 import GeneTooltip from './GeneTooltip.svelte';
 
@@ -959,6 +960,19 @@ function handleTooltipHide() {
   tooltipVisible = false;
 }
 
+function handleGridKeydown(e) {
+  if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) return;
+
+  const container = e.currentTarget;
+  const cells = Array.from(container.querySelectorAll('.gene-cell[tabindex="0"]'));
+  const current = cells.indexOf(document.activeElement);
+  if (current < 0) return;
+
+  const row = document.activeElement.closest('tr');
+  const cols = row ? row.querySelectorAll('.gene-cell[tabindex="0"]').length : 1;
+  handleGridNavigation(cells, current, e, cols);
+}
+
 function toggleFilterState(selectedArr, hiddenArr, key, action) {
   const isSelected = selectedArr.includes(key);
   const isHidden = hiddenArr.includes(key);
@@ -1606,7 +1620,8 @@ export function getStatsData() {
                 </div>
 
                 <!-- Gene Grid -->
-                <div class="gene-grid-container">
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div class="gene-grid-container" onkeydown={handleGridKeydown}>
                     {#if headerStructure && chromosomeData.length > 0}
                         <!-- Optimized dynamic rendering -->
                         {#key currentSpeciesTemplate ? currentSpeciesTemplate.species + "_" + currentSpeciesTemplate.chromosomeCount + "_" + currentSpeciesTemplate.blockCount : "initial"}

--- a/src/lib/components/layout/DataMenu.svelte
+++ b/src/lib/components/layout/DataMenu.svelte
@@ -1,5 +1,5 @@
 <script>
-import { onDestroy } from 'svelte';
+import { onDestroy, tick } from 'svelte';
 import { inspectBackup } from '$lib/services/backupService.js';
 import { pickBackupFile, readBinaryFile } from '$lib/services/fileService.js';
 import ExportDialog from './ExportDialog.svelte';
@@ -16,13 +16,57 @@ let importFileData = $state(null);
 let status = $state(null);
 let statusTimer = 0;
 
+let focusedIndex = $state(-1);
+let menuItems = $state([]);
+
 function toggleMenu() {
   menuOpen = !menuOpen;
   status = null;
+  if (menuOpen) {
+    focusedIndex = 0;
+    tick().then(() => menuItems[0]?.focus());
+  }
 }
 
 function closeMenu() {
   menuOpen = false;
+  focusedIndex = -1;
+}
+
+function handleToggleKeydown(e) {
+  if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+    if (!menuOpen) {
+      e.preventDefault();
+      menuOpen = true;
+      status = null;
+      focusedIndex = 0;
+      tick().then(() => menuItems[0]?.focus());
+    }
+  }
+}
+
+function handleMenuKeydown(e) {
+  if (e.key === 'Escape') {
+    e.preventDefault();
+    closeMenu();
+    document.querySelector('.menu-toggle')?.focus();
+  } else if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    focusedIndex = (focusedIndex + 1) % menuItems.length;
+    menuItems[focusedIndex]?.focus();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    focusedIndex = (focusedIndex - 1 + menuItems.length) % menuItems.length;
+    menuItems[focusedIndex]?.focus();
+  } else if (e.key === 'Home') {
+    e.preventDefault();
+    focusedIndex = 0;
+    menuItems[0]?.focus();
+  } else if (e.key === 'End') {
+    e.preventDefault();
+    focusedIndex = menuItems.length - 1;
+    menuItems[focusedIndex]?.focus();
+  }
 }
 
 function openExport() {
@@ -73,7 +117,14 @@ function handleClickOutside(event) {
 <svelte:window onclick={handleClickOutside} />
 
 <div class="data-menu">
-  <button class="menu-toggle" onclick={toggleMenu} title="Data management">
+  <button
+    class="menu-toggle"
+    onclick={toggleMenu}
+    onkeydown={handleToggleKeydown}
+    title="Data management"
+    aria-haspopup="menu"
+    aria-expanded={menuOpen}
+  >
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <ellipse cx="12" cy="5" rx="9" ry="3"/>
       <path d="M3 5V19A9 3 0 0 0 21 19V5"/>
@@ -82,8 +133,15 @@ function handleClickOutside(event) {
   </button>
 
   {#if menuOpen}
-    <div class="dropdown">
-      <button class="dropdown-item" onclick={openExport}>
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="dropdown" role="menu" onkeydown={handleMenuKeydown}>
+      <button
+        class="dropdown-item"
+        role="menuitem"
+        tabindex={focusedIndex === 0 ? 0 : -1}
+        onclick={openExport}
+        bind:this={menuItems[0]}
+      >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
           <polyline points="7 10 12 15 17 10"/>
@@ -91,7 +149,13 @@ function handleClickOutside(event) {
         </svg>
         Export Backup
       </button>
-      <button class="dropdown-item" onclick={openImport}>
+      <button
+        class="dropdown-item"
+        role="menuitem"
+        tabindex={focusedIndex === 1 ? 0 : -1}
+        onclick={openImport}
+        bind:this={menuItems[1]}
+      >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
           <polyline points="17 8 12 3 7 8"/>

--- a/src/lib/components/layout/DataMenu.svelte
+++ b/src/lib/components/layout/DataMenu.svelte
@@ -135,8 +135,7 @@ function handleClickOutside(event) {
   </button>
 
   {#if menuOpen}
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dropdown" role="menu" onkeydown={handleMenuKeydown}>
+    <div class="dropdown" role="menu" tabindex="-1" onkeydown={handleMenuKeydown}>
       <button
         class="dropdown-item"
         role="menuitem"

--- a/src/lib/components/layout/DataMenu.svelte
+++ b/src/lib/components/layout/DataMenu.svelte
@@ -17,7 +17,9 @@ let status = $state(null);
 let statusTimer = 0;
 
 let focusedIndex = $state(-1);
-let menuItems = $state([]);
+let exportBtn = $state(null);
+let importBtn = $state(null);
+const menuItems = $derived([exportBtn, importBtn].filter(Boolean));
 
 function toggleMenu() {
   menuOpen = !menuOpen;
@@ -140,7 +142,7 @@ function handleClickOutside(event) {
         role="menuitem"
         tabindex={focusedIndex === 0 ? 0 : -1}
         onclick={openExport}
-        bind:this={menuItems[0]}
+        bind:this={exportBtn}
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
@@ -154,7 +156,7 @@ function handleClickOutside(event) {
         role="menuitem"
         tabindex={focusedIndex === 1 ? 0 : -1}
         onclick={openImport}
-        bind:this={menuItems[1]}
+        bind:this={importBtn}
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>

--- a/src/lib/components/layout/ExportDialog.svelte
+++ b/src/lib/components/layout/ExportDialog.svelte
@@ -1,6 +1,7 @@
 <script>
 import { exportDatabase } from '$lib/services/backupService.js';
 import { getTotalImageCount } from '$lib/services/imageService.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 
 const { onClose, onResult } = $props();
 
@@ -37,7 +38,7 @@ async function handleExport() {
 <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
 <div class="modal-backdrop" onclick={onClose} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }} role="presentation">
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="dialog export-dialog" role="dialog" aria-label="Export Backup" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}>
+  <div class="dialog export-dialog" role="dialog" aria-label="Export Backup" aria-modal="true" tabindex="-1" use:focusTrap onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}>
     <div class="dialog-header">
       <h3>Export Backup</h3>
       <button class="close-btn" onclick={onClose}>×</button>

--- a/src/lib/components/layout/ImportDialog.svelte
+++ b/src/lib/components/layout/ImportDialog.svelte
@@ -1,6 +1,7 @@
 <script>
 import { importDatabase } from '$lib/services/backupService.js';
 import { appState } from '$lib/stores/pets.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 
 const { metadata, fileData, onClose, onResult } = $props();
 
@@ -47,7 +48,7 @@ async function handleImport() {
 <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
 <div class="modal-backdrop" onclick={onClose} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }} role="presentation">
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="dialog import-dialog" role="dialog" aria-label="Import Backup" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}>
+  <div class="dialog import-dialog" role="dialog" aria-label="Import Backup" aria-modal="true" tabindex="-1" use:focusTrap onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}>
     <div class="dialog-header">
       <h3>Import Backup</h3>
       <button class="close-btn" onclick={onClose}>×</button>

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -3,6 +3,8 @@
 
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
+import { getFontScale as _getFontScale, clampScale, MAX_SCALE, MIN_SCALE } from '$lib/utils/fontScale.js';
 
 let open = $state(false);
 
@@ -19,6 +21,22 @@ const inTauri = isTauri();
 
 function toErrorMessage(err) {
   return err instanceof Error ? err.message : String(err);
+}
+
+const modKey = /mac/i.test(navigator?.userAgent ?? '') ? '⌘' : 'Ctrl';
+
+function getFontScale() {
+  return _getFontScale($settings);
+}
+
+async function setFontScale(scale) {
+  const clamped = clampScale(scale);
+  document.documentElement.style.fontSize = `${clamped}%`;
+  await settingsActions.update('display.fontScale', clamped);
+}
+
+function adjustFontScale(delta) {
+  setFontScale(getFontScale() + delta);
 }
 
 function toggle() {
@@ -90,7 +108,7 @@ async function installUpdate() {
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="modal-backdrop" onclick={close} onkeydown={(e) => { if (e.key === 'Escape') close(); }} role="presentation">
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dialog settings-dialog" role="dialog" aria-label="Settings" tabindex="-1" onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') close(); }}>
+    <div class="dialog settings-dialog" role="dialog" aria-label="Settings" aria-modal="true" tabindex="-1" use:focusTrap onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') close(); }}>
       <div class="dialog-header">
         <h3>Settings</h3>
         <button class="close-btn" onclick={close} aria-label="Close settings">
@@ -121,6 +139,37 @@ async function installUpdate() {
               <span class="toggle-thumb"></span>
             </button>
           </label>
+        </div>
+
+        <div class="settings-section">
+          <h4>Display</h4>
+
+          <div class="setting-row">
+            <div class="setting-info">
+              <span class="setting-name">Font scale</span>
+              <span class="setting-desc">Adjust with {modKey}+/- or use these controls</span>
+            </div>
+            <div class="scale-controls">
+              <button
+                class="scale-btn"
+                onclick={() => adjustFontScale(-10)}
+                disabled={getFontScale() <= MIN_SCALE}
+                aria-label="Decrease font size"
+              >−</button>
+              <span class="scale-value">{getFontScale()}%</span>
+              <button
+                class="scale-btn"
+                onclick={() => adjustFontScale(10)}
+                disabled={getFontScale() >= MAX_SCALE}
+                aria-label="Increase font size"
+              >+</button>
+              <button
+                class="scale-reset-btn"
+                onclick={() => setFontScale(100)}
+                disabled={getFontScale() === 100}
+              >Reset</button>
+            </div>
+          </div>
         </div>
 
         <div class="settings-section">
@@ -286,6 +335,69 @@ async function installUpdate() {
     margin-top: 20px;
     padding-top: 16px;
     border-top: 1px solid #e5e7eb;
+  }
+
+  .scale-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .scale-btn {
+    width: 28px;
+    height: 28px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #374151;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s ease;
+  }
+
+  .scale-btn:hover:not(:disabled) {
+    background: #f9fafb;
+    border-color: #9ca3af;
+  }
+
+  .scale-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .scale-value {
+    font-size: 13px;
+    font-weight: 600;
+    color: #111827;
+    min-width: 40px;
+    text-align: center;
+  }
+
+  .scale-reset-btn {
+    padding: 4px 10px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #6b7280;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .scale-reset-btn:hover:not(:disabled) {
+    background: #f9fafb;
+    border-color: #9ca3af;
+  }
+
+  .scale-reset-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 
   .check-update-btn {

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -15,7 +15,7 @@ function switchTab(tab) {
         <span class="app-name">Gorgonetics</span>
     </div>
     <div class="top-bar-right">
-    <div class="top-bar-tabs">
+    <nav aria-label="Main navigation" class="top-bar-tabs">
         <button
             class="tab-btn"
             class:active={$activeTab === "pets"}
@@ -30,7 +30,7 @@ function switchTab(tab) {
         >
             🧬 Genes
         </button>
-    </div>
+    </nav>
     <DataMenu />
     <SettingsModal />
     </div>

--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -1,5 +1,5 @@
 <script>
-const { pet, selected = false, onclick } = $props();
+const { pet, selected = false, onclick, onkeydown } = $props();
 
 function getSpeciesEmoji(species) {
   const s = (species || '').toLowerCase();
@@ -13,6 +13,7 @@ function getSpeciesEmoji(species) {
     class="pet-card"
     class:selected
     onclick={() => onclick?.(pet)}
+    {onkeydown}
 >
     <div class="pet-card-main">
         <div class="pet-card-icon">{getSpeciesEmoji(pet.species)}</div>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -3,6 +3,7 @@ import { untrack } from 'svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
 import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 import TagInput from './TagInput.svelte';
 
 const ALL_ATTRIBUTES = getAllAttributeDisplayInfo();
@@ -96,7 +97,7 @@ function updateAttribute(attrKey, value) {
 {#if open}
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="modal-backdrop" onclick={handleBackdropClick} onkeydown={handleKeydown}>
-  <div class="modal-panel" role="dialog" aria-label="Edit Pet">
+  <div class="modal-panel" role="dialog" aria-label="Edit Pet" aria-modal="true" use:focusTrap>
     <div class="modal-header">
       <h2>Edit Pet</h2>
       <button class="modal-close" onclick={handleCancel}>×</button>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -36,7 +36,7 @@ let editName = $state(initial.name);
 let editGender = $state(initial.gender);
 let editBreed = $state(initial.breed);
 const editAttributes = $state(initial.attributes);
-let editTags = $state([...(pet.tags ?? [])]);
+let editTags = $state(untrack(() => [...(pet.tags ?? [])]));
 let saveError = $state('');
 
 const allTags = $derived($allTagsStore);

--- a/src/lib/components/pet/PetImageGallery.svelte
+++ b/src/lib/components/pet/PetImageGallery.svelte
@@ -8,6 +8,7 @@ import {
   uploadImage,
 } from '$lib/services/imageService.js';
 import { createDragState } from '$lib/utils/dragReorder.svelte.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
 
 const { pet } = $props();
@@ -143,13 +144,6 @@ $effect(() => {
   const _id = pet?.id;
   loadImages();
 });
-
-// Focus lightbox when opened so keyboard navigation works
-$effect(() => {
-  if (lightboxIndex >= 0) {
-    document.querySelector('.lightbox')?.focus();
-  }
-});
 </script>
 
 <div class="gallery">
@@ -203,7 +197,7 @@ $effect(() => {
 
 {#if lightboxImage}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="lightbox" role="dialog" aria-label="Image viewer" tabindex="-1" onclick={closeLightbox} onkeydown={handleLightboxKey}>
+  <div class="lightbox" role="dialog" aria-label="Image viewer" aria-modal="true" tabindex="-1" use:focusTrap onclick={closeLightbox} onkeydown={handleLightboxKey}>
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
     <div class="lightbox-content" onclick={(e) => e.stopPropagation()}>
       <img src={lightboxImage.url} alt={lightboxImage.original_name} />
@@ -229,7 +223,7 @@ $effect(() => {
   <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
   <div class="modal-backdrop" onclick={cancelDelete} onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }} role="presentation">
     <!-- svelte-ignore a11y_click_events_have_key_events a11y_interactive_supports_focus -->
-    <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" tabindex="-1" onclick={(e) => e.stopPropagation()}>
+    <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" aria-modal="true" tabindex="-1" use:focusTrap onclick={(e) => e.stopPropagation()}>
       <h3>Delete image?</h3>
       <p>Delete <strong>{deleteTarget.original_name}</strong>? This cannot be undone.</p>
       <div class="confirm-actions">
@@ -379,7 +373,9 @@ $effect(() => {
     transition: opacity 0.15s;
   }
 
-  .thumbnail-card:hover .thumbnail-delete {
+  .thumbnail-card:hover .thumbnail-delete,
+  .thumbnail-card:focus-within .thumbnail-delete,
+  .thumbnail-delete:focus {
     opacity: 1;
   }
 

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -210,14 +210,12 @@ async function handleDrop(e, dropIndex) {
         {/if}
     </div>
 
-    <div class="pet-list-items" role="listbox" aria-label="Pet list">
+    <div class="pet-list-items" aria-label="Pet list">
         {#if filteredPets.length > 0}
             {#each filteredPets as pet, index (pet.id)}
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                     class="pet-card-wrapper"
-                    role="option"
-                    aria-selected={$selectedPet?.id === pet.id}
                     class:drag-over={drag.dragOverIndex === index && drag.draggedIndex !== index}
                     class:dragging={drag.draggedIndex === index}
                     draggable={isDraggable}

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -2,6 +2,7 @@
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
 import { createDragState } from '$lib/utils/dragReorder.svelte.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
 import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
@@ -113,6 +114,31 @@ function cancelDelete() {
   deletingPet = null;
 }
 
+function handlePetCardKeydown(e, index) {
+  const len = filteredPets.length;
+  if (len === 0) return;
+
+  let nextIndex = -1;
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    nextIndex = Math.min(index + 1, len - 1);
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    nextIndex = Math.max(index - 1, 0);
+  } else if (e.key === 'Home') {
+    e.preventDefault();
+    nextIndex = 0;
+  } else if (e.key === 'End') {
+    e.preventDefault();
+    nextIndex = len - 1;
+  }
+
+  if (nextIndex >= 0 && nextIndex !== index) {
+    const cards = document.querySelectorAll('.pet-list-items .pet-card');
+    cards[nextIndex]?.focus();
+  }
+}
+
 const drag = createDragState();
 const isDraggable = $derived(!searchQuery && selectedTags.length === 0);
 
@@ -184,12 +210,14 @@ async function handleDrop(e, dropIndex) {
         {/if}
     </div>
 
-    <div class="pet-list-items">
+    <div class="pet-list-items" role="listbox" aria-label="Pet list">
         {#if filteredPets.length > 0}
             {#each filteredPets as pet, index (pet.id)}
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                     class="pet-card-wrapper"
+                    role="option"
+                    aria-selected={$selectedPet?.id === pet.id}
                     class:drag-over={drag.dragOverIndex === index && drag.draggedIndex !== index}
                     class:dragging={drag.draggedIndex === index}
                     draggable={isDraggable}
@@ -203,6 +231,7 @@ async function handleDrop(e, dropIndex) {
                         {pet}
                         selected={$selectedPet?.id === pet.id}
                         onclick={selectPet}
+                        onkeydown={(e) => handlePetCardKeydown(e, index)}
                     />
                     <div class="pet-card-actions">
                         <button
@@ -267,7 +296,7 @@ async function handleDrop(e, dropIndex) {
 {#if deletingPet}
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="modal-backdrop" onclick={cancelDelete} onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }}>
-    <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete">
+    <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" aria-modal="true" use:focusTrap>
         <p class="confirm-message">Delete <strong>{deletingPet.name}</strong>?</p>
         <p class="confirm-subtext">This action cannot be undone.</p>
         <div class="confirm-actions">
@@ -413,7 +442,8 @@ async function handleDrop(e, dropIndex) {
         gap: 2px;
     }
 
-    .pet-card-wrapper:hover .pet-card-actions {
+    .pet-card-wrapper:hover .pet-card-actions,
+    .pet-card-wrapper:focus-within .pet-card-actions {
         display: flex;
     }
 

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -9,6 +9,7 @@ import { getDb } from './database.js';
 
 const SETTING_DEFAULTS: Record<string, unknown> = {
   'horse.autoSelectBreedFilter': true,
+  'display.fontScale': 100,
 };
 
 export function getDefaultSettings(): Record<string, unknown> {

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -15,7 +15,8 @@ export const settingsActions = {
   },
 
   async update(key: string, value: unknown) {
-    await setSetting(key, value);
+    // Update store optimistically so consumers see the new value immediately
     settings.update((s) => ({ ...s, [key]: value }));
+    await setSetting(key, value);
   },
 };

--- a/src/lib/utils/focusTrap.ts
+++ b/src/lib/utils/focusTrap.ts
@@ -1,0 +1,74 @@
+/**
+ * Focus trap utility for modals and dialogs.
+ * Traps Tab focus within a container and restores focus on cleanup.
+ */
+
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => el.offsetParent !== null);
+}
+
+/**
+ * Activates a focus trap on the given element.
+ * Returns a cleanup function that removes the trap and restores focus.
+ */
+export function createFocusTrap(container: HTMLElement): () => void {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  // Focus the container itself or the first focusable child
+  const focusable = getFocusableElements(container);
+  if (focusable.length > 0) {
+    focusable[0].focus();
+  } else {
+    container.focus();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Tab') return;
+
+    const elements = getFocusableElements(container);
+    if (elements.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = elements[0];
+    const last = elements[elements.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  container.addEventListener('keydown', handleKeydown);
+
+  return () => {
+    container.removeEventListener('keydown', handleKeydown);
+    previouslyFocused?.focus();
+  };
+}
+
+/**
+ * Svelte action that applies a focus trap for the lifetime of the element.
+ * Usage: <div use:focusTrap>
+ */
+export function focusTrap(node: HTMLElement) {
+  const cleanup = createFocusTrap(node);
+  return { destroy: cleanup };
+}

--- a/src/lib/utils/focusTrap.ts
+++ b/src/lib/utils/focusTrap.ts
@@ -12,8 +12,14 @@ const FOCUSABLE = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(', ');
 
+function isVisible(el: HTMLElement): boolean {
+  if (el.hasAttribute('hidden')) return false;
+  const style = window.getComputedStyle(el);
+  return style.display !== 'none' && style.visibility !== 'hidden' && el.getClientRects().length > 0;
+}
+
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter((el) => el.offsetParent !== null);
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(isVisible);
 }
 
 /**

--- a/src/lib/utils/fontScale.ts
+++ b/src/lib/utils/fontScale.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared font scale utilities.
+ * Used by both +layout.svelte (global keyboard shortcuts) and SettingsModal (UI controls).
+ */
+
+export const MIN_SCALE = 75;
+export const MAX_SCALE = 150;
+export const STEP = 10;
+
+export function getFontScale(settings: Record<string, unknown>): number {
+  const val = settings['display.fontScale'];
+  return typeof val === 'number' ? val : 100;
+}
+
+export function applyFontScale(scale: number): void {
+  document.documentElement.style.fontSize = `${scale}%`;
+}
+
+export function clampScale(scale: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale));
+}

--- a/src/lib/utils/keyboard.ts
+++ b/src/lib/utils/keyboard.ts
@@ -1,0 +1,103 @@
+/**
+ * Keyboard navigation utilities for composite widgets.
+ * Implements roving tabindex pattern for lists and grids.
+ */
+
+/**
+ * Handles arrow-key navigation within a list of elements (roving tabindex).
+ * Call from the container's keydown handler.
+ *
+ * @param items - Array of focusable HTMLElements
+ * @param currentIndex - Index of the currently focused item
+ * @param event - The keyboard event
+ * @param options - Navigation options
+ * @returns The new index after navigation, or -1 if the key was not handled
+ */
+export function handleListNavigation(
+  items: HTMLElement[],
+  currentIndex: number,
+  event: KeyboardEvent,
+  options: { orientation?: 'vertical' | 'horizontal'; wrap?: boolean } = {},
+): number {
+  const { orientation = 'vertical', wrap = true } = options;
+  const len = items.length;
+  if (len === 0) return -1;
+
+  const prevKey = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+  const nextKey = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+
+  let newIndex = -1;
+
+  if (event.key === nextKey) {
+    event.preventDefault();
+    newIndex = currentIndex + 1;
+    if (newIndex >= len) newIndex = wrap ? 0 : len - 1;
+  } else if (event.key === prevKey) {
+    event.preventDefault();
+    newIndex = currentIndex - 1;
+    if (newIndex < 0) newIndex = wrap ? len - 1 : 0;
+  } else if (event.key === 'Home') {
+    event.preventDefault();
+    newIndex = 0;
+  } else if (event.key === 'End') {
+    event.preventDefault();
+    newIndex = len - 1;
+  }
+
+  if (newIndex >= 0 && newIndex < len) {
+    // Roving tabindex: deactivate old, activate new
+    items[currentIndex]?.setAttribute('tabindex', '-1');
+    items[newIndex].setAttribute('tabindex', '0');
+    items[newIndex].focus();
+  }
+
+  return newIndex;
+}
+
+/**
+ * Handles arrow-key navigation within a 2D grid of elements.
+ * Elements should be laid out in row-major order.
+ */
+export function handleGridNavigation(
+  items: HTMLElement[],
+  currentIndex: number,
+  event: KeyboardEvent,
+  columns: number,
+): number {
+  const len = items.length;
+  if (len === 0) return -1;
+
+  let newIndex = -1;
+
+  if (event.key === 'ArrowRight') {
+    event.preventDefault();
+    newIndex = currentIndex + 1;
+    if (newIndex >= len) newIndex = currentIndex;
+  } else if (event.key === 'ArrowLeft') {
+    event.preventDefault();
+    newIndex = currentIndex - 1;
+    if (newIndex < 0) newIndex = 0;
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault();
+    newIndex = currentIndex + columns;
+    if (newIndex >= len) newIndex = currentIndex;
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault();
+    newIndex = currentIndex - columns;
+    if (newIndex < 0) newIndex = currentIndex;
+  } else if (event.key === 'Home') {
+    event.preventDefault();
+    newIndex = 0;
+  } else if (event.key === 'End') {
+    event.preventDefault();
+    newIndex = len - 1;
+  }
+
+  if (newIndex >= 0 && newIndex !== currentIndex) {
+    items[currentIndex]?.setAttribute('tabindex', '-1');
+    items[newIndex].setAttribute('tabindex', '0');
+    items[newIndex].focus();
+  }
+
+  return newIndex;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,16 +3,50 @@ import '../app.css';
 import AuthWrapper from '$lib/components/AuthWrapper.svelte';
 import MasterPanel from '$lib/components/layout/MasterPanel.svelte';
 import TopBar from '$lib/components/layout/TopBar.svelte';
+import { settings, settingsActions } from '$lib/stores/settings.js';
+import { applyFontScale, clampScale, getFontScale, STEP } from '$lib/utils/fontScale.js';
 
 const { children } = $props();
+
+const fontScale = $derived(getFontScale($settings));
+
+async function setScale(scale) {
+  const clamped = clampScale(scale);
+  applyFontScale(clamped);
+  await settingsActions.update('display.fontScale', clamped);
+}
+
+function handleGlobalKeydown(e) {
+  const mod = e.metaKey || e.ctrlKey;
+  if (!mod) return;
+
+  if (e.key === '=' || e.key === '+') {
+    e.preventDefault();
+    setScale(fontScale + STEP);
+  } else if (e.key === '-') {
+    e.preventDefault();
+    setScale(fontScale - STEP);
+  } else if (e.key === '0') {
+    e.preventDefault();
+    setScale(100);
+  }
+}
+
+// Apply persisted font scale on load and when it changes
+$effect(() => {
+  applyFontScale(fontScale);
+});
 </script>
 
+<svelte:window onkeydown={handleGlobalKeydown} />
+
+<a class="skip-link" href="#main-content">Skip to main content</a>
 <AuthWrapper>
     <div class="app-shell">
         <TopBar />
         <div class="app-body">
             <MasterPanel />
-            <main class="detail-pane">
+            <main id="main-content" class="detail-pane">
                 {@render children()}
             </main>
         </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,10 +10,11 @@ const { children } = $props();
 
 const fontScale = $derived(getFontScale($settings));
 
-async function setScale(scale) {
+function setScale(scale) {
   const clamped = clampScale(scale);
   applyFontScale(clamped);
-  await settingsActions.update('display.fontScale', clamped);
+  // Update store optimistically so rapid key presses read the latest value
+  settingsActions.update('display.fontScale', clamped);
 }
 
 function handleGlobalKeydown(e) {

--- a/tests/e2e/keyboard.spec.js
+++ b/tests/e2e/keyboard.spec.js
@@ -1,0 +1,264 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady, waitForPets } from './helpers.js';
+
+// ==========================================
+// Keyboard Navigation & Accessibility
+// ==========================================
+
+test.describe('Keyboard Navigation', () => {
+  test.describe('Skip Link', () => {
+    test('skip link appears on Tab and targets main content', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      // Tab to reveal skip link
+      await page.keyboard.press('Tab');
+      const skipLink = page.locator('.skip-link');
+      await expect(skipLink).toBeFocused();
+      await expect(skipLink).toHaveText('Skip to main content');
+      await expect(skipLink).toHaveAttribute('href', '#main-content');
+    });
+  });
+
+  test.describe('Semantic Landmarks', () => {
+    test('TopBar contains nav element', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      const nav = page.locator('nav[aria-label="Main navigation"]');
+      await expect(nav).toBeVisible();
+    });
+
+    test('main content area has id for skip link', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await expect(page.locator('#main-content')).toBeVisible();
+    });
+  });
+
+  test.describe('Data Menu Dropdown', () => {
+    test('opens with Enter key and navigates with arrow keys', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      // Focus the data menu toggle
+      const toggle = page.locator('.menu-toggle');
+      await toggle.focus();
+
+      // Open with Enter
+      await page.keyboard.press('Enter');
+      await expect(page.locator('.dropdown')).toBeVisible();
+
+      // First item should be focused
+      const firstItem = page.locator('.dropdown-item').first();
+      await expect(firstItem).toBeFocused();
+
+      // Arrow down to second item
+      await page.keyboard.press('ArrowDown');
+      const secondItem = page.locator('.dropdown-item').nth(1);
+      await expect(secondItem).toBeFocused();
+
+      // Escape closes
+      await page.keyboard.press('Escape');
+      await expect(page.locator('.dropdown')).not.toBeVisible();
+    });
+
+    test('toggle has aria-haspopup and aria-expanded', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      const toggle = page.locator('.menu-toggle');
+      await expect(toggle).toHaveAttribute('aria-haspopup', 'menu');
+      await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+      await toggle.click();
+      await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  test.describe('Pet List Navigation', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
+    });
+
+    test('arrow keys navigate between pet cards', async ({ page }) => {
+      const firstCard = page.locator('.pet-card').first();
+      await firstCard.focus();
+
+      // Arrow down moves to second card
+      await page.keyboard.press('ArrowDown');
+      const secondCard = page.locator('.pet-card').nth(1);
+      await expect(secondCard).toBeFocused();
+
+      // Arrow up moves back
+      await page.keyboard.press('ArrowUp');
+      await expect(firstCard).toBeFocused();
+    });
+
+    test('Enter on pet card selects the pet', async ({ page }) => {
+      const firstCard = page.locator('.pet-card').first();
+      await firstCard.focus();
+      await page.keyboard.press('Enter');
+
+      // Pet card should now be selected
+      await expect(firstCard).toHaveClass(/selected/);
+    });
+
+    test('action buttons visible on keyboard focus', async ({ page }) => {
+      const firstCard = page.locator('.pet-card').first();
+      await firstCard.focus();
+
+      // Action buttons should be visible when card is focused
+      const actions = page.locator('.pet-card-wrapper').first().locator('.pet-card-actions');
+      await expect(actions).toBeVisible();
+    });
+  });
+
+  test.describe('Settings Modal', () => {
+    test('Escape closes the modal', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      // Open settings
+      await page.locator('.settings-toggle').click();
+      await expect(page.locator('.settings-dialog')).toBeVisible();
+
+      // Escape closes it
+      await page.keyboard.press('Escape');
+      await expect(page.locator('.settings-dialog')).not.toBeVisible();
+    });
+
+    test('modal has aria-modal and focus trap', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await page.locator('.settings-toggle').click();
+      const dialog = page.locator('.settings-dialog');
+      await expect(dialog).toHaveAttribute('aria-modal', 'true');
+      await expect(dialog).toHaveAttribute('role', 'dialog');
+    });
+
+    test('font scale controls are visible', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await page.locator('.settings-toggle').click();
+      await expect(page.locator('.scale-controls')).toBeVisible();
+      await expect(page.locator('.scale-value')).toHaveText('100%');
+    });
+  });
+
+  test.describe('Font Scaling (Issue #89)', () => {
+    test('Cmd/Ctrl+Plus increases font scale', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await page.keyboard.press(`${modifier}+=`);
+
+      // Check that the root font size changed
+      const fontSize = await page.evaluate(() => document.documentElement.style.fontSize);
+      expect(fontSize).toBe('110%');
+    });
+
+    test('Cmd/Ctrl+Minus decreases font scale', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+      await page.keyboard.press(`${modifier}+-`);
+
+      const fontSize = await page.evaluate(() => document.documentElement.style.fontSize);
+      expect(fontSize).toBe('90%');
+    });
+
+    test('Cmd/Ctrl+0 resets font scale', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      const modifier = process.platform === 'darwin' ? 'Meta' : 'Control';
+
+      // Increase first
+      await page.keyboard.press(`${modifier}+=`);
+      let fontSize = await page.evaluate(() => document.documentElement.style.fontSize);
+      expect(fontSize).toBe('110%');
+
+      // Reset
+      await page.keyboard.press(`${modifier}+0`);
+      fontSize = await page.evaluate(() => document.documentElement.style.fontSize);
+      expect(fontSize).toBe('100%');
+    });
+
+    test('font scale buttons in settings work', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await page.locator('.settings-toggle').click();
+      await expect(page.locator('.scale-value')).toHaveText('100%');
+
+      // Click increase
+      await page.locator('.scale-btn[aria-label="Increase font size"]').click();
+      await expect(page.locator('.scale-value')).toHaveText('110%');
+
+      // Click reset
+      await page.locator('.scale-reset-btn').click();
+      await expect(page.locator('.scale-value')).toHaveText('100%');
+    });
+  });
+
+  test.describe('Gene Cell Keyboard', () => {
+    test('gene cells have role button and are keyboard focusable', async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
+
+      // Select a pet first to get gene visualization
+      await page.locator('.pet-card').first().click();
+      await page.waitForTimeout(500);
+
+      const geneCells = page.locator('.gene-cell[role="button"]');
+      const count = await geneCells.count();
+      if (count > 0) {
+        await expect(geneCells.first()).toHaveAttribute('tabindex', '0');
+        await expect(geneCells.first()).toHaveAttribute('aria-label', /Gene/);
+      }
+    });
+  });
+
+  test.describe('Focus Visible Styles', () => {
+    test('focus-visible outline appears on keyboard focus', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      // Tab to first focusable element
+      await page.keyboard.press('Tab'); // skip link
+      await page.keyboard.press('Tab'); // next element
+
+      // Verify outline style is applied (browser applies :focus-visible)
+      const focusedEl = page.locator(':focus');
+      await expect(focusedEl).toBeVisible();
+    });
+  });
+
+  test.describe('Delete Confirmation Dialog', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
+    });
+
+    test('delete dialog has aria-modal and closes on Escape', async ({ page }) => {
+      // Hover to reveal delete button, then click
+      await page.locator('.pet-card-wrapper').first().hover();
+      await page.locator('.delete-btn').first().click();
+
+      const dialog = page.locator('.confirm-dialog');
+      await expect(dialog).toBeVisible();
+      await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+      // Escape closes it
+      await page.keyboard.press('Escape');
+      await expect(dialog).not.toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Full keyboard navigation** (Issue #87): Focus traps on all modals/dialogs, arrow key navigation in pet list/gene grid/data menu, Enter/Space activation, Escape to close, global focus-visible styles, skip-to-content link, semantic `<nav>` landmark, `aria-modal` on all dialogs
- **Font scaling** (Issue #89): Cmd/Ctrl+Plus/Minus/0 keyboard shortcuts (75-150% range), scale controls in Settings modal, persisted via settingsService
- **Utilities**: Reusable `focusTrap` Svelte action, `handleGridNavigation`/`handleListNavigation` keyboard helpers, shared `fontScale` module

## New files
- `src/lib/utils/focusTrap.ts` — Focus trap with Svelte action
- `src/lib/utils/keyboard.ts` — Arrow key navigation for lists and grids
- `src/lib/utils/fontScale.ts` — Shared font scale utilities
- `tests/e2e/keyboard.spec.js` — 18 E2E tests for keyboard navigation

## Test plan
- [x] 222 unit tests pass
- [x] 83 E2E tests pass (65 existing + 18 new keyboard tests)
- [x] Lint clean (biome check)
- [ ] Manual: Tab through the app, verify focus ring visible on keyboard focus only
- [ ] Manual: Arrow keys in pet list, gene grid, data menu
- [ ] Manual: Cmd+Plus/Minus/0 changes font scale, persists across reload
- [ ] Manual: Escape closes all modals, Tab trapped within them

Closes #87, closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)