### PR TITLE
feat: add theme support with dark mode (#88)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -149,7 +149,9 @@ textarea {
   --toggle-on: #3b82f6;
   --toggle-thumb: #ffffff;
 
-  /* Gene color adjustments for dark backgrounds */
+  /* Gene neutral colors lightened for dark backgrounds.
+     These override the :root values — keep aligned with gene-colors.ts
+     if that module ever reads CSS vars instead of hardcoded values. */
   --gene-neutral: #b0b8c4;
   --gene-appearance-neutral: #b0b8c4;
 }

--- a/src/app.css
+++ b/src/app.css
@@ -19,7 +19,8 @@ body {
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans",
     "Helvetica Neue", sans-serif;
-  background-color: #ffffff;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
@@ -35,6 +36,122 @@ button,
 select,
 textarea {
   font: inherit;
+}
+
+/* --- Theme tokens --- */
+:root {
+  /* Surfaces */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --bg-tertiary: #f3f4f6;
+  --bg-hover: #f3f4f6;
+  --bg-selected: #eff6ff;
+  --bg-overlay: rgba(0, 0, 0, 0.35);
+
+  /* Text */
+  --text-primary: #111827;
+  --text-secondary: #374151;
+  --text-tertiary: #6b7280;
+  --text-muted: #9ca3af;
+  --text-inverse: #ffffff;
+
+  /* Borders */
+  --border-primary: #e5e7eb;
+  --border-secondary: #d1d5db;
+  --border-focus: #3b82f6;
+
+  /* Accent */
+  --accent: #3b82f6;
+  --accent-hover: #2563eb;
+  --accent-soft: rgba(59, 130, 246, 0.1);
+  --accent-text: #3b82f6;
+
+  /* Status — error */
+  --error: #ef4444;
+  --error-hover: #dc2626;
+  --error-text: #dc2626;
+  --error-bg: #fef2f2;
+  --error-border: #fecaca;
+
+  /* Status — success */
+  --success-text: #059669;
+  --success-bg: #f0fdf4;
+  --success-border: #bbf7d0;
+
+  /* Status — warning */
+  --warning-text: #92400e;
+  --warning-bg: #fef3c7;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 8px 30px rgba(0, 0, 0, 0.15);
+  --shadow-xl: 0 20px 60px rgba(0, 0, 0, 0.15);
+
+  /* Toggle */
+  --toggle-off: #d1d5db;
+  --toggle-on: #3b82f6;
+  --toggle-thumb: #ffffff;
+}
+
+/* --- Dark theme --- */
+[data-theme="dark"] {
+  /* Surfaces */
+  --bg-primary: #111827;
+  --bg-secondary: #1f2937;
+  --bg-tertiary: #374151;
+  --bg-hover: #374151;
+  --bg-selected: #1e3a5f;
+  --bg-overlay: rgba(0, 0, 0, 0.6);
+
+  /* Text */
+  --text-primary: #f9fafb;
+  --text-secondary: #e5e7eb;
+  --text-tertiary: #9ca3af;
+  --text-muted: #6b7280;
+  --text-inverse: #111827;
+
+  /* Borders */
+  --border-primary: #374151;
+  --border-secondary: #4b5563;
+  --border-focus: #60a5fa;
+
+  /* Accent */
+  --accent: #3b82f6;
+  --accent-hover: #60a5fa;
+  --accent-soft: rgba(59, 130, 246, 0.2);
+  --accent-text: #60a5fa;
+
+  /* Status — error */
+  --error: #ef4444;
+  --error-hover: #f87171;
+  --error-text: #f87171;
+  --error-bg: rgba(239, 68, 68, 0.1);
+  --error-border: rgba(239, 68, 68, 0.3);
+
+  /* Status — success */
+  --success-text: #34d399;
+  --success-bg: rgba(52, 211, 153, 0.1);
+  --success-border: rgba(52, 211, 153, 0.3);
+
+  /* Status — warning */
+  --warning-text: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.1);
+
+  /* Shadows */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 30px rgba(0, 0, 0, 0.5);
+  --shadow-xl: 0 20px 60px rgba(0, 0, 0, 0.6);
+
+  /* Toggle */
+  --toggle-off: #4b5563;
+  --toggle-on: #3b82f6;
+  --toggle-thumb: #ffffff;
+
+  /* Gene color adjustments for dark backgrounds */
+  --gene-neutral: #b0b8c4;
+  --gene-appearance-neutral: #b0b8c4;
 }
 
 /* Gene colors — canonical source: src/lib/theme/gene-colors.ts */
@@ -92,40 +209,40 @@ textarea {
 }
 
 .btn-secondary {
-  background: #ffffff;
-  color: #374151;
-  border-color: #e5e7eb;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border-color: var(--border-primary);
 }
 
 .btn-secondary:hover {
-  background: #f9fafb;
-  border-color: #d1d5db;
+  background: var(--bg-secondary);
+  border-color: var(--border-secondary);
 }
 
 .btn-primary {
-  background: #3b82f6;
-  color: #ffffff;
-  border-color: #3b82f6;
+  background: var(--accent);
+  color: var(--text-inverse);
+  border-color: var(--accent);
 }
 
 .btn-primary:hover {
-  background: #2563eb;
+  background: var(--accent-hover);
 }
 
 .btn-danger {
-  background: #ef4444;
-  color: #ffffff;
+  background: var(--error);
+  color: var(--text-inverse);
 }
 
 .btn-danger:hover {
-  background: #dc2626;
+  background: var(--error-hover);
 }
 
 /* --- Shared modal backdrop --- */
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--bg-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -134,10 +251,10 @@ textarea {
 
 /* --- Shared dialog styles --- */
 .dialog {
-  background: #ffffff;
+  background: var(--bg-primary);
   border-radius: 12px;
   width: 90%;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
 
@@ -146,13 +263,13 @@ textarea {
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .dialog-header h3 {
   font-size: 16px;
   font-weight: 700;
-  color: #111827;
+  color: var(--text-primary);
 }
 
 .dialog-body {
@@ -164,8 +281,8 @@ textarea {
   justify-content: flex-end;
   gap: 8px;
   padding: 14px 20px;
-  border-top: 1px solid #e5e7eb;
-  background: #f9fafb;
+  border-top: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
 }
 
 .close-btn {
@@ -174,7 +291,7 @@ textarea {
   border: none;
   border-radius: 6px;
   background: transparent;
-  color: #6b7280;
+  color: var(--text-tertiary);
   font-size: 18px;
   cursor: pointer;
   display: flex;
@@ -183,12 +300,12 @@ textarea {
 }
 
 .close-btn:hover {
-  background: #f3f4f6;
+  background: var(--bg-hover);
 }
 
 /* --- Global focus-visible styles --- */
 :focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--border-focus);
   outline-offset: 2px;
 }
 
@@ -208,8 +325,8 @@ textarea:focus:not(:focus-visible) {
   top: -40px;
   left: 0;
   padding: 8px 16px;
-  background: #3b82f6;
-  color: #ffffff;
+  background: var(--accent);
+  color: var(--text-inverse);
   font-size: 14px;
   font-weight: 600;
   z-index: 10000;
@@ -244,22 +361,22 @@ textarea:focus:not(:focus-visible) {
 .checkbox-label {
   font-size: 14px;
   font-weight: 500;
-  color: #111827;
+  color: var(--text-primary);
 }
 
 .checkbox-desc {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--text-muted);
 }
 
 /* --- Shared metadata styles --- */
 .meta-dot {
   margin: 0 4px;
-  color: #d1d5db;
+  color: var(--border-secondary);
 }
 
 .gene-count {
-  color: #3b82f6;
+  color: var(--accent-text);
 }
 
 /* --- Shared status styles --- */
@@ -268,23 +385,23 @@ textarea:focus:not(:focus-visible) {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-  color: #6b7280;
+  color: var(--text-tertiary);
   font-style: italic;
 }
 
 .error {
-  color: #dc2626;
-  background-color: #fef2f2;
-  border: 1px solid #fecaca;
+  color: var(--error-text);
+  background-color: var(--error-bg);
+  border: 1px solid var(--error-border);
   border-radius: 6px;
   padding: 0.75rem;
   margin: 0.5rem 0;
 }
 
 .success {
-  color: #059669;
-  background-color: #f0fdf4;
-  border: 1px solid #bbf7d0;
+  color: var(--success-text);
+  background-color: var(--success-bg);
+  border: 1px solid var(--success-border);
   border-radius: 6px;
   padding: 0.75rem;
   margin: 0.5rem 0;

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -36,14 +36,14 @@ onMount(async () => {
     align-items: center;
     justify-content: center;
     height: 100vh;
-    background-color: #f8fafc;
+    background-color: var(--bg-secondary);
   }
 
   .loading-spinner {
     width: 40px;
     height: 40px;
-    border: 4px solid #e5e7eb;
-    border-top: 4px solid #3b82f6;
+    border: 4px solid var(--border-primary);
+    border-top: 4px solid var(--accent);
     border-radius: 50%;
     animation: spin 1s linear infinite;
     margin-bottom: 1rem;
@@ -55,7 +55,7 @@ onMount(async () => {
   }
 
   .loading-screen p {
-    color: #6b7280;
+    color: var(--text-tertiary);
     font-size: 1.1rem;
   }
 

--- a/src/lib/components/GeneEditingView.svelte
+++ b/src/lib/components/GeneEditingView.svelte
@@ -368,21 +368,21 @@ run(() => {
         align-items: center;
         justify-content: space-between;
         padding: 16px 20px;
-        border-bottom: 1px solid #e5e7eb;
-        background: #ffffff;
+        border-bottom: 1px solid var(--border-primary);
+        background: var(--bg-primary);
         flex-shrink: 0;
     }
 
     .gene-editing-title {
         font-size: 18px;
         font-weight: 700;
-        color: #111827;
+        color: var(--text-primary);
         margin: 0;
     }
 
     .gene-editing-count {
         font-size: 12px;
-        color: #6b7280;
+        color: var(--text-tertiary);
     }
 
     .gene-editing-actions {
@@ -392,10 +392,10 @@ run(() => {
 
     .gene-editing-actions .action-btn {
         padding: 6px 14px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border-primary);
         border-radius: 6px;
-        background: #ffffff;
-        color: #374151;
+        background: var(--bg-primary);
+        color: var(--text-secondary);
         font-size: 13px;
         font-weight: 500;
         cursor: pointer;
@@ -403,9 +403,9 @@ run(() => {
     }
 
     .gene-editing-actions .save-btn:not(:disabled) {
-        background: #3b82f6;
-        border-color: #3b82f6;
-        color: white;
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
     }
 
     .gene-editing-actions .action-btn:disabled {
@@ -414,7 +414,7 @@ run(() => {
     }
 
     .gene-editing-actions .action-btn:not(:disabled):hover {
-        border-color: #9ca3af;
+        border-color: var(--text-muted);
     }
 
     .view-btn {
@@ -431,13 +431,13 @@ run(() => {
 
     .view-btn:hover:not(:disabled) {
         background: rgba(255, 255, 255, 0.2);
-        color: white;
+        color: var(--bg-primary);
     }
 
     .view-btn.active {
-        background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
-        border-color: #1d4ed8;
-        color: white;
+        background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
+        border-color: var(--accent-hover);
+        color: var(--bg-primary);
     }
 
     .view-btn:disabled {
@@ -463,15 +463,15 @@ run(() => {
     }
 
     .message.error {
-        background: #fef2f2;
-        color: #dc2626;
-        border-bottom: 1px solid #fecaca;
+        background: var(--error-bg);
+        color: var(--error-text);
+        border-bottom: 1px solid var(--error-border);
     }
 
     .message.success {
-        background: #f0fdf4;
-        color: #16a34a;
-        border-bottom: 1px solid #bbf7d0;
+        background: var(--success-bg);
+        color: var(--success-text);
+        border-bottom: 1px solid var(--success-border);
     }
 
     .message-icon {
@@ -486,7 +486,7 @@ run(() => {
         justify-content: center;
         min-height: 200px;
         gap: 1rem;
-        color: #6b7280;
+        color: var(--text-tertiary);
     }
 
     /* Spinner */
@@ -526,8 +526,8 @@ run(() => {
 
     /* Gene Card */
     .gene-card {
-        background: white;
-        border: 2px solid #e5e7eb;
+        background: var(--bg-primary);
+        border: 2px solid var(--border-primary);
         border-radius: 8px;
         padding: 1rem;
         transition: all 0.2s ease;
@@ -536,13 +536,13 @@ run(() => {
     }
 
     .gene-card:hover {
-        border-color: #d1d5db;
+        border-color: var(--border-secondary);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     }
 
     .gene-card.changed {
-        border-color: #f59e0b;
-        background: #fffbeb;
+        border-color: var(--warning-text);
+        background: var(--warning-bg);
     }
 
     .gene-card.changed::before {
@@ -550,7 +550,7 @@ run(() => {
         position: absolute;
         top: 1rem;
         right: 1rem;
-        color: #f59e0b;
+        color: var(--warning-text);
         font-size: 1.2rem;
     }
 
@@ -561,13 +561,13 @@ run(() => {
         justify-content: space-between;
         margin-bottom: 0.75rem;
         padding-bottom: 0.5rem;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border-primary);
     }
 
     .gene-id {
         font-size: 1rem;
         font-weight: 700;
-        color: #111827;
+        color: var(--text-primary);
     }
 
     .notes-btn {
@@ -583,7 +583,7 @@ run(() => {
     .notes-btn:hover,
     .notes-btn.active {
         opacity: 1;
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
     }
 
     /* Gene Fields */
@@ -602,14 +602,14 @@ run(() => {
     .field label {
         font-size: 0.75rem;
         font-weight: 600;
-        color: #374151;
+        color: var(--text-secondary);
         text-transform: uppercase;
         letter-spacing: 0.025em;
     }
 
     .field input {
         padding: 0.5rem;
-        border: 2px solid #e5e7eb;
+        border: 2px solid var(--border-primary);
         border-radius: 6px;
         font-size: 0.75rem;
         transition: all 0.2s ease;
@@ -617,7 +617,7 @@ run(() => {
 
     .field input:focus {
         outline: none;
-        border-color: #3b82f6;
+        border-color: var(--accent);
         box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
     }
 
@@ -632,9 +632,9 @@ run(() => {
         justify-content: space-between;
         width: 100%;
         padding: 0.5rem;
-        border: 2px solid #e5e7eb;
+        border: 2px solid var(--border-primary);
         border-radius: 6px;
-        background: white;
+        background: var(--bg-primary);
         font-size: 0.75rem;
         font-weight: 500;
         text-align: left;
@@ -643,23 +643,23 @@ run(() => {
     }
 
     .select-trigger:hover {
-        border-color: #d1d5db;
+        border-color: var(--border-secondary);
     }
 
     .select-trigger.positive {
-        background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
-        border-color: #22c55e;
-        color: #059669;
+        background: linear-gradient(135deg, var(--success-bg) 0%, var(--success-bg) 100%);
+        border-color: var(--success-text);
+        color: var(--success-text);
     }
 
     .select-trigger.negative {
-        background: linear-gradient(135deg, #fef2f2 0%, #fecaca 100%);
-        border-color: #ef4444;
-        color: #dc2626;
+        background: linear-gradient(135deg, var(--error-bg) 0%, var(--error-border) 100%);
+        border-color: var(--error);
+        color: var(--error-text);
     }
 
     .select-trigger.none {
-        color: #6b7280;
+        color: var(--text-tertiary);
     }
 
     .chevron {
@@ -676,8 +676,8 @@ run(() => {
         right: 0;
         z-index: 1000;
         margin-top: 0.25rem;
-        background: white;
-        border: 2px solid #e5e7eb;
+        background: var(--bg-primary);
+        border: 2px solid var(--border-primary);
         border-radius: 8px;
         box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
         max-height: 300px;
@@ -697,35 +697,35 @@ run(() => {
     }
 
     .option:hover {
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
     }
 
     .option.none {
-        color: #6b7280;
-        border-bottom: 1px solid #e5e7eb;
+        color: var(--text-tertiary);
+        border-bottom: 1px solid var(--border-primary);
     }
 
     .option.positive {
-        color: #059669;
+        color: var(--success-text);
     }
 
     .option.positive:hover {
-        background: #ecfdf5;
+        background: var(--success-bg);
     }
 
     .option.negative {
-        color: #dc2626;
+        color: var(--error-text);
     }
 
     .option.negative:hover {
-        background: #fef2f2;
+        background: var(--error-bg);
     }
 
     /* Effects Grid */
     .effects-grid {
         display: grid;
         grid-template-columns: 1fr 1fr;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--border-primary);
     }
 
     .effects-column {
@@ -734,12 +734,12 @@ run(() => {
     }
 
     .effects-column:first-child {
-        border-right: 1px solid #e5e7eb;
+        border-right: 1px solid var(--border-primary);
     }
 
     .effects-column .option {
         border-radius: 0;
-        border-bottom: 1px solid #f3f4f6;
+        border-bottom: 1px solid var(--bg-tertiary);
     }
 
     .effects-column .option:last-child {
@@ -750,13 +750,13 @@ run(() => {
     .notes-section {
         margin-top: 0.75rem;
         padding-top: 0.75rem;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--border-primary);
     }
 
     .notes-section textarea {
         width: 100%;
         padding: 0.5rem;
-        border: 2px solid #e5e7eb;
+        border: 2px solid var(--border-primary);
         border-radius: 6px;
         font-size: 0.75rem;
         resize: vertical;
@@ -766,7 +766,7 @@ run(() => {
 
     .notes-section textarea:focus {
         outline: none;
-        border-color: #3b82f6;
+        border-color: var(--accent);
         box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
     }
 

--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -181,9 +181,9 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
     }
 
     :global(.gene-neutral.gene-unknown) {
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
         border: 2.5px dashed color-mix(in srgb, var(--gene-neutral) 50%, transparent);
-        color: #b0b4ba;
+        color: var(--text-muted);
         opacity: 0.7;
         display: flex;
         align-items: center;
@@ -191,7 +191,7 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
     }
 
     .gene-unknown-symbol {
-        color: #b0b4ba;
+        color: var(--text-muted);
         font-size: 1em;
         font-weight: 600;
         opacity: 1;

--- a/src/lib/components/gene/GeneEditor.svelte
+++ b/src/lib/components/gene/GeneEditor.svelte
@@ -123,32 +123,32 @@ run(() => {
     .form-group label {
         font-size: 0.875rem;
         font-weight: 500;
-        color: #374151;
+        color: var(--text-secondary);
     }
 
     .form-group select {
         padding: 0.5rem;
-        border: 1px solid #d1d5db;
+        border: 1px solid var(--border-secondary);
         border-radius: 6px;
         font-size: 0.875rem;
-        background: white;
+        background: var(--bg-primary);
     }
 
     .form-group select:focus {
         outline: none;
-        border-color: #3b82f6;
-        box-shadow: 0 0 0 1px #3b82f6;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 1px var(--accent);
     }
 
     .form-group select:disabled {
-        background-color: #f9fafb;
-        color: #9ca3af;
+        background-color: var(--bg-secondary);
+        color: var(--text-muted);
     }
 
     .load-btn {
         padding: 0.5rem 1rem;
-        background-color: #3b82f6;
-        color: white;
+        background-color: var(--accent);
+        color: var(--text-inverse);
         border: none;
         border-radius: 6px;
         font-size: 0.875rem;
@@ -158,7 +158,7 @@ run(() => {
     }
 
     .load-btn:hover:not(:disabled) {
-        background-color: #2563eb;
+        background-color: var(--accent-hover);
     }
 
     .load-btn:disabled {
@@ -169,9 +169,9 @@ run(() => {
     .error-message {
         padding: 0.5rem;
         border-radius: 6px;
-        background-color: #fef2f2;
-        color: #dc2626;
-        border: 1px solid #fecaca;
+        background-color: var(--error-bg);
+        color: var(--error-text);
+        border: 1px solid var(--error-border);
         display: flex;
         align-items: center;
         gap: 0.5rem;

--- a/src/lib/components/gene/GeneStatsTable.svelte
+++ b/src/lib/components/gene/GeneStatsTable.svelte
@@ -233,7 +233,7 @@ const hiddenLookup = $derived(
 <style>
     .stats-section {
         width: 100%;
-        background: #f9fafb;
+        background: var(--bg-secondary);
         padding: 10px;
         overflow-y: auto;
     }
@@ -254,7 +254,7 @@ const hiddenLookup = $derived(
         margin: 0;
         font-size: 14px;
         font-weight: 600;
-        color: #374151;
+        color: var(--text-secondary);
     }
 
     .selection-counters {
@@ -266,13 +266,13 @@ const hiddenLookup = $derived(
         position: absolute;
         top: 0;
         right: 0;
-        background: #dbeafe;
-        color: #1d4ed8;
+        background: var(--bg-selected);
+        color: var(--accent-hover);
         padding: 4px 8px;
         border-radius: 12px;
         font-size: 11px;
         font-weight: 500;
-        border: 1px solid #93c5fd;
+        border: 1px solid var(--accent);
         white-space: nowrap;
     }
 
@@ -282,7 +282,7 @@ const hiddenLookup = $derived(
 
     .table-instructions {
         font-size: 11px;
-        color: #6b7280;
+        color: var(--text-tertiary);
         margin-bottom: 8px;
         font-style: italic;
     }
@@ -291,17 +291,17 @@ const hiddenLookup = $derived(
         width: 100%;
         border-collapse: collapse;
         font-size: 12px;
-        background: white;
+        background: var(--bg-primary);
         border-radius: 6px;
         overflow: hidden;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        box-shadow: var(--shadow-sm);
     }
 
     .stats-table th,
     .stats-table td {
         padding: 8px;
         text-align: left;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid var(--border-primary);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -324,9 +324,9 @@ const hiddenLookup = $derived(
     }
 
     .stats-table th {
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
         font-weight: 600;
-        color: #374151;
+        color: var(--text-secondary);
     }
 
     .stats-table tbody tr {
@@ -335,52 +335,52 @@ const hiddenLookup = $derived(
     }
 
     .stats-table tbody tr:hover {
-        background-color: #f9fafb;
+        background-color: var(--bg-secondary);
     }
 
     .stats-table tbody tr.selected {
-        background-color: #dbeafe !important;
+        background-color: var(--bg-selected) !important;
         box-shadow:
-            inset 4px 0 0 0 #3b82f6,
-            inset 0 0 0 1px rgba(59, 130, 246, 0.2);
+            inset 4px 0 0 0 var(--accent),
+            inset 0 0 0 1px var(--accent-soft);
     }
 
     .stats-table tbody tr.selected td {
-        color: #1d4ed8;
+        color: var(--accent-hover);
         font-weight: 500;
     }
 
     .stats-table tbody tr.selected:hover {
-        background-color: #bfdbfe !important;
+        background-color: var(--accent-soft) !important;
     }
 
     .attribute-row.hidden-attribute,
     .appearance-row.hidden-attribute {
-        background-color: #fef2f2 !important;
+        background-color: var(--error-bg) !important;
         box-shadow:
-            inset 4px 0 0 0 #ef4444,
+            inset 4px 0 0 0 var(--error),
             inset 0 0 0 1px rgba(239, 68, 68, 0.2);
     }
 
     .attribute-row.hidden-attribute td,
     .appearance-row.hidden-attribute td {
-        color: #dc2626;
+        color: var(--error-text);
         font-weight: 500;
         text-decoration: line-through;
     }
 
     .attribute-row.hidden-attribute:hover,
     .appearance-row.hidden-attribute:hover {
-        background-color: #fecaca !important;
+        background-color: var(--error-border) !important;
     }
 
     .totals-row {
-        border-top: 2px solid #e5e7eb;
-        background-color: #f8fafc !important;
+        border-top: 2px solid var(--border-primary);
+        background-color: var(--bg-secondary) !important;
     }
 
     .totals-row:hover {
-        background-color: #f8fafc !important;
+        background-color: var(--bg-secondary) !important;
         cursor: default !important;
     }
 
@@ -404,6 +404,6 @@ const hiddenLookup = $derived(
         display: flex;
         gap: 16px;
         font-size: 11px;
-        color: #6b7280;
+        color: var(--text-tertiary);
     }
 </style>

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1728,7 +1728,7 @@ export function getStatsData() {
         height: 100%;
         display: flex;
         flex-direction: column;
-        background: #ffffff;
+        background: var(--bg-primary);
         min-height: 0;
     }
 
@@ -1739,7 +1739,7 @@ export function getStatsData() {
         align-items: center;
         justify-content: center;
         height: 300px;
-        color: #666;
+        color: var(--text-tertiary);
         font-size: 16px;
     }
 
@@ -1801,7 +1801,7 @@ export function getStatsData() {
         align-items: center;
         gap: 0.3em;
         font-size: 10px;
-        color: #6b7280;
+        color: var(--text-tertiary);
         white-space: nowrap;
         cursor: pointer;
         padding: 2px 6px;
@@ -1810,7 +1810,7 @@ export function getStatsData() {
     }
 
     .legend-item:hover {
-        background-color: #f3f4f6;
+        background-color: var(--bg-hover);
     }
 
     /* Adjust legend item spacing for GeneCell components */
@@ -1832,10 +1832,10 @@ export function getStatsData() {
     .effect-legend-item.selected,
     .value-legend-item.selected,
     .appearance-legend-item.selected {
-        background: rgba(59, 130, 246, 0.08) !important;
+        background: var(--accent-soft) !important;
         border-radius: 6px;
-        box-shadow: 0 2px 8px rgba(59, 130, 246, 0.08);
-        outline: 2px solid #3b82f6;
+        box-shadow: 0 2px 8px var(--accent-soft);
+        outline: 2px solid var(--accent);
         outline-offset: 2px;
     }
 
@@ -1843,14 +1843,14 @@ export function getStatsData() {
     .value-legend-item.hidden-effect,
     .appearance-legend-item.hidden-effect {
         opacity: 0.7;
-        color: #b91c1c !important;
+        color: var(--error-text) !important;
         text-decoration: line-through;
         filter: grayscale(0.7);
         pointer-events: auto;
-        background: rgba(239, 68, 68, 0.1);
+        background: var(--error-bg);
         border-radius: 6px;
-        box-shadow: 0 2px 8px rgba(239, 68, 68, 0.1);
-        outline: 2px solid #ef4444;
+        box-shadow: 0 2px 8px var(--error-bg);
+        outline: 2px solid var(--error);
         outline-offset: 2px;
         transition:
             opacity 0.2s,
@@ -1862,9 +1862,9 @@ export function getStatsData() {
         flex: 1;
         min-height: 0;
         overflow: auto;
-        border: 1px solid #e2e8f0;
+        border: 1px solid var(--border-primary);
         border-radius: 6px;
-        background: #f9fafb;
+        background: var(--bg-secondary);
     }
 
     .gene-grid-table {
@@ -1877,16 +1877,16 @@ export function getStatsData() {
         position: sticky;
         top: 0;
         z-index: 10;
-        background: #f1f5f9;
+        background: var(--bg-secondary);
     }
 
     .gene-headers th {
-        background: #f1f5f9;
-        border-bottom: 1px solid #e2e8f0;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-primary);
         padding: 2px 4px;
         font-size: 9px;
         font-weight: normal;
-        color: #374151;
+        color: var(--text-secondary);
         text-align: center;
         white-space: nowrap;
     }
@@ -1895,7 +1895,7 @@ export function getStatsData() {
         position: sticky;
         left: 0;
         z-index: 11;
-        background: #f1f5f9;
+        background: var(--bg-secondary);
         font-weight: bold;
         width: 28px;
         min-width: 28px;
@@ -1922,27 +1922,27 @@ export function getStatsData() {
     }
 
     .gene-rows {
-        background: #f9fafb;
+        background: var(--bg-secondary);
     }
 
     .chromosome-row {
-        border-bottom: 1px solid #f1f5f9;
+        border-bottom: 1px solid var(--bg-tertiary);
     }
 
     .chromosome-row:hover {
-        background: #f8fafc;
+        background: var(--bg-secondary);
     }
 
     .chromosome-label {
         position: sticky;
         left: 0;
         z-index: 1;
-        background: #f9fafb;
-        border-right: 1px solid #e2e8f0;
+        background: var(--bg-secondary);
+        border-right: 1px solid var(--border-primary);
         padding: 3px 2px;
         font-size: 10px;
         font-weight: 600;
-        color: #374151;
+        color: var(--text-secondary);
         text-align: center;
         cursor: pointer;
         transition: background-color 0.2s ease;
@@ -1953,7 +1953,7 @@ export function getStatsData() {
     }
 
     .chromosome-label:hover {
-        background: #f3f4f6;
+        background: var(--bg-hover);
     }
 
     .chromosome-label.selected {
@@ -1979,7 +1979,7 @@ export function getStatsData() {
     }
 
     .gene-cell-container.empty {
-        background: #fafafa;
+        background: var(--bg-secondary);
     }
 
     .gene-cell-container.block-start {

--- a/src/lib/components/layout/DataMenu.svelte
+++ b/src/lib/components/layout/DataMenu.svelte
@@ -201,14 +201,14 @@ function handleClickOutside(event) {
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: #6b7280;
+    color: var(--text-tertiary);
     cursor: pointer;
     transition: all 0.15s ease;
   }
 
   .menu-toggle:hover {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
   }
 
   .dropdown {
@@ -216,10 +216,10 @@ function handleClickOutside(event) {
     top: 100%;
     right: 0;
     margin-top: 6px;
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
     border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-md);
     min-width: 180px;
     padding: 4px;
     z-index: 100;
@@ -234,7 +234,7 @@ function handleClickOutside(event) {
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: #374151;
+    color: var(--text-secondary);
     font-size: 13px;
     font-weight: 500;
     cursor: pointer;
@@ -243,7 +243,7 @@ function handleClickOutside(event) {
   }
 
   .dropdown-item:hover {
-    background: #f3f4f6;
+    background: var(--bg-tertiary);
   }
 
   .toast {
@@ -255,20 +255,20 @@ function handleClickOutside(event) {
     font-size: 13px;
     font-weight: 500;
     z-index: 300;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-md);
     animation: slideIn 0.2s ease;
   }
 
   .toast-success {
-    background: #f0fdf4;
-    color: #166534;
-    border: 1px solid #bbf7d0;
+    background: var(--success-bg);
+    color: var(--success-text);
+    border: 1px solid var(--success-border);
   }
 
   .toast-error {
-    background: #fef2f2;
-    color: #991b1b;
-    border: 1px solid #fecaca;
+    background: var(--error-bg);
+    color: var(--error-text);
+    border: 1px solid var(--error-border);
   }
 
   @keyframes slideIn {

--- a/src/lib/components/layout/ExportDialog.svelte
+++ b/src/lib/components/layout/ExportDialog.svelte
@@ -94,13 +94,13 @@ async function handleExport() {
 
   .dialog-desc {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--text-tertiary);
     margin-bottom: 16px;
   }
 
   .checkbox-row {
     padding: 10px 0;
-    border-bottom: 1px solid #f3f4f6;
+    border-bottom: 1px solid var(--bg-tertiary);
   }
 
   .checkbox-row:last-of-type {

--- a/src/lib/components/layout/ImportDialog.svelte
+++ b/src/lib/components/layout/ImportDialog.svelte
@@ -161,14 +161,14 @@ async function handleImport() {
     border-radius: 12px;
     font-size: 11px;
     font-weight: 600;
-    background: #dbeafe;
-    color: #1d4ed8;
+    background: var(--accent-soft);
+    color: var(--accent-hover);
     margin-bottom: 12px;
   }
 
   .format-badge.legacy {
-    background: #fef3c7;
-    color: #92400e;
+    background: var(--warning-bg);
+    color: var(--warning-text);
   }
 
   .backup-info {
@@ -180,18 +180,18 @@ async function handleImport() {
     display: flex;
     justify-content: space-between;
     padding: 4px 0;
-    color: #6b7280;
+    color: var(--text-tertiary);
   }
 
   .info-row span:last-child {
     font-weight: 500;
-    color: #374151;
+    color: var(--text-secondary);
   }
 
   .section-label {
     font-size: 12px;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 8px;
@@ -209,15 +209,15 @@ async function handleImport() {
     align-items: flex-start;
     gap: 12px;
     padding: 10px 12px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--border-primary);
     border-radius: 8px;
     cursor: pointer;
     transition: border-color 0.15s;
   }
 
   .mode-option.active {
-    border-color: #3b82f6;
-    background: #f0f7ff;
+    border-color: var(--accent);
+    background: var(--accent-soft);
   }
 
   .mode-option input[type="radio"] {
@@ -234,21 +234,21 @@ async function handleImport() {
   .mode-label {
     font-size: 14px;
     font-weight: 600;
-    color: #111827;
+    color: var(--text-primary);
   }
 
   .mode-desc {
     font-size: 12px;
-    color: #6b7280;
+    color: var(--text-tertiary);
   }
 
   .warning {
     margin-top: 12px;
     padding: 10px 12px;
-    background: #fef2f2;
-    border: 1px solid #fecaca;
+    background: var(--error-bg);
+    border: 1px solid var(--error-border);
     border-radius: 6px;
     font-size: 12px;
-    color: #dc2626;
+    color: var(--error-text);
   }
 </style>

--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -17,8 +17,8 @@ import { activeTab } from '$lib/stores/pets.js';
 <style>
     .master-panel {
         width: 260px;
-        border-right: 1px solid #e5e7eb;
-        background: #f9fafb;
+        border-right: 1px solid var(--border-primary);
+        background: var(--bg-secondary);
         display: flex;
         flex-direction: column;
         flex-shrink: 0;

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -5,6 +5,7 @@ import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getFontScale as _getFontScale, clampScale, MAX_SCALE, MIN_SCALE } from '$lib/utils/fontScale.js';
+import { applyTheme, getThemePreference } from '$lib/utils/theme.js';
 
 let open = $state(false);
 
@@ -37,6 +38,15 @@ async function setFontScale(scale) {
 
 function adjustFontScale(delta) {
   setFontScale(getFontScale() + delta);
+}
+
+function getTheme() {
+  return getThemePreference($settings);
+}
+
+function setTheme(value) {
+  applyTheme(value);
+  settingsActions.update('display.theme', value);
 }
 
 function toggle() {
@@ -170,6 +180,33 @@ async function installUpdate() {
               >Reset</button>
             </div>
           </div>
+
+          <div class="setting-row">
+            <div class="setting-info">
+              <span class="setting-name">Theme</span>
+              <span class="setting-desc">Choose light, dark, or match your system</span>
+            </div>
+            <div class="theme-selector">
+              <button
+                class="theme-btn"
+                class:active={getTheme() === 'light'}
+                onclick={() => setTheme('light')}
+                aria-label="Light theme"
+              >☀️ Light</button>
+              <button
+                class="theme-btn"
+                class:active={getTheme() === 'dark'}
+                onclick={() => setTheme('dark')}
+                aria-label="Dark theme"
+              >🌙 Dark</button>
+              <button
+                class="theme-btn"
+                class:active={getTheme() === 'system'}
+                onclick={() => setTheme('system')}
+                aria-label="System theme"
+              >💻 System</button>
+            </div>
+          </div>
         </div>
 
         <div class="settings-section">
@@ -248,14 +285,14 @@ async function installUpdate() {
     border: none;
     border-radius: 6px;
     background: transparent;
-    color: #6b7280;
+    color: var(--text-tertiary);
     cursor: pointer;
     transition: all 0.15s ease;
   }
 
   .settings-toggle:hover {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
   }
 
   .settings-dialog {
@@ -265,7 +302,7 @@ async function installUpdate() {
   .settings-section h4 {
     font-size: 12px;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 12px;
@@ -289,12 +326,12 @@ async function installUpdate() {
   .setting-name {
     font-size: 14px;
     font-weight: 500;
-    color: #111827;
+    color: var(--text-primary);
   }
 
   .setting-desc {
     font-size: 12px;
-    color: #6b7280;
+    color: var(--text-tertiary);
     line-height: 1.4;
   }
 
@@ -304,7 +341,7 @@ async function installUpdate() {
     height: 24px;
     border: none;
     border-radius: 12px;
-    background: #d1d5db;
+    background: var(--toggle-off);
     cursor: pointer;
     transition: background 0.2s;
     flex-shrink: 0;
@@ -312,7 +349,7 @@ async function installUpdate() {
   }
 
   .toggle-on {
-    background: #3b82f6;
+    background: var(--toggle-on);
   }
 
   .toggle-thumb {
@@ -322,7 +359,7 @@ async function installUpdate() {
     width: 20px;
     height: 20px;
     border-radius: 50%;
-    background: #ffffff;
+    background: var(--toggle-thumb);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
     transition: transform 0.2s;
   }
@@ -334,7 +371,7 @@ async function installUpdate() {
   .settings-section + .settings-section {
     margin-top: 20px;
     padding-top: 16px;
-    border-top: 1px solid #e5e7eb;
+    border-top: 1px solid var(--border-primary);
   }
 
   .scale-controls {
@@ -347,10 +384,10 @@ async function installUpdate() {
   .scale-btn {
     width: 28px;
     height: 28px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--border-secondary);
     border-radius: 6px;
-    background: #ffffff;
-    color: #374151;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
     font-size: 16px;
     font-weight: 600;
     cursor: pointer;
@@ -361,8 +398,8 @@ async function installUpdate() {
   }
 
   .scale-btn:hover:not(:disabled) {
-    background: #f9fafb;
-    border-color: #9ca3af;
+    background: var(--bg-secondary);
+    border-color: var(--text-muted);
   }
 
   .scale-btn:disabled {
@@ -373,17 +410,17 @@ async function installUpdate() {
   .scale-value {
     font-size: 13px;
     font-weight: 600;
-    color: #111827;
+    color: var(--text-primary);
     min-width: 40px;
     text-align: center;
   }
 
   .scale-reset-btn {
     padding: 4px 10px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--border-secondary);
     border-radius: 6px;
-    background: #ffffff;
-    color: #6b7280;
+    background: var(--bg-primary);
+    color: var(--text-tertiary);
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
@@ -391,8 +428,8 @@ async function installUpdate() {
   }
 
   .scale-reset-btn:hover:not(:disabled) {
-    background: #f9fafb;
-    border-color: #9ca3af;
+    background: var(--bg-secondary);
+    border-color: var(--text-muted);
   }
 
   .scale-reset-btn:disabled {
@@ -400,12 +437,45 @@ async function installUpdate() {
     cursor: not-allowed;
   }
 
+  .theme-selector {
+    display: flex;
+    gap: 4px;
+    background: var(--bg-tertiary);
+    border-radius: 8px;
+    padding: 3px;
+    flex-shrink: 0;
+  }
+
+  .theme-btn {
+    padding: 5px 12px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    white-space: nowrap;
+  }
+
+  .theme-btn:hover {
+    color: var(--text-secondary);
+    background: var(--bg-hover);
+  }
+
+  .theme-btn.active {
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    box-shadow: var(--shadow-sm);
+  }
+
   .check-update-btn {
     padding: 6px 14px;
-    border: 1px solid #d1d5db;
+    border: 1px solid var(--border-secondary);
     border-radius: 6px;
-    background: #ffffff;
-    color: #374151;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
     font-size: 13px;
     font-weight: 500;
     cursor: pointer;
@@ -414,16 +484,16 @@ async function installUpdate() {
   }
 
   .check-update-btn:hover {
-    background: #f9fafb;
-    border-color: #9ca3af;
+    background: var(--bg-secondary);
+    border-color: var(--text-muted);
   }
 
   .install-btn {
     padding: 6px 14px;
     border: none;
     border-radius: 6px;
-    background: #3b82f6;
-    color: #ffffff;
+    background: var(--accent);
+    color: var(--bg-primary);
     font-size: 13px;
     font-weight: 500;
     cursor: pointer;
@@ -432,29 +502,29 @@ async function installUpdate() {
   }
 
   .install-btn:hover {
-    background: #2563eb;
+    background: var(--accent-hover);
   }
 
   .update-message {
     font-size: 13px;
-    color: #6b7280;
+    color: var(--text-tertiary);
   }
 
   .update-message.muted {
-    color: #9ca3af;
+    color: var(--text-muted);
     font-style: italic;
   }
 
   .update-message.success {
-    color: #059669;
+    color: var(--success-text);
   }
 
   .update-message.error {
-    color: #dc2626;
+    color: var(--error-text);
   }
 
   .update-available {
-    background: #eff6ff;
+    background: var(--bg-selected);
     border-radius: 8px;
     padding: 12px;
     margin: -4px 0;
@@ -463,7 +533,7 @@ async function installUpdate() {
   .progress-bar {
     width: 100%;
     height: 6px;
-    background: #e5e7eb;
+    background: var(--border-primary);
     border-radius: 3px;
     overflow: hidden;
     margin-top: 6px;
@@ -471,7 +541,7 @@ async function installUpdate() {
 
   .progress-fill {
     height: 100%;
-    background: #3b82f6;
+    background: var(--accent);
     border-radius: 3px;
     transition: width 0.2s ease;
   }

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -5,7 +5,7 @@ import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getFontScale as _getFontScale, clampScale, MAX_SCALE, MIN_SCALE } from '$lib/utils/fontScale.js';
-import { applyTheme, getThemePreference } from '$lib/utils/theme.js';
+import { getThemePreference } from '$lib/utils/theme.js';
 
 let open = $state(false);
 
@@ -25,27 +25,18 @@ function toErrorMessage(err) {
 }
 
 const modKey = /mac/i.test(navigator?.userAgent ?? '') ? '⌘' : 'Ctrl';
+const currentScale = $derived(_getFontScale($settings));
+const currentTheme = $derived(getThemePreference($settings));
 
-function getFontScale() {
-  return _getFontScale($settings);
-}
-
-async function setFontScale(scale) {
-  const clamped = clampScale(scale);
-  document.documentElement.style.fontSize = `${clamped}%`;
-  await settingsActions.update('display.fontScale', clamped);
+function setFontScale(scale) {
+  settingsActions.update('display.fontScale', clampScale(scale));
 }
 
 function adjustFontScale(delta) {
-  setFontScale(getFontScale() + delta);
-}
-
-function getTheme() {
-  return getThemePreference($settings);
+  setFontScale(currentScale + delta);
 }
 
 function setTheme(value) {
-  applyTheme(value);
   settingsActions.update('display.theme', value);
 }
 
@@ -163,20 +154,20 @@ async function installUpdate() {
               <button
                 class="scale-btn"
                 onclick={() => adjustFontScale(-10)}
-                disabled={getFontScale() <= MIN_SCALE}
+                disabled={currentScale <= MIN_SCALE}
                 aria-label="Decrease font size"
               >−</button>
-              <span class="scale-value">{getFontScale()}%</span>
+              <span class="scale-value">{currentScale}%</span>
               <button
                 class="scale-btn"
                 onclick={() => adjustFontScale(10)}
-                disabled={getFontScale() >= MAX_SCALE}
+                disabled={currentScale >= MAX_SCALE}
                 aria-label="Increase font size"
               >+</button>
               <button
                 class="scale-reset-btn"
                 onclick={() => setFontScale(100)}
-                disabled={getFontScale() === 100}
+                disabled={currentScale === 100}
               >Reset</button>
             </div>
           </div>
@@ -189,19 +180,19 @@ async function installUpdate() {
             <div class="theme-selector">
               <button
                 class="theme-btn"
-                class:active={getTheme() === 'light'}
+                class:active={currentTheme === 'light'}
                 onclick={() => setTheme('light')}
                 aria-label="Light theme"
               >☀️ Light</button>
               <button
                 class="theme-btn"
-                class:active={getTheme() === 'dark'}
+                class:active={currentTheme === 'dark'}
                 onclick={() => setTheme('dark')}
                 aria-label="Dark theme"
               >🌙 Dark</button>
               <button
                 class="theme-btn"
-                class:active={getTheme() === 'system'}
+                class:active={currentTheme === 'system'}
                 onclick={() => setTheme('system')}
                 aria-label="System theme"
               >💻 System</button>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -43,8 +43,8 @@ function switchTab(tab) {
         justify-content: space-between;
         height: 48px;
         padding: 0 16px;
-        background: #ffffff;
-        border-bottom: 1px solid #e5e7eb;
+        background: var(--bg-primary);
+        border-bottom: 1px solid var(--border-primary);
         flex-shrink: 0;
     }
 
@@ -63,7 +63,7 @@ function switchTab(tab) {
     .app-name {
         font-size: 16px;
         font-weight: 700;
-        color: #111827;
+        color: var(--text-primary);
         letter-spacing: -0.025em;
     }
 
@@ -76,7 +76,7 @@ function switchTab(tab) {
     .top-bar-tabs {
         display: flex;
         gap: 4px;
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
         border-radius: 8px;
         padding: 3px;
     }
@@ -86,7 +86,7 @@ function switchTab(tab) {
         border: none;
         border-radius: 6px;
         background: transparent;
-        color: #6b7280;
+        color: var(--text-tertiary);
         font-size: 13px;
         font-weight: 600;
         cursor: pointer;
@@ -94,13 +94,13 @@ function switchTab(tab) {
     }
 
     .tab-btn:hover {
-        color: #374151;
-        background: #e5e7eb;
+        color: var(--text-secondary);
+        background: var(--border-primary);
     }
 
     .tab-btn.active {
-        background: #ffffff;
-        color: #111827;
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-sm);
     }
 </style>

--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -53,8 +53,8 @@ function getSpeciesEmoji(species) {
         justify-content: space-between;
         width: 100%;
         padding: 10px 12px;
-        background: #ffffff;
-        border: 1px solid #e5e7eb;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
         border-radius: 8px;
         cursor: pointer;
         transition: all 0.15s ease;
@@ -62,14 +62,14 @@ function getSpeciesEmoji(species) {
     }
 
     .pet-card:hover {
-        background: #f9fafb;
-        border-color: #d1d5db;
+        background: var(--bg-secondary);
+        border-color: var(--border-secondary);
     }
 
     .pet-card.selected {
-        background: #eff6ff;
-        border-color: #3b82f6;
-        border-left: 3px solid #3b82f6;
+        background: var(--bg-selected);
+        border-color: var(--accent);
+        border-left: 3px solid var(--accent);
     }
 
     .pet-card-main {
@@ -91,7 +91,7 @@ function getSpeciesEmoji(species) {
     .pet-card-name {
         font-size: 13px;
         font-weight: 600;
-        color: #111827;
+        color: var(--text-primary);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -99,7 +99,7 @@ function getSpeciesEmoji(species) {
 
     .pet-card-meta {
         font-size: 11px;
-        color: #6b7280;
+        color: var(--text-tertiary);
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -115,15 +115,15 @@ function getSpeciesEmoji(species) {
     .tag-badge {
         display: inline-block;
         padding: 1px 6px;
-        background: #eff6ff;
-        color: #3b82f6;
+        background: var(--bg-selected);
+        color: var(--accent-text);
         border-radius: 8px;
         font-size: 10px;
         font-weight: 500;
     }
 
     .selected-indicator {
-        color: #3b82f6;
+        color: var(--accent-text);
         font-size: 12px;
         flex-shrink: 0;
     }

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -179,9 +179,9 @@ function updateAttribute(attrKey, value) {
 
 <style>
   .modal-panel {
-    background: #ffffff;
+    background: var(--bg-primary);
     border-radius: 12px;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-xl);
     width: 560px;
     max-width: 90vw;
     max-height: 85vh;
@@ -195,21 +195,21 @@ function updateAttribute(attrKey, value) {
     align-items: center;
     justify-content: space-between;
     padding: 16px 20px;
-    border-bottom: 1px solid #e5e7eb;
+    border-bottom: 1px solid var(--border-primary);
   }
 
   .modal-header h2 {
     margin: 0;
     font-size: 16px;
     font-weight: 700;
-    color: #111827;
+    color: var(--text-primary);
   }
 
   .modal-close {
     background: none;
     border: none;
     font-size: 20px;
-    color: #9ca3af;
+    color: var(--text-muted);
     cursor: pointer;
     padding: 4px 8px;
     border-radius: 4px;
@@ -217,8 +217,8 @@ function updateAttribute(attrKey, value) {
   }
 
   .modal-close:hover {
-    background: #f3f4f6;
-    color: #374151;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
   }
 
   .modal-body {
@@ -232,8 +232,8 @@ function updateAttribute(attrKey, value) {
     justify-content: flex-end;
     gap: 8px;
     padding: 14px 20px;
-    border-top: 1px solid #e5e7eb;
-    background: #f9fafb;
+    border-top: 1px solid var(--border-primary);
+    background: var(--bg-secondary);
   }
 
   .form-section {
@@ -248,7 +248,7 @@ function updateAttribute(attrKey, value) {
     margin: 0 0 12px 0;
     font-size: 13px;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
   }
@@ -261,7 +261,7 @@ function updateAttribute(attrKey, value) {
     display: block;
     font-size: 13px;
     font-weight: 500;
-    color: #374151;
+    color: var(--text-secondary);
     margin-bottom: 4px;
   }
 
@@ -269,11 +269,11 @@ function updateAttribute(attrKey, value) {
   .field select {
     width: 100%;
     padding: 8px 10px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--border-primary);
     border-radius: 6px;
     font-size: 13px;
-    color: #111827;
-    background: #ffffff;
+    color: var(--text-primary);
+    background: var(--bg-primary);
     outline: none;
     transition: border-color 0.15s;
     box-sizing: border-box;
@@ -281,13 +281,13 @@ function updateAttribute(attrKey, value) {
 
   .field input:focus,
   .field select:focus {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft);
   }
 
   .field input:disabled {
-    background: #f9fafb;
-    color: #9ca3af;
+    background: var(--bg-secondary);
+    color: var(--text-muted);
   }
 
   .field-row {
@@ -314,7 +314,7 @@ function updateAttribute(attrKey, value) {
     gap: 6px;
     font-size: 13px;
     font-weight: 500;
-    color: #374151;
+    color: var(--text-secondary);
   }
 
   .attr-icon {
@@ -324,25 +324,25 @@ function updateAttribute(attrKey, value) {
   .attr-field input {
     width: 100%;
     padding: 6px 10px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--border-primary);
     border-radius: 6px;
     font-size: 13px;
-    color: #111827;
-    background: #ffffff;
+    color: var(--text-primary);
+    background: var(--bg-primary);
     outline: none;
     box-sizing: border-box;
   }
 
   .attr-field input:focus {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft);
   }
 
   .save-error {
-    background: #fef2f2;
-    border: 1px solid #fecaca;
+    background: var(--error-bg);
+    border: 1px solid var(--error-border);
     border-radius: 6px;
-    color: #dc2626;
+    color: var(--error-text);
     font-size: 13px;
     padding: 10px 14px;
     margin-bottom: 16px;

--- a/src/lib/components/pet/PetImageGallery.svelte
+++ b/src/lib/components/pet/PetImageGallery.svelte
@@ -257,7 +257,7 @@ $effect(() => {
 
   .gallery-count {
     font-size: 13px;
-    color: #6b7280;
+    color: var(--text-tertiary);
     font-weight: 500;
   }
 
@@ -267,7 +267,7 @@ $effect(() => {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    color: #9ca3af;
+    color: var(--text-muted);
   }
 
   .empty-icon {
@@ -280,13 +280,13 @@ $effect(() => {
     margin: 0;
     font-size: 15px;
     font-weight: 600;
-    color: #6b7280;
+    color: var(--text-tertiary);
   }
 
   .gallery-empty p.empty-hint {
     font-size: 13px;
     font-weight: 400;
-    color: #9ca3af;
+    color: var(--text-muted);
     margin-top: 4px;
   }
 
@@ -298,8 +298,8 @@ $effect(() => {
 
   .thumbnail-card {
     position: relative;
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-primary);
     border-radius: 8px;
     overflow: hidden;
     cursor: grab;
@@ -310,7 +310,7 @@ $effect(() => {
   }
 
   .thumbnail-card.drag-over {
-    border-color: #3b82f6;
+    border-color: var(--accent);
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
   }
 
@@ -339,7 +339,7 @@ $effect(() => {
 
   .thumbnail-name {
     font-size: 11px;
-    color: #374151;
+    color: var(--text-secondary);
     font-weight: 500;
     white-space: nowrap;
     overflow: hidden;
@@ -348,7 +348,7 @@ $effect(() => {
 
   .thumbnail-caption {
     font-size: 10px;
-    color: #9ca3af;
+    color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -477,24 +477,24 @@ $effect(() => {
 
   /* Confirm dialog */
   .confirm-dialog {
-    background: #ffffff;
+    background: var(--bg-primary);
     border-radius: 12px;
     padding: 24px;
     max-width: 380px;
     width: 90%;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-lg);
   }
 
   .confirm-dialog h3 {
     font-size: 16px;
     font-weight: 700;
-    color: #111827;
+    color: var(--text-primary);
     margin-bottom: 8px;
   }
 
   .confirm-dialog p {
     font-size: 14px;
-    color: #6b7280;
+    color: var(--text-tertiary);
     line-height: 1.5;
     margin-bottom: 20px;
   }
@@ -513,10 +513,10 @@ $effect(() => {
     border-radius: 8px;
     font-size: 13px;
     font-weight: 500;
-    background: #f0fdf4;
-    color: #166534;
-    border: 1px solid #bbf7d0;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    background: var(--success-bg);
+    color: var(--success-text);
+    border: 1px solid var(--success-border);
+    box-shadow: var(--shadow-md);
     z-index: 300;
   }
 </style>

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -307,9 +307,9 @@ async function handleDrop(e, dropIndex) {
 
 <style>
     .confirm-dialog {
-        background: #ffffff;
+        background: var(--bg-primary);
         border-radius: 12px;
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+        box-shadow: var(--shadow-xl);
         padding: 24px;
         width: 340px;
         max-width: 90vw;
@@ -318,13 +318,13 @@ async function handleDrop(e, dropIndex) {
 
     .confirm-message {
         font-size: 15px;
-        color: #111827;
+        color: var(--text-primary);
         margin: 0 0 4px 0;
     }
 
     .confirm-subtext {
         font-size: 12px;
-        color: #9ca3af;
+        color: var(--text-muted);
         margin: 0 0 20px 0;
     }
 
@@ -342,29 +342,29 @@ async function handleDrop(e, dropIndex) {
 
     .pet-list-header {
         padding: 12px;
-        border-bottom: 1px solid #e5e7eb;
+        border-bottom: 1px solid var(--border-primary);
         flex-shrink: 0;
     }
 
     .search-input {
         width: 100%;
         padding: 8px 12px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border-primary);
         border-radius: 6px;
         font-size: 13px;
-        background: #f9fafb;
-        color: #111827;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
         outline: none;
         transition: border-color 0.15s;
     }
 
     .search-input:focus {
-        border-color: #3b82f6;
-        background: #ffffff;
+        border-color: var(--accent);
+        background: var(--bg-primary);
     }
 
     .search-input::placeholder {
-        color: #9ca3af;
+        color: var(--text-muted);
     }
 
     .tag-filter {
@@ -376,10 +376,10 @@ async function handleDrop(e, dropIndex) {
 
     .tag-filter-btn {
         padding: 2px 10px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border-primary);
         border-radius: 10px;
-        background: #ffffff;
-        color: #6b7280;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
         font-size: 11px;
         font-weight: 500;
         cursor: pointer;
@@ -387,14 +387,14 @@ async function handleDrop(e, dropIndex) {
     }
 
     .tag-filter-btn:hover {
-        border-color: #93c5fd;
-        color: #3b82f6;
+        border-color: var(--accent);
+        color: var(--accent-text);
     }
 
     .tag-filter-btn.active {
-        background: #3b82f6;
-        border-color: #3b82f6;
-        color: #ffffff;
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
     }
 
     .pet-list-items {
@@ -419,7 +419,7 @@ async function handleDrop(e, dropIndex) {
     }
 
     .pet-card-wrapper.drag-over {
-        border-top: 2px solid #3b82f6;
+        border-top: 2px solid var(--accent);
     }
 
     .drop-zone-end {
@@ -428,7 +428,7 @@ async function handleDrop(e, dropIndex) {
     }
 
     .drop-zone-end.drag-over {
-        border-top: 2px solid #3b82f6;
+        border-top: 2px solid var(--accent);
     }
 
     .pet-card-actions {
@@ -456,30 +456,30 @@ async function handleDrop(e, dropIndex) {
         display: flex;
         align-items: center;
         justify-content: center;
-        color: #6b7280;
+        color: var(--text-tertiary);
         transition: all 0.15s;
     }
 
     .edit-btn:hover {
-        background: #eff6ff;
-        color: #3b82f6;
+        background: var(--bg-selected);
+        color: var(--accent-text);
     }
 
     .delete-btn:hover {
-        background: #fef2f2;
-        color: #ef4444;
+        background: var(--error-bg);
+        color: var(--error);
     }
 
     .empty-state {
         padding: 24px 12px;
         text-align: center;
-        color: #9ca3af;
+        color: var(--text-muted);
         font-size: 13px;
     }
 
     .pet-list-footer {
         padding: 12px;
-        border-top: 1px solid #e5e7eb;
+        border-top: 1px solid var(--border-primary);
         display: flex;
         align-items: center;
         gap: 12px;
@@ -489,7 +489,7 @@ async function handleDrop(e, dropIndex) {
     .upload-btn {
         flex: 1;
         padding: 8px 12px;
-        background: #3b82f6;
+        background: var(--accent);
         color: white;
         border: none;
         border-radius: 6px;
@@ -500,17 +500,17 @@ async function handleDrop(e, dropIndex) {
     }
 
     .upload-btn:hover {
-        background: #2563eb;
+        background: var(--accent-hover);
     }
 
     .upload-btn:disabled {
-        background: #9ca3af;
+        background: var(--text-muted);
         cursor: not-allowed;
     }
 
     .pet-count {
         font-size: 11px;
-        color: #9ca3af;
+        color: var(--text-muted);
         white-space: nowrap;
     }
 </style>

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -235,26 +235,26 @@ onDestroy(() => {
         align-items: center;
         justify-content: space-between;
         padding: 12px 20px;
-        border-bottom: 1px solid #e5e7eb;
-        background: #ffffff;
+        border-bottom: 1px solid var(--border-primary);
+        background: var(--bg-primary);
         flex-shrink: 0;
     }
 
     .detail-title {
         font-size: 18px;
         font-weight: 700;
-        color: #111827;
+        color: var(--text-primary);
         margin: 0;
     }
 
     .detail-meta {
         font-size: 12px;
-        color: #6b7280;
+        color: var(--text-tertiary);
         margin-top: 2px;
     }
 
     .unknown-badge {
-        color: #f59e0b;
+        color: var(--warning-text);
         font-weight: 600;
     }
 
@@ -273,16 +273,16 @@ onDestroy(() => {
     .breed-label {
         font-size: 11px;
         font-weight: 600;
-        color: #6b7280;
+        color: var(--text-tertiary);
         margin-right: 4px;
     }
 
     .breed-btn {
         padding: 3px 8px;
-        border: 1px solid #e5e7eb;
+        border: 1px solid var(--border-primary);
         border-radius: 4px;
-        background: #ffffff;
-        color: #6b7280;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
         font-size: 11px;
         font-weight: 500;
         cursor: pointer;
@@ -290,14 +290,14 @@ onDestroy(() => {
     }
 
     .breed-btn:hover {
-        border-color: #d1d5db;
-        color: #374151;
+        border-color: var(--border-secondary);
+        color: var(--text-secondary);
     }
 
     .breed-btn.active {
-        background: #3b82f6;
-        border-color: #3b82f6;
-        color: #ffffff;
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
     }
 
     .breed-btn:disabled {
@@ -309,20 +309,20 @@ onDestroy(() => {
     .auto-btn.active {
         background: #22c55e;
         border-color: #22c55e;
-        color: #ffffff;
+        color: var(--bg-primary);
     }
 
     .breed-divider {
         width: 1px;
         height: 16px;
-        background: #d1d5db;
+        background: var(--border-secondary);
         margin: 0 2px;
     }
 
     .view-controls {
         display: flex;
         gap: 4px;
-        background: #f3f4f6;
+        background: var(--bg-tertiary);
         border-radius: 6px;
         padding: 3px;
     }
@@ -332,7 +332,7 @@ onDestroy(() => {
         border: none;
         border-radius: 4px;
         background: transparent;
-        color: #6b7280;
+        color: var(--text-tertiary);
         font-size: 12px;
         font-weight: 600;
         cursor: pointer;
@@ -340,12 +340,12 @@ onDestroy(() => {
     }
 
     .view-btn:hover {
-        color: #374151;
+        color: var(--text-secondary);
     }
 
     .view-btn.active {
-        background: #ffffff;
-        color: #111827;
+        background: var(--bg-primary);
+        color: var(--text-primary);
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
     }
 
@@ -370,8 +370,8 @@ onDestroy(() => {
 
     .stats-drawer {
         flex-shrink: 0;
-        border-left: 1px solid #e5e7eb;
-        background: #f9fafb;
+        border-left: 1px solid var(--border-primary);
+        background: var(--bg-secondary);
         display: flex;
         flex-direction: column;
         overflow: hidden;
@@ -397,29 +397,29 @@ onDestroy(() => {
         align-items: center;
         justify-content: space-between;
         padding: 10px 12px;
-        background: #f3f4f6;
-        border-bottom: 1px solid #e5e7eb;
+        background: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-primary);
         flex-shrink: 0;
     }
 
     .stats-drawer-title {
         font-size: 12px;
         font-weight: 600;
-        color: #374151;
+        color: var(--text-secondary);
     }
 
     .stats-close {
         background: none;
         border: none;
         font-size: 18px;
-        color: #6b7280;
+        color: var(--text-tertiary);
         cursor: pointer;
         padding: 0 4px;
         line-height: 1;
     }
 
     .stats-close:hover {
-        color: #111827;
+        color: var(--text-primary);
     }
 
     .stats-drawer-body {

--- a/src/lib/components/pet/TagInput.svelte
+++ b/src/lib/components/pet/TagInput.svelte
@@ -102,9 +102,9 @@ function handleSuggestionMousedown(e, suggestion) {
     flex-wrap: wrap;
     gap: 4px;
     padding: 6px 8px;
-    border: 1px solid #e5e7eb;
+    border: 1px solid var(--border-primary);
     border-radius: 6px;
-    background: #ffffff;
+    background: var(--bg-primary);
     min-height: 34px;
     align-items: center;
     cursor: text;
@@ -112,8 +112,8 @@ function handleSuggestionMousedown(e, suggestion) {
   }
 
   .tag-input-container:focus-within {
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft);
   }
 
   .tag-pill {
@@ -121,8 +121,8 @@ function handleSuggestionMousedown(e, suggestion) {
     align-items: center;
     gap: 3px;
     padding: 2px 8px;
-    background: #eff6ff;
-    color: #3b82f6;
+    background: var(--bg-selected);
+    color: var(--accent-text);
     border-radius: 10px;
     font-size: 11px;
     font-weight: 500;
@@ -135,7 +135,7 @@ function handleSuggestionMousedown(e, suggestion) {
     padding: 0;
     margin: 0;
     cursor: pointer;
-    color: #93c5fd;
+    color: var(--accent);
     font-size: 13px;
     line-height: 1;
     display: flex;
@@ -143,7 +143,7 @@ function handleSuggestionMousedown(e, suggestion) {
   }
 
   .tag-remove:hover {
-    color: #ef4444;
+    color: var(--error);
   }
 
   .tag-text-input {
@@ -152,13 +152,13 @@ function handleSuggestionMousedown(e, suggestion) {
     border: none;
     outline: none;
     font-size: 13px;
-    color: #111827;
+    color: var(--text-primary);
     background: transparent;
     padding: 2px 0;
   }
 
   .tag-text-input::placeholder {
-    color: #9ca3af;
+    color: var(--text-muted);
   }
 
   .tag-suggestions {
@@ -167,10 +167,10 @@ function handleSuggestionMousedown(e, suggestion) {
     left: 0;
     right: 0;
     margin-top: 4px;
-    background: #ffffff;
-    border: 1px solid #e5e7eb;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
     border-radius: 6px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-md);
     z-index: 10;
     max-height: 160px;
     overflow-y: auto;
@@ -183,12 +183,12 @@ function handleSuggestionMousedown(e, suggestion) {
     border: none;
     background: none;
     font-size: 13px;
-    color: #374151;
+    color: var(--text-secondary);
     text-align: left;
     cursor: pointer;
   }
 
   .tag-suggestion:hover {
-    background: #f3f4f6;
+    background: var(--bg-hover);
   }
 </style>

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -10,6 +10,7 @@ import { getDb } from './database.js';
 const SETTING_DEFAULTS: Record<string, unknown> = {
   'horse.autoSelectBreedFilter': true,
   'display.fontScale': 100,
+  'display.theme': 'system',
 };
 
 export function getDefaultSettings(): Record<string, unknown> {

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -8,6 +8,7 @@ export type ThemePreference = 'light' | 'dark' | 'system';
 /** Resolve a preference to the actual theme to apply. */
 export function resolveTheme(preference: ThemePreference): 'light' | 'dark' {
   if (preference === 'system') {
+    if (typeof window === 'undefined') return 'light';
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
   return preference;
@@ -15,6 +16,7 @@ export function resolveTheme(preference: ThemePreference): 'light' | 'dark' {
 
 /** Apply the resolved theme to the document root. */
 export function applyTheme(preference: ThemePreference): void {
+  if (typeof document === 'undefined') return;
   const resolved = resolveTheme(preference);
   document.documentElement.setAttribute('data-theme', resolved);
 }

--- a/src/lib/utils/theme.ts
+++ b/src/lib/utils/theme.ts
@@ -1,0 +1,27 @@
+/**
+ * Theme utilities for applying light/dark mode.
+ * Manages the data-theme attribute on the document root.
+ */
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+/** Resolve a preference to the actual theme to apply. */
+export function resolveTheme(preference: ThemePreference): 'light' | 'dark' {
+  if (preference === 'system') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return preference;
+}
+
+/** Apply the resolved theme to the document root. */
+export function applyTheme(preference: ThemePreference): void {
+  const resolved = resolveTheme(preference);
+  document.documentElement.setAttribute('data-theme', resolved);
+}
+
+/** Get the current theme preference from settings. */
+export function getThemePreference(settings: Record<string, unknown>): ThemePreference {
+  const val = settings['display.theme'];
+  if (val === 'light' || val === 'dark' || val === 'system') return val;
+  return 'system';
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,14 +1,25 @@
 <script>
 import '../app.css';
+import { onDestroy } from 'svelte';
 import AuthWrapper from '$lib/components/AuthWrapper.svelte';
 import MasterPanel from '$lib/components/layout/MasterPanel.svelte';
 import TopBar from '$lib/components/layout/TopBar.svelte';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { applyFontScale, clampScale, getFontScale, STEP } from '$lib/utils/fontScale.js';
+import { applyTheme, getThemePreference } from '$lib/utils/theme.js';
 
 const { children } = $props();
 
 const fontScale = $derived(getFontScale($settings));
+const themePreference = $derived(getThemePreference($settings));
+
+// Listen for system theme changes when preference is 'system'
+const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+function onSystemThemeChange() {
+  applyTheme(themePreference);
+}
+mediaQuery.addEventListener('change', onSystemThemeChange);
+onDestroy(() => mediaQuery.removeEventListener('change', onSystemThemeChange));
 
 function setScale(scale) {
   const clamped = clampScale(scale);
@@ -36,6 +47,11 @@ function handleGlobalKeydown(e) {
 // Apply persisted font scale on load and when it changes
 $effect(() => {
   applyFontScale(fontScale);
+});
+
+// Apply theme on load and when preference changes
+$effect(() => {
+  applyTheme(themePreference);
 });
 </script>
 
@@ -70,7 +86,7 @@ $effect(() => {
     .detail-pane {
         flex: 1;
         overflow: hidden;
-        background: #ffffff;
+        background: var(--bg-primary);
         min-width: 0;
         position: relative;
     }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script>
 import '../app.css';
-import { onDestroy } from 'svelte';
+import { onDestroy, onMount } from 'svelte';
 import AuthWrapper from '$lib/components/AuthWrapper.svelte';
 import MasterPanel from '$lib/components/layout/MasterPanel.svelte';
 import TopBar from '$lib/components/layout/TopBar.svelte';
@@ -13,12 +13,15 @@ const { children } = $props();
 const fontScale = $derived(getFontScale($settings));
 const themePreference = $derived(getThemePreference($settings));
 
-const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+let mediaQuery;
 function onSystemThemeChange() {
   applyTheme(themePreference);
 }
-mediaQuery.addEventListener('change', onSystemThemeChange);
-onDestroy(() => mediaQuery.removeEventListener('change', onSystemThemeChange));
+onMount(() => {
+  mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', onSystemThemeChange);
+});
+onDestroy(() => mediaQuery?.removeEventListener('change', onSystemThemeChange));
 
 function setScale(scale) {
   const clamped = clampScale(scale);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,7 +13,6 @@ const { children } = $props();
 const fontScale = $derived(getFontScale($settings));
 const themePreference = $derived(getThemePreference($settings));
 
-// Listen for system theme changes when preference is 'system'
 const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 function onSystemThemeChange() {
   applyTheme(themePreference);
@@ -44,12 +43,10 @@ function handleGlobalKeydown(e) {
   }
 }
 
-// Apply persisted font scale on load and when it changes
 $effect(() => {
   applyFontScale(fontScale);
 });
 
-// Apply theme on load and when preference changes
 $effect(() => {
   applyTheme(themePreference);
 });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,9 +51,9 @@ onMount(async () => {
 		align-items: center;
 		justify-content: space-between;
 		padding: 8px 16px;
-		background: #fef2f2;
-		border-bottom: 1px solid #fecaca;
-		color: #dc2626;
+		background: var(--error-bg);
+		border-bottom: 1px solid var(--error-border);
+		color: var(--error-text);
 		font-size: 13px;
 		flex-shrink: 0;
 	}
@@ -63,7 +63,7 @@ onMount(async () => {
 		border: none;
 		font-size: 16px;
 		cursor: pointer;
-		color: #dc2626;
+		color: var(--error-text);
 		padding: 0 4px;
 	}
 
@@ -74,7 +74,7 @@ onMount(async () => {
 		align-items: center;
 		justify-content: center;
 		gap: 8px;
-		color: #9ca3af;
+		color: var(--text-muted);
 	}
 
 	.empty-icon {
@@ -85,21 +85,21 @@ onMount(async () => {
 	.state-title {
 		font-size: 16px;
 		font-weight: 600;
-		color: #6b7280;
+		color: var(--text-tertiary);
 		margin: 0;
 	}
 
 	.state-text {
 		font-size: 13px;
-		color: #9ca3af;
+		color: var(--text-muted);
 		margin: 0;
 	}
 
 	.spinner {
 		width: 32px;
 		height: 32px;
-		border: 3px solid #e5e7eb;
-		border-top: 3px solid #3b82f6;
+		border: 3px solid var(--border-primary);
+		border-top: 3px solid var(--accent);
 		border-radius: 50%;
 		animation: spin 0.8s linear infinite;
 	}

--- a/tests/e2e/theme.spec.js
+++ b/tests/e2e/theme.spec.js
@@ -1,0 +1,153 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+// ==========================================
+// Theme / Dark Mode
+// ==========================================
+
+test.describe('Theme Support', () => {
+  test('defaults to system theme (light in test env)', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('light');
+  });
+
+  test('theme toggle is visible in settings', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    await expect(page.locator('.theme-selector')).toBeVisible();
+    await expect(page.locator('.theme-btn').filter({ hasText: 'Light' })).toBeVisible();
+    await expect(page.locator('.theme-btn').filter({ hasText: 'Dark' })).toBeVisible();
+    await expect(page.locator('.theme-btn').filter({ hasText: 'System' })).toBeVisible();
+  });
+
+  test('system theme is active by default', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    const systemBtn = page.locator('.theme-btn').filter({ hasText: 'System' });
+    await expect(systemBtn).toHaveClass(/active/);
+  });
+
+  test('switching to dark mode applies data-theme="dark"', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+  });
+
+  test('dark mode changes background color', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Get light mode bg
+    const lightBg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+
+    // Switch to dark
+    await page.locator('.settings-toggle').click();
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+
+    const darkBg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+    expect(darkBg).not.toBe(lightBg);
+  });
+
+  test('switching to light mode applies data-theme="light"', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+
+    // Go dark first
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+    let theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+
+    // Switch back to light
+    await page.locator('.theme-btn').filter({ hasText: 'Light' }).click();
+    theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('light');
+  });
+
+  test('dark mode button shows active state', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+
+    const darkBtn = page.locator('.theme-btn').filter({ hasText: 'Dark' });
+    await expect(darkBtn).toHaveClass(/active/);
+  });
+
+  test('theme persists across settings reopen', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Set dark
+    await page.locator('.settings-toggle').click();
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+
+    // Close and reopen settings
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.settings-dialog')).not.toBeVisible();
+
+    await page.locator('.settings-toggle').click();
+    const darkBtn = page.locator('.theme-btn').filter({ hasText: 'Dark' });
+    await expect(darkBtn).toHaveClass(/active/);
+  });
+
+  test('CSS custom properties change with theme', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    const lightTextColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--text-primary').trim(),
+    );
+
+    await page.locator('.settings-toggle').click();
+    await page.locator('.theme-btn').filter({ hasText: 'Dark' }).click();
+
+    const darkTextColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--text-primary').trim(),
+    );
+
+    expect(darkTextColor).not.toBe(lightTextColor);
+  });
+
+  test('system preference is respected', async ({ page }) => {
+    // Emulate dark color scheme
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Default is 'system', so should resolve to dark
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+  });
+
+  test('system preference switch updates live', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    // Ensure we're on system preference
+    let theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('light');
+
+    // Switch system to dark
+    await page.emulateMedia({ colorScheme: 'dark' });
+    // Give the media query listener time to fire
+    await page.waitForTimeout(100);
+
+    theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    expect(theme).toBe('dark');
+  });
+});

--- a/tests/e2e/theme.spec.js
+++ b/tests/e2e/theme.spec.js
@@ -6,7 +6,8 @@ import { waitForAppReady } from './helpers.js';
 // ==========================================
 
 test.describe('Theme Support', () => {
-  test('defaults to system theme (light in test env)', async ({ page }) => {
+  test('defaults to system theme (light when emulated)', async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
     await page.goto('/');
     await waitForAppReady(page);
 
@@ -139,15 +140,11 @@ test.describe('Theme Support', () => {
     await waitForAppReady(page);
 
     // Ensure we're on system preference
-    let theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
+    const theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
     expect(theme).toBe('light');
 
     // Switch system to dark
     await page.emulateMedia({ colorScheme: 'dark' });
-    // Give the media query listener time to fire
-    await page.waitForTimeout(100);
-
-    theme = await page.evaluate(() => document.documentElement.getAttribute('data-theme'));
-    expect(theme).toBe('dark');
+    await page.waitForFunction(() => document.documentElement.getAttribute('data-theme') === 'dark');
   });
 });


### PR DESCRIPTION
## Summary
- **CSS token system**: Extracted ~120 hardcoded colors into semantic CSS custom properties (`--bg-*`, `--text-*`, `--border-*`, `--accent`, `--error-*`, `--success-*`, `--shadow-*`, etc.) with light and dark theme definitions in `:root` and `[data-theme="dark"]`
- **Full component migration**: All 22 component files migrated from hardcoded hex colors to `var()` token references
- **Theme toggle**: Light / Dark / System selector in Settings modal, persisted via settingsService
- **System preference**: Respects `prefers-color-scheme` media query with live updates when system theme changes
- **Gene colors preserved**: Gene visualization colors (`--gene-*`) kept as-is with minor neutral tone adjustments for dark backgrounds. Lightbox and tooltip overlays retain fixed dark styling for contrast.

## New files
- `src/lib/utils/theme.ts` — Theme resolution and application utilities
- `tests/e2e/theme.spec.js` — 11 E2E tests for dark mode

## Test plan
- [x] 222 unit tests pass
- [x] 94 E2E tests pass (83 existing + 11 new theme tests)
- [x] Lint clean (biome check)
- [x] Manual: Toggle between Light/Dark/System in Settings
- [x] Manual: Verify dark mode renders correctly across all views (pet list, gene grid, gene editor, image gallery)
- [x] Manual: Verify gene colors have adequate contrast on dark backgrounds
- [x] Manual: Change system preference and confirm app follows when set to System

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)