### PR TITLE
feat: head-to-head pet comparison

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Gorgonetics ${{ github.ref_name }}"

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ metadata.sqlite
 # AI plugin artifacts
 docs/superpowers/
 .superpowers/
+.omc/
 
 # Misc
 *.backup

--- a/src/lib/components/comparison/AttributeComparison.svelte
+++ b/src/lib/components/comparison/AttributeComparison.svelte
@@ -1,0 +1,211 @@
+<script>
+import { compareAttributes } from '$lib/services/comparisonService.js';
+
+const { petA, petB } = $props();
+
+const results = $derived(petA && petB ? compareAttributes(petA, petB) : []);
+
+const summary = $derived.by(() => {
+  let aWins = 0;
+  let bWins = 0;
+  let ties = 0;
+  for (const r of results) {
+    if (r.winner === 'a') aWins++;
+    else if (r.winner === 'b') bWins++;
+    else ties++;
+  }
+  return { aWins, bWins, ties };
+});
+</script>
+
+<div class="attribute-comparison">
+    {#each results as attr (attr.key)}
+        <div class="attr-row">
+            <div class="attr-header">
+                <span class="attr-icon">{attr.icon}</span>
+                <span class="attr-name">{attr.name}</span>
+                {#if attr.winner !== 'tie'}
+                    <span class="diff-badge" class:positive={attr.diff > 0} class:negative={attr.diff < 0}>
+                        {attr.diff > 0 ? '+' : ''}{attr.diff}
+                    </span>
+                {/if}
+            </div>
+            <div class="attr-bars">
+                <div class="bar-row">
+                    <span class="bar-label pet-a-label">{petA.name}</span>
+                    <div class="bar-track">
+                        <div
+                            class="bar-fill"
+                            class:winner={attr.winner === 'a'}
+                            class:loser={attr.winner === 'b'}
+                            style="width: {attr.petAValue}%"
+                        ></div>
+                    </div>
+                    <span class="bar-value" class:winner-text={attr.winner === 'a'}>{attr.petAValue}</span>
+                </div>
+                <div class="bar-row">
+                    <span class="bar-label pet-b-label">{petB.name}</span>
+                    <div class="bar-track">
+                        <div
+                            class="bar-fill"
+                            class:winner={attr.winner === 'b'}
+                            class:loser={attr.winner === 'a'}
+                            style="width: {attr.petBValue}%"
+                        ></div>
+                    </div>
+                    <span class="bar-value" class:winner-text={attr.winner === 'b'}>{attr.petBValue}</span>
+                </div>
+            </div>
+        </div>
+    {/each}
+
+    <div class="summary-row">
+        <span class="summary-item winner-text">
+            {petA.name}: {summary.aWins} win{summary.aWins !== 1 ? 's' : ''}
+        </span>
+        <span class="summary-divider">·</span>
+        <span class="summary-item tie-text">
+            {summary.ties} tie{summary.ties !== 1 ? 's' : ''}
+        </span>
+        <span class="summary-divider">·</span>
+        <span class="summary-item loser-text">
+            {petB.name}: {summary.bWins} win{summary.bWins !== 1 ? 's' : ''}
+        </span>
+    </div>
+</div>
+
+<style>
+    .attribute-comparison {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .attr-row {
+        background: var(--bg-secondary);
+        border-radius: 8px;
+        padding: 12px 16px;
+    }
+
+    .attr-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 8px;
+    }
+
+    .attr-icon {
+        font-size: 14px;
+    }
+
+    .attr-name {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .diff-badge {
+        margin-left: auto;
+        font-size: 11px;
+        font-weight: 700;
+        padding: 1px 6px;
+        border-radius: 8px;
+    }
+
+    .diff-badge.positive {
+        background: rgba(22, 163, 74, 0.1);
+        color: #16a34a;
+    }
+
+    .diff-badge.negative {
+        background: rgba(220, 38, 38, 0.1);
+        color: #dc2626;
+    }
+
+    .attr-bars {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .bar-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .bar-label {
+        font-size: 11px;
+        color: var(--text-tertiary);
+        width: 80px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex-shrink: 0;
+    }
+
+    .bar-track {
+        flex: 1;
+        height: 14px;
+        background: var(--bg-tertiary);
+        border-radius: 7px;
+        overflow: hidden;
+    }
+
+    .bar-fill {
+        height: 100%;
+        border-radius: 7px;
+        background: var(--border-secondary);
+        transition: width 0.3s ease;
+        min-width: 2px;
+    }
+
+    .bar-fill.winner {
+        background: #16a34a;
+    }
+
+    .bar-fill.loser {
+        background: var(--border-secondary);
+    }
+
+    .bar-value {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-secondary);
+        width: 32px;
+        text-align: right;
+        flex-shrink: 0;
+    }
+
+    .bar-value.winner-text {
+        color: #16a34a;
+    }
+
+    .summary-row {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 12px;
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: 600;
+    }
+
+    .summary-item.winner-text {
+        color: #16a34a;
+    }
+
+    .summary-item.tie-text {
+        color: var(--text-tertiary);
+    }
+
+    .summary-item.loser-text {
+        color: #dc2626;
+    }
+
+    .summary-divider {
+        color: var(--text-muted);
+    }
+</style>

--- a/src/lib/components/comparison/ComparisonPetPicker.svelte
+++ b/src/lib/components/comparison/ComparisonPetPicker.svelte
@@ -1,0 +1,330 @@
+<script>
+import { normalizeSpecies } from '$lib/services/configService.js';
+import { comparisonActions, comparisonPets, speciesMismatch } from '$lib/stores/comparison.js';
+import { pets } from '$lib/stores/pets.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
+
+let searchQuery = $state('');
+
+// Auto-filter to same species as Slot A
+const slotASpecies = $derived($comparisonPets[0] ? normalizeSpecies($comparisonPets[0].species) : '');
+
+const filteredPets = $derived.by(() => {
+  const q = searchQuery ? searchQuery.toLowerCase() : '';
+  return $pets.filter((pet) => {
+    // Don't show already-selected pets
+    if ($comparisonPets[0]?.id === pet.id || $comparisonPets[1]?.id === pet.id) return false;
+    // Search filter
+    if (q && !(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
+      return false;
+    }
+    // Species filter: when Slot A is filled, only show same species
+    if (slotASpecies && normalizeSpecies(pet.species) !== slotASpecies) return false;
+    return true;
+  });
+});
+
+function handlePetClick(pet) {
+  comparisonActions.addPet(pet);
+}
+</script>
+
+<div class="comparison-picker">
+    <h3 class="picker-title">Compare Pets</h3>
+
+    <div class="picker-slots">
+        <div class="slot-label">Pet A</div>
+        <div class="picker-slot" class:filled={$comparisonPets[0]}>
+            {#if $comparisonPets[0]}
+                <span class="slot-pet">
+                    <span class="slot-emoji">{getSpeciesEmoji($comparisonPets[0].species)}</span>
+                    <span class="slot-name">{$comparisonPets[0].name}</span>
+                </span>
+                <button class="slot-clear" onclick={() => comparisonActions.setPet(0, null)} title="Remove">×</button>
+            {:else}
+                <span class="empty-slot">Pick a pet...</span>
+            {/if}
+        </div>
+
+        <button class="swap-btn" onclick={() => comparisonActions.swapPets()} title="Swap pets"
+            disabled={!$comparisonPets[0] && !$comparisonPets[1]}>
+            ⇅
+        </button>
+
+        <div class="slot-label">Pet B</div>
+        <div class="picker-slot" class:filled={$comparisonPets[1]}>
+            {#if $comparisonPets[1]}
+                <span class="slot-pet">
+                    <span class="slot-emoji">{getSpeciesEmoji($comparisonPets[1].species)}</span>
+                    <span class="slot-name">{$comparisonPets[1].name}</span>
+                </span>
+                <button class="slot-clear" onclick={() => comparisonActions.setPet(1, null)} title="Remove">×</button>
+            {:else}
+                <span class="empty-slot">Pick a pet...</span>
+            {/if}
+        </div>
+    </div>
+
+    {#if $speciesMismatch}
+        <div class="species-warning" role="alert">
+            ⚠️ Different species — comparison may be limited
+        </div>
+    {/if}
+
+    <div class="picker-search">
+        <input
+            type="text"
+            class="search-input"
+            placeholder="Search pets..."
+            bind:value={searchQuery}
+        />
+    </div>
+
+    {#if slotASpecies}
+        <div class="species-filter-hint">
+            Showing {slotASpecies} only
+        </div>
+    {/if}
+
+    <div class="picker-list">
+        {#each filteredPets as pet (pet.id)}
+            <button class="picker-pet-card" onclick={() => handlePetClick(pet)}>
+                <span class="picker-pet-icon">{getSpeciesEmoji(pet.species)}</span>
+                <span class="picker-pet-info">
+                    <span class="picker-pet-name">{pet.name || 'Unnamed'}</span>
+                    <span class="picker-pet-meta">
+                        {pet.species || 'Unknown'}
+                        {#if pet.breed && pet.breed !== 'Mixed'}
+                            · {pet.breed}
+                        {/if}
+                        · {pet.gender || 'Unknown'}
+                    </span>
+                </span>
+            </button>
+        {:else}
+            <p class="picker-empty">
+                {#if $pets.length === 0}
+                    No pets uploaded yet
+                {:else}
+                    No matching pets
+                {/if}
+            </p>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .comparison-picker {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        height: 100%;
+        overflow: hidden;
+    }
+
+    .picker-title {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--text-primary);
+        margin: 0;
+        padding: 12px 12px 0;
+    }
+
+    .picker-slots {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 0 12px;
+    }
+
+    .slot-label {
+        font-size: 10px;
+        font-weight: 600;
+        color: var(--text-tertiary);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .picker-slot {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 8px 10px;
+        background: var(--bg-primary);
+        border: 1px dashed var(--border-primary);
+        border-radius: 8px;
+        font-size: 13px;
+        min-height: 38px;
+    }
+
+    .picker-slot.filled {
+        border-style: solid;
+        border-color: var(--accent);
+        background: var(--bg-selected);
+    }
+
+    .slot-pet {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+    }
+
+    .slot-emoji {
+        font-size: 16px;
+        flex-shrink: 0;
+    }
+
+    .slot-name {
+        font-weight: 600;
+        color: var(--text-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .slot-clear {
+        background: none;
+        border: none;
+        color: var(--text-tertiary);
+        font-size: 16px;
+        cursor: pointer;
+        padding: 0 2px;
+        line-height: 1;
+        flex-shrink: 0;
+    }
+
+    .slot-clear:hover {
+        color: var(--error);
+    }
+
+    .empty-slot {
+        color: var(--text-muted);
+        font-style: italic;
+        font-size: 12px;
+    }
+
+    .swap-btn {
+        align-self: center;
+        background: var(--bg-tertiary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        padding: 2px 10px;
+        font-size: 14px;
+        cursor: pointer;
+        color: var(--text-secondary);
+        transition: all 0.15s ease;
+    }
+
+    .swap-btn:hover:not(:disabled) {
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+    }
+
+    .swap-btn:disabled {
+        opacity: 0.3;
+        cursor: default;
+    }
+
+    .species-warning {
+        margin: 0 12px;
+        padding: 6px 10px;
+        background: var(--warning-bg, #fef3c7);
+        border: 1px solid var(--warning-border, #f59e0b);
+        border-radius: 6px;
+        font-size: 11px;
+        color: var(--warning-text, #92400e);
+    }
+
+    .picker-search {
+        padding: 0 12px;
+    }
+
+    .search-input {
+        width: 100%;
+        padding: 6px 10px;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        font-size: 12px;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        outline: none;
+        box-sizing: border-box;
+    }
+
+    .search-input:focus {
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px var(--accent-soft);
+    }
+
+    .species-filter-hint {
+        padding: 0 12px;
+        font-size: 10px;
+        color: var(--text-tertiary);
+        font-style: italic;
+    }
+
+    .picker-list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 0 12px 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .picker-pet-card {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 8px 10px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        text-align: left;
+    }
+
+    .picker-pet-card:hover {
+        background: var(--bg-secondary);
+        border-color: var(--accent);
+    }
+
+    .picker-pet-icon {
+        font-size: 16px;
+        flex-shrink: 0;
+    }
+
+    .picker-pet-info {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+    }
+
+    .picker-pet-name {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .picker-pet-meta {
+        font-size: 10px;
+        color: var(--text-tertiary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .picker-empty {
+        text-align: center;
+        color: var(--text-muted);
+        font-size: 12px;
+        padding: 20px 0;
+        margin: 0;
+    }
+</style>

--- a/src/lib/components/comparison/ComparisonView.svelte
+++ b/src/lib/components/comparison/ComparisonView.svelte
@@ -1,0 +1,208 @@
+<script>
+import AttributeComparison from '$lib/components/comparison/AttributeComparison.svelte';
+import GeneStatsComparison from '$lib/components/comparison/GeneStatsComparison.svelte';
+import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
+import { normalizeSpecies } from '$lib/services/configService.js';
+import { comparisonPets, comparisonReady, speciesMismatch } from '$lib/stores/comparison.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
+
+let activeView = $state('attributes');
+
+const speciesLabel = $derived($comparisonPets[0] ? normalizeSpecies($comparisonPets[0].species) : '');
+</script>
+
+<div class="comparison-view">
+    {#if $comparisonReady}
+        <div class="comparison-header">
+            <div class="comparison-title-row">
+                <h2 class="comparison-title">
+                    <span class="pet-name-a">{$comparisonPets[0]?.name}</span>
+                    <span class="vs-label">vs</span>
+                    <span class="pet-name-b">{$comparisonPets[1]?.name}</span>
+                </h2>
+                {#if speciesLabel}
+                    <span class="species-badge">
+                        {getSpeciesEmoji($comparisonPets[0]?.species)} {speciesLabel}
+                    </span>
+                {/if}
+            </div>
+
+            {#if $speciesMismatch}
+                <div class="mismatch-warning" role="alert">
+                    ⚠️ These pets are different species. Genome comparison is not available across species.
+                </div>
+            {/if}
+
+            <nav class="view-tabs" aria-label="Comparison views">
+                <button
+                    class="view-tab"
+                    class:active={activeView === 'attributes'}
+                    onclick={() => activeView = 'attributes'}
+                >
+                    Attributes
+                </button>
+                <button
+                    class="view-tab"
+                    class:active={activeView === 'geneStats'}
+                    onclick={() => activeView = 'geneStats'}
+                    disabled={$speciesMismatch}
+                >
+                    Gene Stats
+                </button>
+                <button
+                    class="view-tab"
+                    class:active={activeView === 'genomeDiff'}
+                    onclick={() => activeView = 'genomeDiff'}
+                    disabled={$speciesMismatch}
+                >
+                    Genome Diff
+                </button>
+            </nav>
+        </div>
+
+        <div class="comparison-body">
+            {#if activeView === 'attributes'}
+                <AttributeComparison petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+            {:else if activeView === 'geneStats'}
+                <GeneStatsComparison petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+            {:else if activeView === 'genomeDiff'}
+                <GenomeGridDiff petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+            {/if}
+        </div>
+    {:else}
+        <div class="empty-state">
+            <div class="empty-icon">⚖️</div>
+            <p class="state-title">Select two pets to compare</p>
+            <p class="state-text">Use the sidebar to pick two same-species pets for head-to-head comparison</p>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .comparison-view {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .comparison-header {
+        padding: 16px 20px 0;
+        border-bottom: 1px solid var(--border-primary);
+        flex-shrink: 0;
+    }
+
+    .comparison-title-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 12px;
+    }
+
+    .comparison-title {
+        font-size: 18px;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin: 0;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .vs-label {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--text-muted);
+        text-transform: uppercase;
+    }
+
+    .species-badge {
+        font-size: 12px;
+        padding: 2px 8px;
+        background: var(--bg-tertiary);
+        border-radius: 10px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .mismatch-warning {
+        padding: 8px 12px;
+        background: var(--warning-bg, #fef3c7);
+        border: 1px solid var(--warning-border, #f59e0b);
+        border-radius: 6px;
+        font-size: 12px;
+        color: var(--warning-text, #92400e);
+        margin-bottom: 12px;
+    }
+
+    .view-tabs {
+        display: flex;
+        gap: 4px;
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 3px;
+        margin-bottom: -1px;
+        width: fit-content;
+    }
+
+    .view-tab {
+        padding: 6px 16px;
+        border: none;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--text-tertiary);
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .view-tab:hover:not(:disabled) {
+        color: var(--text-secondary);
+        background: var(--border-primary);
+    }
+
+    .view-tab.active {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-sm);
+    }
+
+    .view-tab:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .comparison-body {
+        flex: 1;
+        overflow-y: auto;
+        padding: 20px;
+    }
+
+    .empty-state {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        color: var(--text-muted);
+    }
+
+    .empty-icon {
+        font-size: 48px;
+        opacity: 0.4;
+    }
+
+    .state-title {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--text-tertiary);
+        margin: 0;
+    }
+
+    .state-text {
+        font-size: 13px;
+        color: var(--text-muted);
+        margin: 0;
+    }
+</style>

--- a/src/lib/components/comparison/GeneStatsComparison.svelte
+++ b/src/lib/components/comparison/GeneStatsComparison.svelte
@@ -1,0 +1,257 @@
+<script>
+import { compareGeneStats } from '$lib/services/comparisonService.js';
+
+const { petA, petB } = $props();
+
+let results = $state([]);
+let loading = $state(false);
+let error = $state(null);
+
+// Reload when pets change
+$effect(() => {
+  if (petA?.id && petB?.id) {
+    loadStats();
+  }
+});
+
+async function loadStats() {
+  try {
+    loading = true;
+    error = null;
+    results = await compareGeneStats(petA, petB);
+  } catch (err) {
+    error = err.message || 'Failed to load gene stats';
+    results = [];
+  } finally {
+    loading = false;
+  }
+}
+
+function sumEntry(entry) {
+  return entry.positive + entry.negative;
+}
+
+const totalsA = $derived.by(() => {
+  const t = { positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 };
+  for (const r of results) {
+    t.positive += r.petA.positive;
+    t.negative += r.petA.negative;
+    t.dominant += r.petA.dominant;
+    t.recessive += r.petA.recessive;
+    t.mixed += r.petA.mixed;
+  }
+  return t;
+});
+
+const totalsB = $derived.by(() => {
+  const t = { positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 };
+  for (const r of results) {
+    t.positive += r.petB.positive;
+    t.negative += r.petB.negative;
+    t.dominant += r.petB.dominant;
+    t.recessive += r.petB.recessive;
+    t.mixed += r.petB.mixed;
+  }
+  return t;
+});
+</script>
+
+<div class="gene-stats-comparison">
+    {#if loading}
+        <div class="loading-state">
+            <div class="spinner"></div>
+            <p>Loading gene stats...</p>
+        </div>
+    {:else if error}
+        <div class="error-state">⚠️ {error}</div>
+    {:else if results.length > 0}
+        <table class="stats-table">
+            <thead>
+                <tr>
+                    <th class="attr-col">Attribute</th>
+                    <th class="group-header pet-a-header" colspan="5">{petA.name}</th>
+                    <th class="group-header pet-b-header" colspan="5">{petB.name}</th>
+                </tr>
+                <tr class="sub-header">
+                    <th></th>
+                    <th class="num pos" title="Positive genes">+</th>
+                    <th class="num neg" title="Negative genes">−</th>
+                    <th class="num" title="Dominant">●</th>
+                    <th class="num" title="Recessive">○</th>
+                    <th class="num" title="Mixed">◐</th>
+                    <th class="num pos" title="Positive genes">+</th>
+                    <th class="num neg" title="Negative genes">−</th>
+                    <th class="num" title="Dominant">●</th>
+                    <th class="num" title="Recessive">○</th>
+                    <th class="num" title="Mixed">◐</th>
+                </tr>
+            </thead>
+            <tbody>
+                {#each results as row (row.key)}
+                    <tr class="data-row">
+                        <td class="attr-cell">
+                            <span class="attr-icon">{row.icon}</span>
+                            {row.name}
+                        </td>
+                        <td class="num pos" class:better={row.petA.positive > row.petB.positive}>{row.petA.positive}</td>
+                        <td class="num neg" class:worse={row.petA.negative > row.petB.negative}>{row.petA.negative}</td>
+                        <td class="num">{row.petA.dominant}</td>
+                        <td class="num">{row.petA.recessive}</td>
+                        <td class="num border-right">{row.petA.mixed}</td>
+                        <td class="num pos" class:better={row.petB.positive > row.petA.positive}>{row.petB.positive}</td>
+                        <td class="num neg" class:worse={row.petB.negative > row.petA.negative}>{row.petB.negative}</td>
+                        <td class="num">{row.petB.dominant}</td>
+                        <td class="num">{row.petB.recessive}</td>
+                        <td class="num">{row.petB.mixed}</td>
+                    </tr>
+                {/each}
+                <tr class="totals-row">
+                    <td><strong>Total</strong></td>
+                    <td class="num pos"><strong>{totalsA.positive}</strong></td>
+                    <td class="num neg"><strong>{totalsA.negative}</strong></td>
+                    <td class="num"><strong>{totalsA.dominant}</strong></td>
+                    <td class="num"><strong>{totalsA.recessive}</strong></td>
+                    <td class="num border-right"><strong>{totalsA.mixed}</strong></td>
+                    <td class="num pos"><strong>{totalsB.positive}</strong></td>
+                    <td class="num neg"><strong>{totalsB.negative}</strong></td>
+                    <td class="num"><strong>{totalsB.dominant}</strong></td>
+                    <td class="num"><strong>{totalsB.recessive}</strong></td>
+                    <td class="num"><strong>{totalsB.mixed}</strong></td>
+                </tr>
+            </tbody>
+        </table>
+    {:else}
+        <p class="empty-text">No gene data available for comparison.</p>
+    {/if}
+</div>
+
+<style>
+    .gene-stats-comparison {
+        width: 100%;
+    }
+
+    .loading-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        padding: 40px;
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+
+    .spinner {
+        width: 24px;
+        height: 24px;
+        border: 3px solid var(--border-primary);
+        border-top: 3px solid var(--accent);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+
+    .error-state {
+        padding: 12px 16px;
+        background: var(--error-bg);
+        border: 1px solid var(--error-border);
+        border-radius: 6px;
+        color: var(--error-text);
+        font-size: 13px;
+    }
+
+    .stats-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        background: var(--bg-primary);
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: var(--shadow-sm);
+    }
+
+    .stats-table th,
+    .stats-table td {
+        padding: 8px 6px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-primary);
+        white-space: nowrap;
+    }
+
+    .stats-table th {
+        background: var(--bg-tertiary);
+        font-weight: 600;
+        color: var(--text-secondary);
+    }
+
+    .group-header {
+        text-align: center;
+        font-size: 12px;
+        font-weight: 700;
+        border-bottom: 2px solid var(--border-primary);
+    }
+
+    .pet-a-header {
+        border-right: 2px solid var(--border-primary);
+    }
+
+    .sub-header th {
+        font-size: 11px;
+        font-weight: 600;
+        text-align: center;
+        padding: 4px 6px;
+    }
+
+    .num {
+        text-align: center;
+    }
+
+    .pos { color: #16a34a; }
+    .neg { color: #dc2626; }
+
+    .better {
+        font-weight: 700;
+        background: rgba(22, 163, 74, 0.08);
+    }
+
+    .worse {
+        font-weight: 700;
+        background: rgba(220, 38, 38, 0.08);
+    }
+
+    .border-right {
+        border-right: 2px solid var(--border-primary);
+    }
+
+    .attr-cell {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .attr-icon {
+        font-size: 13px;
+    }
+
+    .data-row {
+        transition: background-color 0.15s ease;
+    }
+
+    .data-row:hover {
+        background: var(--bg-secondary);
+    }
+
+    .totals-row {
+        border-top: 2px solid var(--border-primary);
+        background: var(--bg-secondary);
+    }
+
+    .empty-text {
+        color: var(--text-muted);
+        font-size: 13px;
+        text-align: center;
+        padding: 40px;
+    }
+</style>

--- a/src/lib/components/comparison/GenomeDiff.svelte
+++ b/src/lib/components/comparison/GenomeDiff.svelte
@@ -1,0 +1,410 @@
+<script>
+import { diffGenomes } from '$lib/services/comparisonService.js';
+
+const { petA, petB } = $props();
+
+let diffs = $state([]);
+let summary = $state(null);
+let loading = $state(false);
+let error = $state(null);
+let showDiffsOnly = $state(false);
+
+// Track which chromosomes are expanded
+let expandedChromosomes = $state(new Set());
+
+$effect(() => {
+  if (petA?.id && petB?.id) {
+    loadDiff();
+  }
+});
+
+async function loadDiff() {
+  try {
+    loading = true;
+    error = null;
+    const result = await diffGenomes(petA, petB);
+    diffs = result.diffs;
+    summary = result.summary;
+
+    // Auto-expand chromosomes with differences
+    const expanded = new Set();
+    for (const d of diffs) {
+      if (d.differentGenes > 0) expanded.add(d.chromosome);
+    }
+    expandedChromosomes = expanded;
+  } catch (err) {
+    error = err.message || 'Failed to load genome diff';
+    diffs = [];
+    summary = null;
+  } finally {
+    loading = false;
+  }
+}
+
+function toggleChromosome(chr) {
+  expandedChromosomes = new Set(expandedChromosomes);
+  if (expandedChromosomes.has(chr)) {
+    expandedChromosomes.delete(chr);
+  } else {
+    expandedChromosomes.add(chr);
+  }
+}
+
+function geneTypeLabel(type) {
+  if (!type) return '·';
+  return type;
+}
+
+function geneTypeClass(type) {
+  if (type === 'D') return 'dominant';
+  if (type === 'R') return 'recessive';
+  if (type === 'x') return 'mixed';
+  if (type === '?') return 'unknown';
+  return 'empty';
+}
+</script>
+
+<div class="genome-diff">
+    {#if loading}
+        <div class="loading-state">
+            <div class="spinner"></div>
+            <p>Computing genome diff...</p>
+        </div>
+    {:else if error}
+        <div class="error-state">⚠️ {error}</div>
+    {:else if summary}
+        <div class="diff-summary">
+            <span class="similarity-badge">
+                {summary.similarityPercent}% identical
+            </span>
+            <span class="summary-detail">
+                {summary.identicalGenes}/{summary.totalGenes} genes match
+                · {summary.differentGenes} difference{summary.differentGenes !== 1 ? 's' : ''}
+            </span>
+            <label class="diff-toggle">
+                <input type="checkbox" bind:checked={showDiffsOnly} />
+                Show differences only
+            </label>
+        </div>
+
+        <div class="chromosome-list">
+            {#each diffs as chrDiff (chrDiff.chromosome)}
+                {@const hasDiffs = chrDiff.differentGenes > 0}
+                {@const isExpanded = expandedChromosomes.has(chrDiff.chromosome)}
+                {@const visibleGenes = showDiffsOnly ? chrDiff.genes.filter(g => g.isDifferent) : chrDiff.genes}
+
+                {#if !showDiffsOnly || hasDiffs}
+                    <div class="chromosome-section" class:has-diffs={hasDiffs}>
+                        <button class="chromosome-header" onclick={() => toggleChromosome(chrDiff.chromosome)}>
+                            <span class="chr-expand">{isExpanded ? '▾' : '▸'}</span>
+                            <span class="chr-name">Chromosome {chrDiff.chromosome}</span>
+                            <span class="chr-stats">
+                                {#if hasDiffs}
+                                    <span class="chr-identical">{chrDiff.identicalGenes}/{chrDiff.totalGenes} identical</span>
+                                    <span class="chr-different">{chrDiff.differentGenes} diff</span>
+                                {:else}
+                                    <span class="chr-match">✓ all match</span>
+                                {/if}
+                            </span>
+                        </button>
+
+                        {#if isExpanded && visibleGenes.length > 0}
+                            <div class="chromosome-body">
+                                <div class="gene-grid">
+                                    <div class="gene-grid-header">
+                                        <span class="gene-col-id">Gene</span>
+                                        <span class="gene-col-type">{petA.name}</span>
+                                        <span class="gene-col-type">{petB.name}</span>
+                                        <span class="gene-col-effect">Effect</span>
+                                    </div>
+                                    {#each visibleGenes as gene (gene.geneId)}
+                                        <div class="gene-row" class:diff-row={gene.isDifferent}>
+                                            <span class="gene-col-id">{gene.geneId}</span>
+                                            <span class="gene-col-type">
+                                                <span class="gene-type-cell {geneTypeClass(gene.petAType)}">{geneTypeLabel(gene.petAType)}</span>
+                                            </span>
+                                            <span class="gene-col-type">
+                                                <span class="gene-type-cell {geneTypeClass(gene.petBType)}">{geneTypeLabel(gene.petBType)}</span>
+                                            </span>
+                                            <span class="gene-col-effect">
+                                                {#if gene.isDifferent && (gene.petAEffect || gene.petBEffect)}
+                                                    {#if gene.petAEffect && gene.petAEffect !== 'None'}
+                                                        <span class="effect-label effect-a" title="{petA.name}: {gene.petAEffect}">{gene.petAEffect}</span>
+                                                    {/if}
+                                                    {#if gene.petBEffect && gene.petBEffect !== 'None'}
+                                                        <span class="effect-label effect-b" title="{petB.name}: {gene.petBEffect}">{gene.petBEffect}</span>
+                                                    {/if}
+                                                {/if}
+                                            </span>
+                                        </div>
+                                    {/each}
+                                </div>
+                            </div>
+                        {/if}
+                    </div>
+                {/if}
+            {/each}
+        </div>
+    {:else}
+        <p class="empty-text">No genome data available for comparison.</p>
+    {/if}
+</div>
+
+<style>
+    .genome-diff {
+        width: 100%;
+    }
+
+    .loading-state {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        padding: 40px;
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+
+    .spinner {
+        width: 24px;
+        height: 24px;
+        border: 3px solid var(--border-primary);
+        border-top: 3px solid var(--accent);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
+    }
+
+    .error-state {
+        padding: 12px 16px;
+        background: var(--error-bg);
+        border: 1px solid var(--error-border);
+        border-radius: 6px;
+        color: var(--error-text);
+        font-size: 13px;
+    }
+
+    .diff-summary {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        background: var(--bg-secondary);
+        border-radius: 8px;
+        margin-bottom: 16px;
+        flex-wrap: wrap;
+    }
+
+    .similarity-badge {
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--text-primary);
+        padding: 4px 10px;
+        background: var(--bg-tertiary);
+        border-radius: 10px;
+    }
+
+    .summary-detail {
+        font-size: 12px;
+        color: var(--text-secondary);
+    }
+
+    .diff-toggle {
+        margin-left: auto;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+        color: var(--text-secondary);
+        cursor: pointer;
+    }
+
+    .diff-toggle input {
+        cursor: pointer;
+    }
+
+    .chromosome-list {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .chromosome-section {
+        border: 1px solid var(--border-primary);
+        border-radius: 8px;
+        overflow: hidden;
+    }
+
+    .chromosome-section.has-diffs {
+        border-color: var(--warning-border, #f59e0b);
+    }
+
+    .chromosome-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+        padding: 8px 12px;
+        background: var(--bg-secondary);
+        border: none;
+        cursor: pointer;
+        font-size: 13px;
+        text-align: left;
+        transition: background 0.15s ease;
+    }
+
+    .chromosome-header:hover {
+        background: var(--bg-tertiary);
+    }
+
+    .chr-expand {
+        color: var(--text-tertiary);
+        font-size: 11px;
+        width: 12px;
+    }
+
+    .chr-name {
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .chr-stats {
+        margin-left: auto;
+        display: flex;
+        gap: 8px;
+        font-size: 11px;
+    }
+
+    .chr-identical {
+        color: var(--text-tertiary);
+    }
+
+    .chr-different {
+        color: #dc2626;
+        font-weight: 600;
+    }
+
+    .chr-match {
+        color: #16a34a;
+    }
+
+    .chromosome-body {
+        border-top: 1px solid var(--border-primary);
+        padding: 8px;
+    }
+
+    .gene-grid {
+        display: flex;
+        flex-direction: column;
+        font-size: 11px;
+    }
+
+    .gene-grid-header {
+        display: grid;
+        grid-template-columns: 60px 50px 50px 1fr;
+        gap: 4px;
+        padding: 4px 8px;
+        font-weight: 600;
+        color: var(--text-tertiary);
+        border-bottom: 1px solid var(--border-primary);
+        margin-bottom: 2px;
+    }
+
+    .gene-row {
+        display: grid;
+        grid-template-columns: 60px 50px 50px 1fr;
+        gap: 4px;
+        padding: 2px 8px;
+        align-items: center;
+        border-radius: 4px;
+    }
+
+    .gene-row.diff-row {
+        background: rgba(234, 179, 8, 0.1);
+    }
+
+    .gene-col-id {
+        font-family: monospace;
+        font-size: 11px;
+        color: var(--text-secondary);
+    }
+
+    .gene-col-type {
+        text-align: center;
+    }
+
+    .gene-type-cell {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        font-size: 11px;
+        font-weight: 700;
+        font-family: monospace;
+    }
+
+    .gene-type-cell.dominant {
+        background: var(--accent);
+        color: white;
+    }
+
+    .gene-type-cell.recessive {
+        background: transparent;
+        border: 2px solid var(--accent);
+        color: var(--accent);
+    }
+
+    .gene-type-cell.mixed {
+        background: linear-gradient(135deg, var(--accent) 50%, transparent 50%);
+        border: 2px solid var(--accent);
+        color: white;
+    }
+
+    .gene-type-cell.unknown {
+        background: var(--bg-tertiary);
+        color: var(--text-muted);
+    }
+
+    .gene-type-cell.empty {
+        background: var(--bg-tertiary);
+        color: var(--text-muted);
+    }
+
+    .gene-col-effect {
+        display: flex;
+        gap: 4px;
+        flex-wrap: wrap;
+    }
+
+    .effect-label {
+        font-size: 10px;
+        padding: 1px 5px;
+        border-radius: 6px;
+        white-space: nowrap;
+        max-width: 120px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .effect-label.effect-a {
+        background: rgba(59, 130, 246, 0.1);
+        color: var(--accent);
+    }
+
+    .effect-label.effect-b {
+        background: rgba(168, 85, 247, 0.1);
+        color: #a855f7;
+    }
+
+    .empty-text {
+        color: var(--text-muted);
+        font-size: 13px;
+        text-align: center;
+        padding: 40px;
+    }
+</style>

--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,0 +1,87 @@
+<script>
+import { HORSE_BREEDS } from '$lib/types/index.js';
+
+const {
+  summary,
+  isHorse,
+  breedFilter,
+  autoBreed = false,
+  petsHaveKnownBreed = false,
+  petsShareBreed = false,
+  showDiffsOnly,
+  selectedAttributes,
+  hiddenAttributes,
+  attributeDisplayInfo,
+  onBreedChange,
+  onAutoBreedToggle,
+  onAttributeToggle,
+  onDiffsOnlyChange,
+  onResetAttributes,
+} = $props();
+</script>
+
+<div class="diff-controls">
+    <div class="diff-summary">
+        <span class="similarity-badge">{summary.similarityPercent}% identical</span>
+        <span class="summary-detail">{summary.identicalGenes}/{summary.totalGenes} genes match · {summary.differentGenes} diff</span>
+        <label class="diff-toggle">
+            <input type="checkbox" checked={showDiffsOnly} onchange={(e) => onDiffsOnlyChange(e.target.checked)} />
+            Differences only
+        </label>
+    </div>
+    {#if isHorse}
+        <div class="breed-filter">
+            <span class="breed-label">Breed:</span>
+            {#if petsHaveKnownBreed}
+                <button class="breed-btn auto-btn" class:active={autoBreed} onclick={onAutoBreedToggle} title={petsShareBreed ? "Auto-select pets' breed" : "Pets have different breeds"}>Auto</button>
+                <span class="breed-divider"></span>
+            {/if}
+            <button class="breed-btn" class:active={!autoBreed && breedFilter === ''} disabled={autoBreed} onclick={() => onBreedChange('')}>All</button>
+            {#each Object.entries(HORSE_BREEDS) as [name, abbrev]}
+                <button class="breed-btn" class:active={!autoBreed && breedFilter === name} disabled={autoBreed} onclick={() => onBreedChange(name)} title={name}>{abbrev}</button>
+            {/each}
+        </div>
+    {/if}
+    <div class="attribute-filter">
+        <span class="attr-filter-label">Attribute:</span>
+        <button class="attr-filter-btn" class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0} onclick={onResetAttributes}>All</button>
+        {#each attributeDisplayInfo as attr (attr.key)}
+            <button
+                class="attr-filter-btn"
+                class:active={selectedAttributes.includes(attr.key)}
+                class:hidden-attr={hiddenAttributes.includes(attr.key)}
+                onclick={(e) => onAttributeToggle(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
+                title="{attr.name}"
+            >{attr.icon} {attr.name}</button>
+        {/each}
+    </div>
+</div>
+
+<div class="grid-instructions">Click chromosome labels to filter · Ctrl+click to multi-select · Alt+click to hide</div>
+
+<style>
+    .diff-controls { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+    .diff-summary { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: var(--bg-secondary); border-radius: 8px; flex-wrap: wrap; }
+    .similarity-badge { font-size: 14px; font-weight: 700; color: var(--text-primary); padding: 4px 10px; background: var(--bg-tertiary); border-radius: 10px; }
+    .summary-detail { font-size: 12px; color: var(--text-secondary); }
+    .diff-toggle { margin-left: auto; display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
+    .diff-toggle input { cursor: pointer; }
+
+    .breed-filter { display: flex; align-items: center; gap: 3px; padding: 0 4px; }
+    .breed-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
+    .breed-btn { padding: 3px 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
+    .breed-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
+    .breed-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
+    .breed-btn:disabled { opacity: 0.4; cursor: default; pointer-events: none; }
+    .auto-btn.active { background: #22c55e; border-color: #22c55e; color: var(--bg-primary); }
+    .breed-divider { width: 1px; height: 16px; background: var(--border-primary); margin: 0 2px; }
+
+    .attribute-filter { display: flex; align-items: center; gap: 3px; flex-wrap: wrap; padding: 0 4px; }
+    .attr-filter-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
+    .attr-filter-btn { padding: 3px 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; white-space: nowrap; }
+    .attr-filter-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
+    .attr-filter-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
+    .attr-filter-btn.hidden-attr { background: var(--error-bg); border-color: var(--error-border); color: var(--error-text); text-decoration: line-through; }
+
+    .grid-instructions { font-size: 11px; color: var(--text-tertiary); margin-bottom: 6px; font-style: italic; padding: 0 4px; }
+</style>

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -46,11 +46,22 @@ const petsHaveKnownBreed = $derived(
 );
 const petsShareBreed = $derived(petsHaveKnownBreed && petA.breed === petB.breed);
 
+let manualBreedOverride = $state(false);
+
 $effect(() => {
-  // Re-initialize autoBreed from setting when pets change
+  // Re-initialize autoBreed from setting when pets change, reset manual override
   const _a = petA?.id;
   const _b = petB?.id;
+  manualBreedOverride = false;
   autoBreed = !!$settings['horse.autoSelectBreedFilter'];
+});
+
+// Sync with setting changes only when user hasn't manually toggled
+$effect(() => {
+  const settingValue = !!$settings['horse.autoSelectBreedFilter'];
+  if (!manualBreedOverride) {
+    autoBreed = settingValue;
+  }
 });
 
 $effect(() => {
@@ -435,6 +446,7 @@ function handleCellLeave() {
             {attributeDisplayInfo}
             onBreedChange={(name) => { breedFilter = breedFilter === name ? '' : name; }}
             onAutoBreedToggle={() => {
+                manualBreedOverride = true;
                 autoBreed = !autoBreed;
                 if (autoBreed && petsShareBreed) {
                     breedFilter = petA.breed;

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -1,0 +1,568 @@
+<script>
+import { onDestroy, onMount } from 'svelte';
+import GenomeDiffControls from '$lib/components/comparison/GenomeDiffControls.svelte';
+import GeneTooltip from '$lib/components/gene/GeneTooltip.svelte';
+import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import { getGeneEffectsCached } from '$lib/services/geneService.js';
+import { blockLetter } from '$lib/services/genomeParser.js';
+import { getPetGenome } from '$lib/services/petService.js';
+import { settings } from '$lib/stores/settings.js';
+import { HORSE_BREEDS } from '$lib/types/index.js';
+import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { capitalize } from '$lib/utils/string.js';
+
+const { petA, petB } = $props();
+
+let loading = $state(false);
+let error = $state(null);
+let summary = $state(null);
+let showDiffsOnly = $state(false);
+
+let effectsDB = {};
+let speciesKey = $state('');
+const isHorse = $derived(speciesKey === 'horse');
+
+let sortedBlocks = [];
+let blockMaxGenes = new Map();
+let blockIndices = $state({});
+
+let allAttributeNames = [];
+let attributeDisplayInfo = $state([]);
+
+let chromosomeRows = $state([]);
+let chrBreedRelevance = {};
+
+// Filters
+let breedFilter = $state('');
+let autoBreed = $state(false);
+let selectedChromosomes = $state([]);
+let hiddenChromosomes = $state([]);
+let selectedAttributes = $state([]);
+let hiddenAttributes = $state([]);
+
+// Auto-breed: use the shared setting and detect from pets' breeds
+const petsHaveKnownBreed = $derived(
+  isHorse && petA?.breed && HORSE_BREEDS[petA.breed] && petB?.breed && HORSE_BREEDS[petB.breed],
+);
+const petsShareBreed = $derived(petsHaveKnownBreed && petA.breed === petB.breed);
+
+$effect(() => {
+  // Re-initialize autoBreed from setting when pets change
+  const _a = petA?.id;
+  const _b = petB?.id;
+  autoBreed = !!$settings['horse.autoSelectBreedFilter'];
+});
+
+$effect(() => {
+  if (autoBreed && isHorse) {
+    if (petsShareBreed) {
+      breedFilter = petA.breed;
+    } else if (petsHaveKnownBreed) {
+      // Different breeds — can't auto-select, clear
+      breedFilter = '';
+    }
+  }
+});
+
+// Tooltip
+let tooltipVisible = $state(false);
+let tooltipX = $state(0);
+let tooltipY = $state(0);
+let tooltipGeneId = $state('');
+let tooltipGeneType = $state('');
+let tooltipEffect = $state('');
+let tooltipPotentialEffects = $state([]);
+
+// Dynamic filter style element — created programmatically (can't use <style> in Svelte template)
+let filterStyleEl = null;
+
+onMount(() => {
+  filterStyleEl = document.createElement('style');
+  filterStyleEl.id = 'genome-diff-filters';
+  document.head.appendChild(filterStyleEl);
+});
+
+onDestroy(() => {
+  filterStyleEl?.remove();
+  filterStyleEl = null;
+});
+
+$effect(() => {
+  if (petA?.id && petB?.id) {
+    loadData();
+  }
+});
+
+// --- Dynamic filter stylesheet (zero DOM traversal, zero Svelte re-render) ---
+$effect(() => {
+  if (!filterStyleEl) return;
+  filterStyleEl.textContent = buildFilterCSS({
+    selectedAttributes,
+    hiddenAttributes,
+    breedFilter,
+    selectedChromosomes,
+    hiddenChromosomes,
+    showDiffsOnly,
+    isHorse,
+    chrBreedRelevance,
+  });
+});
+
+async function loadData() {
+  try {
+    loading = true;
+    error = null;
+    breedFilter = '';
+    selectedChromosomes = [];
+    hiddenChromosomes = [];
+    selectedAttributes = [];
+    hiddenAttributes = [];
+
+    speciesKey = normalizeSpecies(petA.species);
+    const [genomeA, genomeB, efData] = await Promise.all([
+      getPetGenome(petA.id),
+      getPetGenome(petB.id),
+      getGeneEffectsCached(speciesKey),
+    ]);
+
+    if (!genomeA || !genomeB) throw new Error('Failed to load genome data');
+    effectsDB = efData?.effects ?? {};
+
+    const config = getAttributeConfig(speciesKey);
+    allAttributeNames = config.all_attribute_names.map((n) => capitalize(n));
+    attributeDisplayInfo = config.attributes;
+
+    const parsedA = parseGenes(genomeA.genes);
+    const parsedB = parseGenes(genomeB.genes);
+
+    const allBlks = new Set();
+    const maxGenes = new Map();
+    for (const parsed of [parsedA, parsedB]) {
+      for (const chrData of Object.values(parsed)) {
+        for (const block of chrData.blocks) {
+          allBlks.add(block.letter);
+          const cur = maxGenes.get(block.letter) || 0;
+          maxGenes.set(block.letter, Math.max(cur, block.genes.length));
+        }
+      }
+    }
+    sortedBlocks = [...allBlks].sort();
+    blockMaxGenes = maxGenes;
+
+    const indices = {};
+    for (const block of sortedBlocks) {
+      indices[block] = Array.from({ length: maxGenes.get(block) || 0 }, (_, i) => i);
+    }
+    blockIndices = indices;
+
+    // Pre-compute breed relevance per chromosome
+    chrBreedRelevance = {};
+    if (speciesKey === 'horse') {
+      for (const [geneId, data] of Object.entries(effectsDB)) {
+        const chr = geneId.replace(/[A-Z].*/i, '');
+        if (!chrBreedRelevance[chr]) chrBreedRelevance[chr] = { generic: false, breeds: new Set() };
+        if (!data.breed || data.breed === '') chrBreedRelevance[chr].generic = true;
+        else chrBreedRelevance[chr].breeds.add(data.breed);
+      }
+    }
+
+    const chrKeys = [...new Set([...Object.keys(parsedA), ...Object.keys(parsedB)])].sort((a, b) => {
+      const nA = Number.parseInt(a, 10);
+      const nB = Number.parseInt(b, 10);
+      if (!Number.isNaN(nA) && !Number.isNaN(nB)) return nA - nB;
+      return a.localeCompare(b);
+    });
+
+    let totalGenes = 0;
+    let identicalGenes = 0;
+    let differentGenes = 0;
+
+    chromosomeRows = chrKeys.map((chr) => {
+      const dataA = parsedA[chr] || { blocks: [] };
+      const dataB = parsedB[chr] || { blocks: [] };
+
+      const genesByBlockA = new Map();
+      const genesByBlockB = new Map();
+      for (const b of dataA.blocks) genesByBlockA.set(b.letter, b.genes);
+      for (const b of dataB.blocks) genesByBlockB.set(b.letter, b.genes);
+
+      const cellsA = {};
+      const cellsB = {};
+      const diffs = {};
+      let chrDiffs = 0;
+      let chrTotal = 0;
+
+      for (const block of sortedBlocks) {
+        const genesA = genesByBlockA.get(block) || [];
+        const genesB = genesByBlockB.get(block) || [];
+        const maxLen = maxGenes.get(block) || 0;
+        cellsA[block] = new Array(maxLen);
+        cellsB[block] = new Array(maxLen);
+        diffs[block] = new Array(maxLen);
+
+        for (let i = 0; i < maxLen; i++) {
+          const gA = genesA[i] || null;
+          const gB = genesB[i] || null;
+          // Pre-compute everything: static CSS class, attribute, breed
+          cellsA[block][i] = gA ? makeCell(gA) : null;
+          cellsB[block][i] = gB ? makeCell(gB) : null;
+          const isDiff = (gA?.type || null) !== (gB?.type || null);
+          diffs[block][i] = isDiff;
+          chrTotal++;
+          if (isDiff) chrDiffs++;
+        }
+      }
+
+      totalGenes += chrTotal;
+      differentGenes += chrDiffs;
+      identicalGenes += chrTotal - chrDiffs;
+
+      return { chr, cellsA, cellsB, diffs, chrTotal, chrDiffs, hasDiffs: chrDiffs > 0 };
+    });
+
+    const pct = totalGenes > 0 ? Math.round((identicalGenes / totalGenes) * 100) : 0;
+    summary = { totalGenes, identicalGenes, differentGenes, similarityPercent: pct };
+  } catch (err) {
+    error = err.message || 'Failed to load genome data';
+    chromosomeRows = [];
+    summary = null;
+  } finally {
+    loading = false;
+  }
+}
+
+/** Build a cell object with pre-computed static CSS class string */
+function makeCell(gene) {
+  const analysis = analyzeGene(gene.id, gene.type);
+  let cls = 'gene-cell gene-' + analysis.effectType + ' ';
+  if (gene.type === '?') cls = 'gene-cell gene-neutral gene-unknown';
+  else if (gene.type === 'D') cls += 'gene-dominant';
+  else if (gene.type === 'R') cls += 'gene-recessive';
+  else if (gene.type === 'x') cls += 'gene-mixed';
+  else cls += 'gene-recessive';
+
+  return {
+    id: gene.id,
+    type: gene.type,
+    cssClass: cls,
+    attribute: analysis.attribute || '',
+    breed: analysis.breed || '',
+    effect: analysis.effect || '',
+  };
+}
+
+// --- Gene parsing ---
+
+function parseGenes(genesData) {
+  const parsed = {};
+  for (const [chromosome, geneString] of Object.entries(genesData)) {
+    const blockStrings = geneString.split(' ');
+    const blocks = [];
+    for (let bi = 0; bi < blockStrings.length; bi++) {
+      const bl = blockLetter(bi);
+      const blockGenes = [];
+      for (let i = 0; i < blockStrings[bi].length; i++) {
+        blockGenes.push({ id: `${chromosome}${bl}${i + 1}`, type: blockStrings[bi][i], block: bl, position: i + 1 });
+      }
+      blocks.push({ letter: bl, genes: blockGenes });
+    }
+    parsed[chromosome] = { blocks };
+  }
+  return parsed;
+}
+
+// --- Gene analysis (once per gene) ---
+
+const NO_EFFECT_SENTINELS = new Set([
+  'No gene data found',
+  'No dominant effect',
+  'No recessive effect',
+  'Unknown gene type',
+  'None',
+  'null',
+]);
+
+function isNoEffect(effect) {
+  return !effect || NO_EFFECT_SENTINELS.has(effect);
+}
+
+function getGeneEffect(geneId, geneType) {
+  const data = effectsDB[geneId];
+  if (!data) return 'No gene data found';
+  if (geneType === 'D' || geneType === 'x') {
+    const e = data.effectDominant;
+    return isNoEffect(e) ? 'No dominant effect' : e;
+  }
+  if (geneType === 'R') {
+    const e = data.effectRecessive;
+    return isNoEffect(e) ? 'No recessive effect' : e;
+  }
+  return 'Unknown gene type';
+}
+
+function getGeneBreed(geneId) {
+  return effectsDB[geneId]?.breed || '';
+}
+
+function analyzeGene(geneId, geneType) {
+  const effect = getGeneEffect(geneId, geneType);
+  const breed = getGeneBreed(geneId);
+
+  if (isNoEffect(effect)) return { effectType: 'neutral', attribute: null, effect, breed };
+
+  const effectStr = effect || '';
+  let attribute = null;
+  for (const attrName of allAttributeNames) {
+    if (effectStr.includes(attrName)) {
+      attribute = attrName;
+      break;
+    }
+  }
+
+  const isPotential = effectStr.includes('?') || effectStr.toLowerCase().includes('potential');
+  const hasPlus = effectStr.includes('+');
+  const hasMinus = effectStr.includes('-');
+
+  let effectType = 'neutral';
+  if (isPotential && hasPlus) effectType = 'potential-positive';
+  else if (isPotential && hasMinus) effectType = 'potential-negative';
+  else if (!isPotential && hasPlus) effectType = 'positive';
+  else if (!isPotential && hasMinus) effectType = 'negative';
+
+  return { effectType, attribute, effect, breed };
+}
+
+// --- Filter UI actions ---
+
+function toggleChromosomeFilter(chr, ctrlKey, altKey) {
+  if (altKey) {
+    hiddenChromosomes = hiddenChromosomes.includes(chr)
+      ? hiddenChromosomes.filter((c) => c !== chr)
+      : [...hiddenChromosomes.filter((c) => c !== chr), chr];
+    selectedChromosomes = selectedChromosomes.filter((c) => c !== chr);
+  } else if (ctrlKey) {
+    selectedChromosomes = selectedChromosomes.includes(chr)
+      ? selectedChromosomes.filter((c) => c !== chr)
+      : [...selectedChromosomes, chr];
+    hiddenChromosomes = hiddenChromosomes.filter((c) => c !== chr);
+  } else {
+    selectedChromosomes = selectedChromosomes.length === 1 && selectedChromosomes[0] === chr ? [] : [chr];
+    hiddenChromosomes = hiddenChromosomes.filter((c) => c !== chr);
+  }
+}
+
+function toggleAttributeFilter(attrKey, ctrlKey, altKey) {
+  if (altKey) {
+    hiddenAttributes = hiddenAttributes.includes(attrKey)
+      ? hiddenAttributes.filter((a) => a !== attrKey)
+      : [...hiddenAttributes.filter((a) => a !== attrKey), attrKey];
+    selectedAttributes = selectedAttributes.filter((a) => a !== attrKey);
+  } else if (ctrlKey) {
+    selectedAttributes = selectedAttributes.includes(attrKey)
+      ? selectedAttributes.filter((a) => a !== attrKey)
+      : [...selectedAttributes, attrKey];
+    hiddenAttributes = hiddenAttributes.filter((a) => a !== attrKey);
+  } else {
+    selectedAttributes = selectedAttributes.length === 1 && selectedAttributes[0] === attrKey ? [] : [attrKey];
+    hiddenAttributes = hiddenAttributes.filter((a) => a !== attrKey);
+  }
+}
+
+// --- Tooltip ---
+
+function handleCellEnter(event, cell) {
+  if (!cell) return;
+  const potentialEffects = [];
+  const dominantEffect = getGeneEffect(cell.id, 'D');
+  const recessiveEffect = getGeneEffect(cell.id, 'R');
+
+  if (cell.type !== 'D' && !isNoEffect(dominantEffect)) {
+    const color = dominantEffect.includes('+') ? '#34d399' : dominantEffect.includes('-') ? '#f87171' : '#666';
+    potentialEffects.push(`If Dominant: <span style="color: ${color}">${dominantEffect}</span>`);
+  }
+  if (cell.type !== 'R' && !isNoEffect(recessiveEffect)) {
+    const color = recessiveEffect.includes('+') ? '#34d399' : recessiveEffect.includes('-') ? '#f87171' : '#666';
+    potentialEffects.push(`If Recessive: <span style="color: ${color}">${recessiveEffect}</span>`);
+  }
+
+  const breed = getGeneBreed(cell.id);
+  if (breed && speciesKey === 'horse') {
+    if (breedFilter && breed !== breedFilter) {
+      potentialEffects.push(
+        `<span style="color: #9ca3af">⚬ ${breed} breed only — inactive for ${breedFilter} filter</span>`,
+      );
+    } else if (!breedFilter) {
+      potentialEffects.push(`<span style="color: #9ca3af">⚬ ${breed} breed gene</span>`);
+    }
+  }
+
+  const offset = 12;
+  let x = event.clientX + offset;
+  let y = event.clientY - offset - 60;
+  if (x + 250 > window.innerWidth) x = event.clientX - 250 - offset;
+  if (y < 0) y = event.clientY + offset;
+
+  tooltipX = x;
+  tooltipY = y;
+  tooltipGeneId = cell.id;
+  tooltipGeneType = cell.type;
+  tooltipEffect = cell.effect || '';
+  tooltipPotentialEffects = potentialEffects;
+  tooltipVisible = true;
+}
+
+function handleCellLeave() {
+  tooltipVisible = false;
+}
+</script>
+
+<div class="genome-grid-diff">
+    {#if loading}
+        <div class="loading-state"><div class="spinner"></div><p>Loading genomes...</p></div>
+    {:else if error}
+        <div class="error-state">⚠️ {error}</div>
+    {:else if summary}
+        <GenomeDiffControls
+            {summary}
+            {isHorse}
+            {breedFilter}
+            {autoBreed}
+            {petsHaveKnownBreed}
+            {petsShareBreed}
+            {showDiffsOnly}
+            {selectedAttributes}
+            {hiddenAttributes}
+            {attributeDisplayInfo}
+            onBreedChange={(name) => { breedFilter = breedFilter === name ? '' : name; }}
+            onAutoBreedToggle={() => {
+                autoBreed = !autoBreed;
+                if (autoBreed && petsShareBreed) {
+                    breedFilter = petA.breed;
+                } else if (!autoBreed) {
+                    breedFilter = '';
+                }
+            }}
+            onAttributeToggle={toggleAttributeFilter}
+            onDiffsOnlyChange={(val) => { showDiffsOnly = val; }}
+            onResetAttributes={() => { selectedAttributes = []; hiddenAttributes = []; }}
+        />
+
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div class="grid-container" onmouseleave={handleCellLeave}>
+            <table class="gene-grid-table">
+                <thead class="gene-headers">
+                    <tr>
+                        <th class="chromosome-header">Chr</th>
+                        <th class="pet-label-header">Pet</th>
+                        {#each sortedBlocks as block (block)}
+                            {#each blockIndices[block] as i (i)}
+                                <th class="position-header {i === 0 ? 'block-start block-label' : ''}">{i === 0 ? block : ''}</th>
+                            {/each}
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody class="gene-rows">
+                    {#each chromosomeRows as row (row.chr)}
+                        <tr class="chromosome-row pet-a-row" data-chr={row.chr} data-hasdiffs={row.hasDiffs}>
+                            <td class="chromosome-label" rowspan="2"
+                                onclick={(e) => toggleChromosomeFilter(row.chr, e.ctrlKey || e.metaKey, e.altKey)}
+                            >{row.chr}</td>
+                            <td class="pet-label pet-a-label">{petA.name}</td>
+                            {#each sortedBlocks as block (block)}
+                                {#each blockIndices[block] as i (i)}
+                                    {@const cell = row.cellsA[block][i]}
+                                    {@const isDiff = row.diffs[block][i]}
+                                    <td class="gene-cell-container {i === 0 ? 'block-start' : ''} {!cell ? 'empty' : ''} {isDiff ? 'diff-cell' : ''}"
+                                        data-isdiff={isDiff} data-hascell={!!cell}>
+                                        {#if cell}
+                                            <!-- svelte-ignore a11y_no_static_element_interactions -->
+                                            <div class={cell.cssClass} data-attr={cell.attribute} data-breed={cell.breed}
+                                                onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
+                                            >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
+                                        {/if}
+                                    </td>
+                                {/each}
+                            {/each}
+                        </tr>
+                        <tr class="chromosome-row pet-b-row" data-chr={row.chr} data-hasdiffs={row.hasDiffs}>
+                            <td class="pet-label pet-b-label">{petB.name}</td>
+                            {#each sortedBlocks as block (block)}
+                                {#each blockIndices[block] as i (i)}
+                                    {@const cell = row.cellsB[block][i]}
+                                    {@const isDiff = row.diffs[block][i]}
+                                    <td class="gene-cell-container {i === 0 ? 'block-start' : ''} {!cell ? 'empty' : ''} {isDiff ? 'diff-cell' : ''}"
+                                        data-isdiff={isDiff} data-hascell={!!cell}>
+                                        {#if cell}
+                                            <!-- svelte-ignore a11y_no_static_element_interactions -->
+                                            <div class={cell.cssClass} data-attr={cell.attribute} data-breed={cell.breed}
+                                                onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
+                                            >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
+                                        {/if}
+                                    </td>
+                                {/each}
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+
+        <GeneTooltip visible={tooltipVisible} x={tooltipX} y={tooltipY} geneId={tooltipGeneId} geneType={tooltipGeneType} effect={tooltipEffect} potentialEffects={tooltipPotentialEffects} />
+    {:else}
+        <p class="empty-text">No genome data available for comparison.</p>
+    {/if}
+</div>
+
+<style>
+    .genome-grid-diff { width: 100%; }
+    .loading-state { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 40px; color: var(--text-muted); font-size: 13px; }
+    .spinner { width: 24px; height: 24px; border: 3px solid var(--border-primary); border-top: 3px solid var(--accent); border-radius: 50%; animation: spin 0.8s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .error-state { padding: 12px 16px; background: var(--error-bg); border: 1px solid var(--error-border); border-radius: 6px; color: var(--error-text); font-size: 13px; }
+
+    .grid-container { overflow: auto; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-secondary); }
+    .gene-grid-table { width: auto; border-collapse: collapse; table-layout: fixed; }
+    .gene-headers { position: sticky; top: 0; z-index: 10; background: var(--bg-secondary); }
+    .gene-headers th { background: var(--bg-secondary); border-bottom: 1px solid var(--border-primary); padding: 2px 4px; font-size: 9px; font-weight: normal; color: var(--text-secondary); text-align: center; white-space: nowrap; }
+    .chromosome-header { position: sticky; left: 0; z-index: 11; background: var(--bg-secondary); font-weight: bold; width: 28px; min-width: 28px; max-width: 28px; }
+    .pet-label-header { position: sticky; left: 28px; z-index: 11; background: var(--bg-secondary); font-weight: bold; width: 60px; min-width: 60px; max-width: 60px; }
+    .position-header { width: 16px; min-width: 16px; max-width: 16px; }
+    .position-header.block-label { font-weight: bold; }
+    .position-header.block-start { padding-left: 10px; }
+
+    .gene-rows { background: var(--bg-secondary); }
+    .chromosome-row { border-bottom: 1px solid var(--bg-tertiary); }
+    .chromosome-row.pet-a-row { border-bottom: none; }
+    .chromosome-row.pet-b-row { border-bottom: 2px solid var(--border-primary); }
+
+    .chromosome-label { position: sticky; left: 0; z-index: 1; background: var(--bg-secondary); font-size: 10px; font-weight: 700; color: var(--text-secondary); padding: 2px 4px; text-align: center; vertical-align: middle; border-right: 1px solid var(--border-primary); white-space: nowrap; cursor: pointer; user-select: none; }
+    .chromosome-label:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+
+    .pet-label { position: sticky; left: 28px; z-index: 1; font-size: 9px; font-weight: 600; padding: 1px 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; border-right: 1px solid var(--border-primary); width: 60px; min-width: 60px; max-width: 60px; }
+    .pet-a-label { background: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary)); color: var(--accent); }
+    .pet-b-label { background: color-mix(in srgb, #a855f7 8%, var(--bg-secondary)); color: #a855f7; }
+
+    .gene-cell-container { padding: 1px; text-align: center; vertical-align: middle; }
+    .gene-cell-container.empty { opacity: 0.3; }
+    .gene-cell-container.block-start { padding-left: 8px; }
+    .gene-cell-container.diff-cell { background: rgba(234, 179, 8, 0.15); }
+    .gene-cell-container.identical-dimmed { opacity: 0.2; }
+
+    /* Breed override — applied via direct DOM manipulation */
+    :global(.gene-inactive-breed-override) {
+        background-color: #e8e8ec !important;
+        border-color: #d0d0d6 !important;
+        opacity: 0.5;
+    }
+    :global(.gene-inactive-breed-override.gene-recessive) {
+        background-color: rgba(208, 208, 214, 0.15) !important;
+        border-color: #d0d0d6 !important;
+    }
+    :global(.gene-inactive-breed-override.gene-mixed) {
+        background: linear-gradient(135deg, transparent 50%, #d0d0d6 50%) !important;
+        border-color: #d0d0d6 !important;
+    }
+
+    .gene-unknown-symbol { color: var(--text-muted); font-size: 1em; font-weight: 600; }
+    .empty-text { color: var(--text-muted); font-size: 13px; text-align: center; padding: 40px; }
+</style>

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -13,6 +13,7 @@ import { blockLetter } from '$lib/services/genomeParser.js';
 import { getPetGenome } from '$lib/services/petService.js';
 import { EFFECT_COLORS } from '$lib/theme/gene-colors.js';
 import { handleGridNavigation } from '$lib/utils/keyboard.js';
+import { capitalize } from '$lib/utils/string.js';
 import GeneCell from './GeneCell.svelte';
 import GeneTooltip from './GeneTooltip.svelte';
 
@@ -228,8 +229,6 @@ async function loadPetData() {
     await loadGeneEffectsForSpecies(currentPet.species);
     loadAppearanceConfigForSpecies(currentPet.species);
 
-    // Static templates disabled - current dynamic rendering performance is sufficient
-
     await updateVisualization();
   } catch (err) {
     error = `Failed to load pet: ${err.message}`;
@@ -319,7 +318,7 @@ async function initializeStats() {
     if (currentPet?.species) {
       const config = getAttributeConfig(normalizeSpecies(currentPet.species));
       if (config) {
-        attrNames = config.all_attribute_names.map((name) => name.charAt(0).toUpperCase() + name.slice(1));
+        attrNames = config.all_attribute_names.map((name) => capitalize(name));
       }
     }
     allAttributeNames = attrNames;
@@ -859,13 +858,6 @@ async function createGeneVisualization() {
       };
     });
     if (import.meta.env.DEV) console.timeEnd(buildTime);
-
-    if (import.meta.env.DEV) console.time('🔄 State update (triggers DOM render)');
-    // This assignment triggers Svelte's DOM update cycle
-    // With template caching, DOM structure should be reused when possible
-    if (import.meta.env.DEV) console.timeEnd('🔄 State update (triggers DOM render)');
-
-    // Performance optimization complete - using optimized dynamic rendering
 
     if (import.meta.env.DEV) console.timeEnd('🚀 Gene Visualization Processing');
   } catch (err) {

--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -1,4 +1,5 @@
 <script>
+import ComparisonPetPicker from '$lib/components/comparison/ComparisonPetPicker.svelte';
 import GeneEditor from '$lib/components/gene/GeneEditor.svelte';
 import PetList from '$lib/components/pet/PetList.svelte';
 import { activeTab } from '$lib/stores/pets.js';
@@ -11,6 +12,8 @@ import { activeTab } from '$lib/stores/pets.js';
         <div class="gene-editor-wrapper">
             <GeneEditor />
         </div>
+    {:else if $activeTab === "compare"}
+        <ComparisonPetPicker />
     {/if}
 </aside>
 

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -30,6 +30,13 @@ function switchTab(tab) {
         >
             🧬 Genes
         </button>
+        <button
+            class="tab-btn"
+            class:active={$activeTab === "compare"}
+            onclick={() => switchTab("compare")}
+        >
+            ⚖️ Compare
+        </button>
     </nav>
     <DataMenu />
     <SettingsModal />

--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -1,12 +1,7 @@
 <script>
-const { pet, selected = false, onclick, onkeydown } = $props();
+import { getSpeciesEmoji } from '$lib/utils/species.js';
 
-function getSpeciesEmoji(species) {
-  const s = (species || '').toLowerCase();
-  if (s.includes('bee') || s.includes('wasp')) return '🐝';
-  if (s.includes('horse')) return '🐴';
-  return '🐾';
-}
+const { pet, selected = false, onclick, onkeydown } = $props();
 </script>
 
 <button

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -1,11 +1,39 @@
 <script>
+import { normalizeSpecies } from '$lib/services/configService.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
+import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
 import { createDragState } from '$lib/utils/dragReorder.svelte.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
 import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
+
+function isSelectedForComparison(petId) {
+  return $comparisonPets[0]?.id === petId || $comparisonPets[1]?.id === petId;
+}
+
+function toggleComparisonPet(pet) {
+  if (isSelectedForComparison(pet.id)) {
+    comparisonActions.removePet(pet.id);
+  } else {
+    comparisonActions.addPet(pet);
+  }
+}
+
+function isCompareDisabled(pet) {
+  if (isSelectedForComparison(pet.id)) return false;
+  if ($comparisonReady) return true;
+  // Disable different species when first pet is selected
+  const first = $comparisonPets[0];
+  if (first && normalizeSpecies(first.species) !== normalizeSpecies(pet.species)) return true;
+  return false;
+}
+
+function startCompare() {
+  comparisonActions.toggleSelectMode();
+  appState.switchTab('compare');
+}
 
 let searchQuery = $state('');
 let selectedTags = $state([]);
@@ -225,10 +253,19 @@ async function handleDrop(e, dropIndex) {
                     ondrop={(e) => handleDrop(e, index)}
                     ondragend={drag.handleDragEnd}
                 >
+                    {#if $compareSelectMode}
+                        <input
+                            type="checkbox"
+                            class="compare-checkbox"
+                            checked={isSelectedForComparison(pet.id)}
+                            disabled={isCompareDisabled(pet)}
+                            onchange={() => toggleComparisonPet(pet)}
+                        />
+                    {/if}
                     <PetCard
                         {pet}
                         selected={$selectedPet?.id === pet.id}
-                        onclick={selectPet}
+                        onclick={$compareSelectMode ? () => toggleComparisonPet(pet) : selectPet}
                         onkeydown={(e) => handlePetCardKeydown(e, index)}
                     />
                     <div class="pet-card-actions">
@@ -267,17 +304,36 @@ async function handleDrop(e, dropIndex) {
     </div>
 
     <div class="pet-list-footer">
-        <button
-            class="upload-btn"
-            onclick={handleUpload}
-            disabled={uploading}
-        >
-            {#if uploadProgress}
-                Uploading... ({uploadProgress.current}/{uploadProgress.total})
-            {:else}
-                + Upload Genome
-            {/if}
-        </button>
+        {#if $compareSelectMode}
+            <button class="cancel-compare-btn" onclick={() => comparisonActions.toggleSelectMode()}>
+                Cancel
+            </button>
+            <button
+                class="compare-now-btn"
+                disabled={!$comparisonReady}
+                onclick={startCompare}
+            >
+                Compare ({[$comparisonPets[0], $comparisonPets[1]].filter(Boolean).length}/2) →
+            </button>
+        {:else}
+            <button
+                class="upload-btn"
+                onclick={handleUpload}
+                disabled={uploading}
+            >
+                {#if uploadProgress}
+                    Uploading... ({uploadProgress.current}/{uploadProgress.total})
+                {:else}
+                    + Upload Genome
+                {/if}
+            </button>
+            <button
+                class="compare-mode-btn"
+                onclick={() => comparisonActions.toggleSelectMode()}
+                disabled={$pets.length < 2}
+                title="Compare two pets"
+            >⚖️</button>
+        {/if}
         <span class="pet-count">{$pets.length} pets</span>
     </div>
 </div>
@@ -408,6 +464,9 @@ async function handleDrop(e, dropIndex) {
 
     .pet-card-wrapper {
         position: relative;
+        display: flex;
+        align-items: center;
+        gap: 6px;
     }
 
     .pet-card-wrapper[draggable='true'] {
@@ -512,5 +571,77 @@ async function handleDrop(e, dropIndex) {
         font-size: 11px;
         color: var(--text-muted);
         white-space: nowrap;
+    }
+
+    .compare-checkbox {
+        width: 16px;
+        height: 16px;
+        cursor: pointer;
+        accent-color: var(--accent);
+        flex-shrink: 0;
+    }
+
+    .compare-checkbox:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+    }
+
+    .compare-mode-btn {
+        padding: 8px 10px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        flex-shrink: 0;
+    }
+
+    .compare-mode-btn:hover:not(:disabled) {
+        background: var(--bg-selected);
+        border-color: var(--accent);
+    }
+
+    .compare-mode-btn:disabled {
+        opacity: 0.3;
+        cursor: not-allowed;
+    }
+
+    .cancel-compare-btn {
+        padding: 8px 12px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 500;
+        cursor: pointer;
+        color: var(--text-secondary);
+        transition: all 0.15s ease;
+    }
+
+    .cancel-compare-btn:hover {
+        background: var(--bg-tertiary);
+    }
+
+    .compare-now-btn {
+        flex: 1;
+        padding: 8px 12px;
+        background: var(--accent);
+        color: white;
+        border: none;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s;
+    }
+
+    .compare-now-btn:hover:not(:disabled) {
+        background: var(--accent-hover);
+    }
+
+    .compare-now-btn:disabled {
+        background: var(--text-muted);
+        cursor: not-allowed;
     }
 </style>

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -260,6 +260,7 @@ async function handleDrop(e, dropIndex) {
                             checked={isSelectedForComparison(pet.id)}
                             disabled={isCompareDisabled(pet)}
                             onchange={() => toggleComparisonPet(pet)}
+                            aria-label="Select {pet.name || 'Unnamed'} for comparison"
                         />
                     {/if}
                     <PetCard

--- a/src/lib/services/comparisonService.ts
+++ b/src/lib/services/comparisonService.ts
@@ -1,0 +1,180 @@
+/**
+ * Comparison engine for head-to-head pet comparison.
+ */
+
+import { getAllAttributeNames, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import { getGeneEffectsCached } from '$lib/services/geneService.js';
+import { getPetGenome } from '$lib/services/petService.js';
+import type {
+  AttributeComparisonResult,
+  ChromosomeDiff,
+  GeneDiffEntry,
+  GeneStatsComparisonResult,
+  Pet,
+} from '$lib/types/index.js';
+import { computeGeneStats, parseGenomeGenes } from '$lib/utils/geneAnalysis.js';
+import { capitalize } from '$lib/utils/string.js';
+
+async function loadGenomePair(petA: Pet, petB: Pet) {
+  const species = normalizeSpecies(petA.species);
+  const [genomeA, genomeB, effectsData] = await Promise.all([
+    getPetGenome(petA.id),
+    getPetGenome(petB.id),
+    getGeneEffectsCached(species),
+  ]);
+  if (!genomeA || !genomeB) {
+    throw new Error('Failed to load genome data for comparison');
+  }
+  return { species, genomeA, genomeB, effectsData };
+}
+
+/**
+ * Compare attributes between two same-species pets.
+ */
+export function compareAttributes(petA: Pet, petB: Pet): AttributeComparisonResult[] {
+  const species = normalizeSpecies(petA.species);
+  const config = getAttributeConfig(species);
+  const attrNames = getAllAttributeNames(species);
+
+  return attrNames.map((attrName) => {
+    const info = config.attributes.find((a) => a.key.toLowerCase() === attrName.toLowerCase());
+    const key = capitalize(attrName);
+    const valA = ((petA as Record<string, unknown>)[attrName] as number) ?? 0;
+    const valB = ((petB as Record<string, unknown>)[attrName] as number) ?? 0;
+    const diff = valA - valB;
+
+    let winner: 'a' | 'b' | 'tie' = 'tie';
+    if (diff > 0) winner = 'a';
+    else if (diff < 0) winner = 'b';
+
+    return {
+      key,
+      name: info?.name ?? key,
+      icon: info?.icon ?? '',
+      petAValue: valA,
+      petBValue: valB,
+      diff,
+      winner,
+    };
+  });
+}
+
+/**
+ * Compare gene stats between two same-species pets.
+ * Loads genome data and gene effects, then computes per-attribute stats for both.
+ */
+export async function compareGeneStats(petA: Pet, petB: Pet): Promise<GeneStatsComparisonResult[]> {
+  const { species, genomeA, genomeB, effectsData } = await loadGenomePair(petA, petB);
+
+  const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
+
+  const statsA = computeGeneStats(genomeA.genes, species, effectsDB, petA.breed);
+  const statsB = computeGeneStats(genomeB.genes, species, effectsDB, petB.breed);
+
+  const config = getAttributeConfig(species);
+  const attrNames = getAllAttributeNames(species);
+
+  const emptyEntry = () => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+
+  return attrNames.map((attrName) => {
+    const key = capitalize(attrName);
+    const info = config.attributes.find((a) => a.key.toLowerCase() === attrName.toLowerCase());
+
+    return {
+      key,
+      name: info?.name ?? key,
+      icon: info?.icon ?? '',
+      petA: statsA.stats[key] ?? emptyEntry(),
+      petB: statsB.stats[key] ?? emptyEntry(),
+    };
+  });
+}
+
+/**
+ * Compute a chromosome-by-chromosome genome diff between two pets.
+ */
+export async function diffGenomes(
+  petA: Pet,
+  petB: Pet,
+): Promise<{
+  diffs: ChromosomeDiff[];
+  summary: { totalGenes: number; identicalGenes: number; differentGenes: number; similarityPercent: number };
+}> {
+  const { species, genomeA, genomeB, effectsData } = await loadGenomePair(petA, petB);
+
+  const effectsDB = effectsData?.effects ?? {};
+  const parsedA = parseGenomeGenes(genomeA.genes);
+  const parsedB = parseGenomeGenes(genomeB.genes);
+
+  // Union of all chromosomes, sorted
+  const allChromosomes = [...new Set([...Object.keys(parsedA), ...Object.keys(parsedB)])].sort(
+    (a, b) => Number.parseInt(a, 10) - Number.parseInt(b, 10),
+  );
+
+  const diffs: ChromosomeDiff[] = [];
+  let totalGenes = 0;
+  let identicalGenes = 0;
+  let differentGenes = 0;
+
+  for (const chr of allChromosomes) {
+    const genesA = parsedA[chr] ?? [];
+    const genesB = parsedB[chr] ?? [];
+    const maxLen = Math.max(genesA.length, genesB.length);
+
+    const genes: GeneDiffEntry[] = [];
+
+    for (let i = 0; i < maxLen; i++) {
+      const gA = genesA[i] ?? null;
+      const gB = genesB[i] ?? null;
+
+      const typeA = gA?.type ?? null;
+      const typeB = gB?.type ?? null;
+      const isDifferent = typeA !== typeB;
+      const geneId = gA?.id ?? gB?.id ?? `${chr}?${i + 1}`;
+
+      // Look up effects for differing genes
+      let petAEffect: string | undefined;
+      let petBEffect: string | undefined;
+      if (isDifferent) {
+        if (typeA && typeA !== '?' && effectsDB[geneId]) {
+          const data = effectsDB[geneId];
+          petAEffect = typeA === 'R' ? data.effectRecessive : data.effectDominant;
+        }
+        if (typeB && typeB !== '?' && effectsDB[geneId]) {
+          const data = effectsDB[geneId];
+          petBEffect = typeB === 'R' ? data.effectRecessive : data.effectDominant;
+        }
+      }
+
+      genes.push({
+        geneId,
+        block: gA?.block ?? gB?.block ?? '?',
+        position: gA?.position ?? gB?.position ?? i + 1,
+        petAType: typeA as GeneDiffEntry['petAType'],
+        petBType: typeB as GeneDiffEntry['petBType'],
+        isDifferent,
+        petAEffect,
+        petBEffect,
+      });
+
+      totalGenes++;
+      if (isDifferent) differentGenes++;
+      else identicalGenes++;
+    }
+
+    diffs.push({
+      chromosome: chr,
+      totalGenes: genes.length,
+      identicalGenes: genes.filter((g) => !g.isDifferent).length,
+      differentGenes: genes.filter((g) => g.isDifferent).length,
+      genes,
+    });
+  }
+
+  const similarityPercent = totalGenes > 0 ? Math.round((identicalGenes / totalGenes) * 100) : 0;
+
+  return {
+    diffs,
+    summary: { totalGenes, identicalGenes, differentGenes, similarityPercent },
+  };
+}

--- a/src/lib/services/configService.ts
+++ b/src/lib/services/configService.ts
@@ -6,6 +6,7 @@
 
 import { getBeewaspAppearanceColor, getHorseAppearanceColor } from '$lib/theme/gene-colors.js';
 import type { AppearanceInfo, AttributeInfo } from '$lib/types/index.js';
+import { capitalize } from '$lib/utils/string.js';
 
 // --- Core attribute order (matches game order) ---
 
@@ -287,7 +288,7 @@ export function getAttributeConfig(species: string): {
   const normalized = normalizeSpecies(species);
   const allAttrs = getAllAttributes(species);
   const attributes = Object.entries(allAttrs).map(([name, info]) => ({
-    key: name.charAt(0).toUpperCase() + name.slice(1),
+    key: capitalize(name),
     name: info.name,
     icon: info.icon,
     description: info.description ?? '',
@@ -448,7 +449,7 @@ export function getAllAttributeDisplayInfo(): AttributeInfo[] {
   ];
   for (const speciesAttrs of orderedSpecies.map((s) => SPECIES_ATTRIBUTES[s])) {
     for (const [name, info] of Object.entries(speciesAttrs)) {
-      const key = name.charAt(0).toUpperCase() + name.slice(1);
+      const key = capitalize(name);
       if (!seen.has(key)) {
         seen.add(key);
         result.push({ key, name: info.name, icon: info.icon, description: info.description ?? '' });
@@ -460,7 +461,7 @@ export function getAllAttributeDisplayInfo(): AttributeInfo[] {
   for (const attr of CORE_ATTRIBUTE_ORDER) {
     const info = CORE_ATTRIBUTES[attr];
     if (!info) continue;
-    const key = attr.charAt(0).toUpperCase() + attr.slice(1);
+    const key = capitalize(attr);
     if (!seen.has(key)) {
       seen.add(key);
       result.push({ key, name: info.name, icon: info.icon, description: info.description ?? '' });

--- a/src/lib/stores/comparison.ts
+++ b/src/lib/stores/comparison.ts
@@ -1,0 +1,69 @@
+import { derived, type Writable, writable } from 'svelte/store';
+import { normalizeSpecies } from '$lib/services/configService.js';
+import type { Pet } from '$lib/types/index.js';
+
+/** The two pets selected for comparison (index 0 = left, index 1 = right). */
+export const comparisonPets: Writable<[Pet | null, Pet | null]> = writable([null, null]);
+
+/** Whether multi-select mode is active in PetList. */
+export const compareSelectMode: Writable<boolean> = writable(false);
+
+/** Are both comparison slots filled? */
+export const comparisonReady = derived(comparisonPets, ($cp) => $cp[0] !== null && $cp[1] !== null);
+
+/** Do the two selected pets have different species? */
+export const speciesMismatch = derived(comparisonPets, ($cp) => {
+  if (!$cp[0] || !$cp[1]) return false;
+  return normalizeSpecies($cp[0].species) !== normalizeSpecies($cp[1].species);
+});
+
+function update(fn: (current: [Pet | null, Pet | null]) => [Pet | null, Pet | null]) {
+  comparisonPets.update(fn);
+}
+
+export const comparisonActions = {
+  /** Set a specific slot (0 = left, 1 = right). */
+  setPet(index: 0 | 1, pet: Pet | null) {
+    update((current) => {
+      const next: [Pet | null, Pet | null] = [...current];
+      next[index] = pet;
+      return next;
+    });
+  },
+
+  /** Add a pet to the first empty slot, or replace slot 1 if both are full. */
+  addPet(pet: Pet) {
+    update((current) => {
+      if (current[0] === null) return [pet, current[1]];
+      if (current[1] === null) return [current[0], pet];
+      // Both full — replace slot 1
+      return [current[0], pet];
+    });
+  },
+
+  /** Remove a pet by ID from whichever slot it occupies. */
+  removePet(petId: number) {
+    update((current) => {
+      if (current[0]?.id !== petId && current[1]?.id !== petId) return current;
+      const next: [Pet | null, Pet | null] = [...current];
+      if (next[0]?.id === petId) next[0] = null;
+      if (next[1]?.id === petId) next[1] = null;
+      return next;
+    });
+  },
+
+  /** Swap left and right pets. */
+  swapPets() {
+    update((current) => [current[1], current[0]]);
+  },
+
+  /** Clear both slots. */
+  clear() {
+    comparisonPets.set([null, null]);
+  },
+
+  /** Toggle multi-select mode in PetList. */
+  toggleSelectMode() {
+    compareSelectMode.update((v) => !v);
+  },
+};

--- a/src/lib/stores/comparison.ts
+++ b/src/lib/stores/comparison.ts
@@ -25,7 +25,7 @@ export const comparisonActions = {
   /** Set a specific slot (0 = left, 1 = right). */
   setPet(index: 0 | 1, pet: Pet | null) {
     update((current) => {
-      const next: [Pet | null, Pet | null] = [...current];
+      const next: [Pet | null, Pet | null] = [current[0], current[1]];
       next[index] = pet;
       return next;
     });
@@ -45,10 +45,7 @@ export const comparisonActions = {
   removePet(petId: number) {
     update((current) => {
       if (current[0]?.id !== petId && current[1]?.id !== petId) return current;
-      const next: [Pet | null, Pet | null] = [...current];
-      if (next[0]?.id === petId) next[0] = null;
-      if (next[1]?.id === petId) next[1] = null;
-      return next;
+      return [current[0]?.id === petId ? null : current[0], current[1]?.id === petId ? null : current[1]];
     });
   },
 

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -2,7 +2,7 @@ import { derived, type Writable, writable } from 'svelte/store';
 import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 
-export type Tab = 'pets' | 'editor';
+export type Tab = 'pets' | 'editor' | 'compare';
 
 export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
@@ -112,6 +112,9 @@ export const appState = {
       geneEditingView.set(null);
     } else if (tab === 'editor') {
       selectedPet.set(null);
+    } else if (tab === 'compare') {
+      selectedPet.set(null);
+      geneEditingView.set(null);
     }
   },
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -227,3 +227,65 @@ export interface PetGenomeVisualization {
   species: string;
   chromosomes: Record<string, VisualizationGene[]>;
 }
+
+// --- Comparison types ---
+
+export interface AttributeComparisonResult {
+  key: string;
+  name: string;
+  icon: string;
+  petAValue: number;
+  petBValue: number;
+  diff: number;
+  winner: 'a' | 'b' | 'tie';
+}
+
+export interface GeneStatsEntry {
+  positive: number;
+  negative: number;
+  dominant: number;
+  recessive: number;
+  mixed: number;
+}
+
+export interface GeneStatsComparisonResult {
+  key: string;
+  name: string;
+  icon: string;
+  petA: GeneStatsEntry;
+  petB: GeneStatsEntry;
+}
+
+export interface GeneDiffEntry {
+  geneId: string;
+  block: string;
+  position: number;
+  petAType: GeneType | null;
+  petBType: GeneType | null;
+  isDifferent: boolean;
+  petAEffect?: string;
+  petBEffect?: string;
+}
+
+export interface ChromosomeDiff {
+  chromosome: string;
+  totalGenes: number;
+  identicalGenes: number;
+  differentGenes: number;
+  genes: GeneDiffEntry[];
+}
+
+export interface ComparisonResult {
+  petA: Pet;
+  petB: Pet;
+  species: string;
+  attributes: AttributeComparisonResult[];
+  geneStats: GeneStatsComparisonResult[];
+  genomeDiff: ChromosomeDiff[];
+  summary: {
+    totalGenes: number;
+    identicalGenes: number;
+    differentGenes: number;
+    similarityPercent: number;
+  };
+}

--- a/src/lib/utils/filterCSS.js
+++ b/src/lib/utils/filterCSS.js
@@ -1,0 +1,74 @@
+/**
+ * Build CSS rules for genome grid diff filters.
+ * Isolated in a .js file to avoid biome's Svelte parser choking on CSS-in-JS.
+ */
+
+const G = '.grid-container';
+const FILTERED = '{ opacity: 0.15 !important; filter: grayscale(1) !important; pointer-events: none !important; }';
+const HIDDEN = '{ display: none !important; }';
+const INACTIVE = '{ background-color: #e8e8ec !important; border-color: #d0d0d6 !important; opacity: 0.5 !important; }';
+const DIMMED = '{ opacity: 0.2 !important; }';
+
+/**
+ * @param {object} filters
+ * @param {string[]} filters.selectedAttributes
+ * @param {string[]} filters.hiddenAttributes
+ * @param {string} filters.breedFilter
+ * @param {string[]} filters.selectedChromosomes
+ * @param {string[]} filters.hiddenChromosomes
+ * @param {boolean} filters.showDiffsOnly
+ * @param {boolean} filters.isHorse
+ * @param {Record<string, { generic: boolean; breeds: Set<string> }>} filters.chrBreedRelevance
+ * @returns {string}
+ */
+export function buildFilterCSS(filters) {
+  const {
+    selectedAttributes: sa,
+    hiddenAttributes: ha,
+    breedFilter: bf,
+    selectedChromosomes: sc,
+    hiddenChromosomes: hc,
+    showDiffsOnly: sd,
+    isHorse: horse,
+    chrBreedRelevance,
+  } = filters;
+
+  const rules = [];
+
+  // Attribute filter
+  if (sa.length > 0) {
+    let not = '';
+    for (const a of sa) not += `:not([data-attr="${a}"])`;
+    rules.push(`${G} .gene-cell[data-attr]${not} ${FILTERED}`);
+  }
+  for (const a of ha) {
+    rules.push(`${G} .gene-cell[data-attr="${a}"] ${FILTERED}`);
+  }
+
+  // Breed filter
+  if (horse && bf) {
+    rules.push(`${G} .gene-cell[data-breed]:not([data-breed=""]):not([data-breed="${bf}"]) ${INACTIVE}`);
+    for (const [chr, rel] of Object.entries(chrBreedRelevance)) {
+      if (!rel.generic && !rel.breeds.has(bf)) {
+        rules.push(`${G} tr[data-chr="${chr}"] ${HIDDEN}`);
+      }
+    }
+  }
+
+  // Chromosome filters
+  if (sc.length > 0) {
+    const notChr = sc.map((c) => `[data-chr="${c}"]`).join('):not(');
+    rules.push(`${G} tr[data-chr]:not(${notChr}) ${HIDDEN}`);
+  }
+  for (const c of hc) {
+    rules.push(`${G} tr[data-chr="${c}"] ${HIDDEN}`);
+  }
+
+  // Diffs only
+  if (sd) {
+    rules.push(`${G} td[data-isdiff="false"][data-hascell="true"] ${DIMMED}`);
+    rules.push(`${G} tr[data-hasdiffs="false"] ${HIDDEN}`);
+  }
+
+  return rules.join('\n');
+}

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -1,0 +1,182 @@
+/**
+ * Shared gene analysis utility.
+ *
+ * Extracts the stats computation logic from GeneVisualizer so it can be
+ * reused by both the visualizer and the comparison service.
+ */
+
+import { getAllAttributeNames, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import { blockLetter } from '$lib/services/genomeParser.js';
+import type { GeneStatsEntry } from '$lib/types/index.js';
+import { capitalize } from '$lib/utils/string.js';
+
+// --- Effect classification helpers ---
+
+const NO_EFFECT_SENTINELS = new Set([
+  'No gene data found',
+  'No dominant effect',
+  'No recessive effect',
+  'Unknown gene type',
+  'None',
+  'null',
+]);
+
+function isNoEffect(effect: string | null | undefined): boolean {
+  return !effect || NO_EFFECT_SENTINELS.has(effect);
+}
+
+function getGeneEffect(
+  geneEffectsDB: Record<string, Record<string, { effectDominant: string; effectRecessive: string; breed: string }>>,
+  speciesKey: string,
+  geneId: string,
+  geneType: string,
+): string {
+  const geneData = geneEffectsDB[speciesKey]?.[geneId];
+  if (!geneData) return 'No gene data found';
+
+  if (geneType === 'D' || geneType === 'x') {
+    const effect = geneData.effectDominant;
+    return isNoEffect(effect) ? 'No dominant effect' : effect;
+  }
+  if (geneType === 'R') {
+    const effect = geneData.effectRecessive;
+    return isNoEffect(effect) ? 'No recessive effect' : effect;
+  }
+  return 'Unknown gene type';
+}
+
+function getGeneBreed(
+  geneEffectsDB: Record<string, Record<string, { breed: string }>>,
+  speciesKey: string,
+  geneId: string,
+): string {
+  return geneEffectsDB[speciesKey]?.[geneId]?.breed || '';
+}
+
+/** Parsed gene from a genome string. */
+export interface ParsedGene {
+  id: string;
+  type: string;
+  block: string;
+  position: number;
+}
+
+/**
+ * Parse a genome's gene strings into structured gene objects.
+ * Input: `genes` from `getPetGenome()` — `Record<string, string>` where
+ * each value is like `"RDRD RDRR ?D?? x?xR"`.
+ */
+export function parseGenomeGenes(genes: Record<string, string>): Record<string, ParsedGene[]> {
+  const result: Record<string, ParsedGene[]> = {};
+
+  for (const [chromosome, geneString] of Object.entries(genes)) {
+    const blockStrings = geneString.split(' ');
+    const allGenes: ParsedGene[] = [];
+
+    for (let blockIndex = 0; blockIndex < blockStrings.length; blockIndex++) {
+      const bl = blockLetter(blockIndex);
+      const blockString = blockStrings[blockIndex];
+
+      for (let i = 0; i < blockString.length; i++) {
+        allGenes.push({
+          id: `${chromosome}${bl}${i + 1}`,
+          type: blockString[i],
+          block: bl,
+          position: i + 1,
+        });
+      }
+    }
+
+    result[chromosome] = allGenes;
+  }
+
+  return result;
+}
+
+/**
+ * Compute per-attribute gene stats for a pet's genome.
+ *
+ * Returns a map of attribute key → { positive, negative, dominant, recessive, mixed }.
+ * Also returns totalGenes and neutralGenes counts.
+ */
+type GeneEffectsDB = Record<string, Record<string, { effectDominant: string; effectRecessive: string; breed: string }>>;
+
+export function computeGeneStats(
+  genes: Record<string, string>,
+  species: string,
+  geneEffectsDB: GeneEffectsDB,
+  petBreed?: string,
+): { stats: Record<string, GeneStatsEntry>; totalGenes: number; neutralGenes: number } {
+  const speciesKey = normalizeSpecies(species);
+  const config = getAttributeConfig(speciesKey);
+  const attrNames = getAllAttributeNames(speciesKey).map((name) => capitalize(name));
+
+  const emptyEntry = (): GeneStatsEntry => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+  const stats: Record<string, GeneStatsEntry> = {};
+  for (const attr of attrNames) {
+    stats[attr] = emptyEntry();
+  }
+
+  let totalGenes = 0;
+  let neutralGenes = 0;
+
+  const parsedGenome = parseGenomeGenes(genes);
+  const effectsDB = geneEffectsDB;
+
+  for (const [_chromosome, geneList] of Object.entries(parsedGenome)) {
+    for (const gene of geneList) {
+      if (gene.type === '?') continue;
+      totalGenes++;
+
+      // Skip genes from other breeds (horse only)
+      if (speciesKey === 'horse' && petBreed && petBreed !== 'Mixed') {
+        const breed = getGeneBreed(effectsDB, speciesKey, gene.id);
+        if (breed && breed !== petBreed) continue;
+      }
+
+      const effect = getGeneEffect(effectsDB, speciesKey, gene.id, gene.type);
+      if (isNoEffect(effect)) {
+        neutralGenes++;
+        continue;
+      }
+
+      const effectStr = effect || '';
+      const isPotential = effectStr.includes('?') || effectStr.toLowerCase().includes('potential');
+      if (isPotential) {
+        neutralGenes++;
+        continue;
+      }
+
+      const hasPlus = effectStr.includes('+');
+      const hasMinus = effectStr.includes('-');
+
+      if (!hasPlus && !hasMinus) {
+        neutralGenes++;
+        continue;
+      }
+
+      // Find which attribute this effect targets
+      let matchedAttr: string | null = null;
+      for (const attrName of attrNames) {
+        if (effectStr.includes(attrName)) {
+          matchedAttr = attrName;
+          break;
+        }
+      }
+
+      if (!matchedAttr || !stats[matchedAttr]) {
+        neutralGenes++;
+        continue;
+      }
+
+      const entry = stats[matchedAttr];
+      if (hasPlus) entry.positive++;
+      if (hasMinus) entry.negative++;
+      if (gene.type === 'D') entry.dominant++;
+      else if (gene.type === 'R') entry.recessive++;
+      else if (gene.type === 'x') entry.mixed++;
+    }
+  }
+
+  return { stats, totalGenes, neutralGenes };
+}

--- a/src/lib/utils/species.ts
+++ b/src/lib/utils/species.ts
@@ -1,0 +1,6 @@
+export function getSpeciesEmoji(species: string | undefined | null): string {
+  const s = (species || '').toLowerCase();
+  if (s.includes('bee') || s.includes('wasp')) return '🐝';
+  if (s.includes('horse')) return '🐴';
+  return '🐾';
+}

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -1,0 +1,3 @@
+export function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,9 @@
 <script>
 import { onMount } from 'svelte';
+import ComparisonView from '$lib/components/comparison/ComparisonView.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
-import { appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
+import { activeTab, appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
 
 onMount(async () => {
   await appState.loadPets();
@@ -17,7 +18,9 @@ onMount(async () => {
 		</div>
 	{/if}
 
-	{#if $loading}
+	{#if $activeTab === 'compare'}
+		<ComparisonView />
+	{:else if $loading}
 		<div class="center-state">
 			<div class="spinner"></div>
 			<p class="state-text">Loading...</p>

--- a/tests/e2e/comparison.spec.js
+++ b/tests/e2e/comparison.spec.js
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForAppReady, waitForPets } from './helpers.js';
+import { waitForPets } from './helpers.js';
 
 test.describe('Pet Comparison', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/comparison.spec.js
+++ b/tests/e2e/comparison.spec.js
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady, waitForPets } from './helpers.js';
+
+test.describe('Pet Comparison', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForPets(page);
+  });
+
+  test('shows Compare tab in top bar', async ({ page }) => {
+    await expect(page.locator('.tab-btn').filter({ hasText: 'Compare' })).toBeVisible();
+  });
+
+  test('clicking Compare tab shows empty state', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await expect(page.getByText('Select two pets to compare')).toBeVisible();
+  });
+
+  test('Compare tab shows pet picker in sidebar', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await expect(page.locator('.picker-title')).toHaveText('Compare Pets');
+    await expect(page.locator('.empty-slot')).toHaveCount(2);
+  });
+
+  test('clicking a pet in picker fills a slot', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await page.locator('.picker-pet-card').first().click();
+    await expect(page.locator('.empty-slot')).toHaveCount(1);
+    await expect(page.locator('.slot-name')).toHaveCount(1);
+  });
+
+  test('species filter activates when slot A is filled', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await page.locator('.picker-pet-card').first().click();
+    // Species filter hint should appear
+    await expect(page.locator('.species-filter-hint')).toBeVisible();
+  });
+
+  test('clearing a slot removes species filter', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await page.locator('.picker-pet-card').first().click();
+    await expect(page.locator('.species-filter-hint')).toBeVisible();
+
+    await page.locator('.slot-clear').first().click();
+    await expect(page.locator('.species-filter-hint')).toHaveCount(0);
+    await expect(page.locator('.empty-slot')).toHaveCount(2);
+  });
+
+  test('swap button works with one pet', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await page.locator('.picker-pet-card').first().click();
+    const name = await page.locator('.slot-name').textContent();
+
+    // Swap moves pet from Slot A to Slot B
+    await page.locator('.swap-btn').click();
+
+    // Slot A should now be empty, Slot B should have the pet
+    const slots = page.locator('.picker-slot');
+    await expect(slots.first().locator('.empty-slot')).toBeVisible();
+    await expect(slots.last().locator('.slot-name')).toHaveText(name);
+  });
+
+  test('PetList shows compare mode button', async ({ page }) => {
+    await expect(page.locator('.compare-mode-btn')).toBeVisible();
+  });
+
+  test('PetList compare mode shows checkboxes', async ({ page }) => {
+    await page.locator('.compare-mode-btn').click();
+    await expect(page.locator('.compare-checkbox').first()).toBeVisible();
+    await expect(page.locator('.cancel-compare-btn')).toBeVisible();
+  });
+
+  test('PetList compare mode cancel exits mode', async ({ page }) => {
+    await page.locator('.compare-mode-btn').click();
+    await expect(page.locator('.compare-checkbox').first()).toBeVisible();
+
+    await page.locator('.cancel-compare-btn').click();
+    await expect(page.locator('.compare-checkbox')).toHaveCount(0);
+    await expect(page.locator('.upload-btn')).toBeVisible();
+  });
+
+  test('PetList compare checkbox selects a pet', async ({ page }) => {
+    await page.locator('.compare-mode-btn').click();
+    await page.locator('.compare-checkbox').first().click();
+
+    // Compare button should show 1/2
+    await expect(page.locator('.compare-now-btn')).toContainText('1/2');
+  });
+});

--- a/tests/e2e/perf-comparison.spec.js
+++ b/tests/e2e/perf-comparison.spec.js
@@ -1,167 +1,166 @@
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 import { waitForPets } from './helpers.js';
 
-test.describe('Performance: GenomeGridDiff vs GeneVisualizer', () => {
-  test('measure attribute filter click time in comparison grid', async ({ page }) => {
-    await page.goto('/');
-    await waitForPets(page);
+test.describe
+  .skip('Performance: GenomeGridDiff vs GeneVisualizer', () => {
+    test('measure attribute filter click time in comparison grid', async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
 
-    // Navigate to compare tab and select two horses
-    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+      // Navigate to compare tab and select two horses
+      await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
 
-    // Pick the first pet (should be a horse or bee)
-    await page.locator('.picker-pet-card').first().click();
-    await page.waitForTimeout(500);
-
-    // Check if we have a second pet available — if species filter hides it, clear and try
-    const pickerCards = await page.locator('.picker-pet-card').count();
-    if (pickerCards === 0) {
-      // Only 1 pet of this species — clear and pick the other
-      await page.locator('.slot-clear').first().click();
-      // Can't compare with demo data (1 bee, 1 horse) — skip
-      test.skip();
-      return;
-    }
-
-    await page.locator('.picker-pet-card').first().click();
-    await page.waitForTimeout(500);
-
-    // Switch to Genome Diff tab
-    await page.locator('.view-tab').filter({ hasText: 'Genome Diff' }).click();
-    await page.waitForTimeout(1000);
-
-    // Collect console logs
-    const logs = [];
-    page.on('console', (msg) => {
-      if (msg.text().includes('[GenomeGridDiff]')) {
-        logs.push(msg.text());
-      }
-    });
-
-    // Check if attribute filter buttons exist
-    const attrBtns = page.locator('.attr-filter-btn');
-    const btnCount = await attrBtns.count();
-    console.log(`Found ${btnCount} attribute filter buttons`);
-
-    if (btnCount < 2) {
-      test.skip();
-      return;
-    }
-
-    // Measure: click an attribute filter and time until paint
-    const timings = [];
-
-    for (let clickNum = 0; clickNum < 3; clickNum++) {
-      // Click the second attribute button (first is "All")
-      const btnIndex = (clickNum % (btnCount - 1)) + 1;
-
-      const startTime = Date.now();
-
-      await page.evaluate(() => {
-        window.__perfStart = performance.now();
-      });
-
-      await attrBtns.nth(btnIndex).click();
-
-      // Wait for any visual update
-      await page.waitForTimeout(50);
-
-      const elapsed = await page.evaluate(() => {
-        return performance.now() - window.__perfStart;
-      });
-
-      timings.push(elapsed);
-      console.log(`Click ${clickNum + 1}: attribute filter took ${elapsed.toFixed(1)}ms (wall clock)`);
-
-      // Reset
-      await attrBtns.first().click();
-      await page.waitForTimeout(50);
-    }
-
-    // Print console logs from the component
-    console.log('\nComponent logs:');
-    for (const log of logs) {
-      console.log(`  ${log}`);
-    }
-
-    console.log(`\nAverage click time: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`);
-
-    // Count total DOM elements in the grid
-    const domCount = await page.evaluate(() => {
-      const grid = document.querySelector('.grid-container');
-      return grid ? grid.querySelectorAll('*').length : 0;
-    });
-    console.log(`Total DOM elements in grid: ${domCount}`);
-
-    const geneCellCount = await page.evaluate(() => {
-      return document.querySelectorAll('.gene-cell').length;
-    });
-    console.log(`Total gene cells: ${geneCellCount}`);
-  });
-
-  test('measure attribute filter in regular GeneVisualizer for comparison', async ({ page }) => {
-    await page.goto('/');
-    await waitForPets(page);
-
-    // Click first pet to open visualization
-    await page.locator('.pet-card').first().click();
-    await page.waitForTimeout(1000);
-
-    // Open stats drawer
-    const statsBtn = page.locator('.view-btn').filter({ hasText: 'Stats' });
-    if ((await statsBtn.count()) > 0) {
-      await statsBtn.click();
+      // Pick the first pet (should be a horse or bee)
+      await page.locator('.picker-pet-card').first().click();
       await page.waitForTimeout(500);
-    }
 
-    // Count gene cells
-    const geneCellCount = await page.evaluate(() => {
-      return document.querySelectorAll('.gene-cell').length;
-    });
-    console.log(`Regular GeneVisualizer gene cells: ${geneCellCount}`);
+      // Check if we have a second pet available — if species filter hides it, clear and try
+      const pickerCards = await page.locator('.picker-pet-card').count();
+      if (pickerCards === 0) {
+        // Only 1 pet of this species — clear and pick the other
+        await page.locator('.slot-clear').first().click();
+        // Can't compare with demo data (1 bee, 1 horse) — skip
+        test.skip();
+        return;
+      }
 
-    const domCount = await page.evaluate(() => {
-      const grid = document.querySelector('.gene-grid-container');
-      return grid ? grid.querySelectorAll('*').length : 0;
-    });
-    console.log(`Regular GeneVisualizer DOM elements in grid: ${domCount}`);
+      await page.locator('.picker-pet-card').first().click();
+      await page.waitForTimeout(500);
 
-    // Click an attribute row in the stats table to filter
-    const attrRows = page.locator('.attribute-row');
-    const rowCount = await attrRows.count();
-    console.log(`Stats table attribute rows: ${rowCount}`);
+      // Switch to Genome Diff tab
+      await page.locator('.view-tab').filter({ hasText: 'Genome Diff' }).click();
+      await page.waitForTimeout(1000);
 
-    if (rowCount < 2) {
-      test.skip();
-      return;
-    }
-
-    const timings = [];
-    for (let clickNum = 0; clickNum < 3; clickNum++) {
-      const rowIndex = clickNum % rowCount;
-
-      await page.evaluate(() => {
-        window.__perfStart = performance.now();
+      // Collect console logs
+      const logs = [];
+      page.on('console', (msg) => {
+        if (msg.text().includes('[GenomeGridDiff]')) {
+          logs.push(msg.text());
+        }
       });
 
-      await attrRows.nth(rowIndex).click();
+      // Check if attribute filter buttons exist
+      const attrBtns = page.locator('.attr-filter-btn');
+      const btnCount = await attrBtns.count();
+      console.log(`Found ${btnCount} attribute filter buttons`);
 
-      await page.waitForTimeout(50);
+      if (btnCount < 2) {
+        test.skip();
+        return;
+      }
 
-      const elapsed = await page.evaluate(() => {
-        return performance.now() - window.__perfStart;
+      // Measure: click an attribute filter and time until paint
+      const timings = [];
+
+      for (let clickNum = 0; clickNum < 3; clickNum++) {
+        // Click the second attribute button (first is "All")
+        const btnIndex = (clickNum % (btnCount - 1)) + 1;
+
+        await page.evaluate(() => {
+          window.__perfStart = performance.now();
+        });
+
+        await attrBtns.nth(btnIndex).click();
+
+        // Wait for any visual update
+        await page.waitForTimeout(50);
+
+        const elapsed = await page.evaluate(() => {
+          return performance.now() - window.__perfStart;
+        });
+
+        timings.push(elapsed);
+        console.log(`Click ${clickNum + 1}: attribute filter took ${elapsed.toFixed(1)}ms (wall clock)`);
+
+        // Reset
+        await attrBtns.first().click();
+        await page.waitForTimeout(50);
+      }
+
+      // Print console logs from the component
+      console.log('\nComponent logs:');
+      for (const log of logs) {
+        console.log(`  ${log}`);
+      }
+
+      console.log(`\nAverage click time: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`);
+
+      // Count total DOM elements in the grid
+      const domCount = await page.evaluate(() => {
+        const grid = document.querySelector('.grid-container');
+        return grid ? grid.querySelectorAll('*').length : 0;
       });
+      console.log(`Total DOM elements in grid: ${domCount}`);
 
-      timings.push(elapsed);
-      console.log(`Click ${clickNum + 1}: GeneVisualizer filter took ${elapsed.toFixed(1)}ms`);
+      const geneCellCount = await page.evaluate(() => {
+        return document.querySelectorAll('.gene-cell').length;
+      });
+      console.log(`Total gene cells: ${geneCellCount}`);
+    });
 
-      // Click same row again to deselect
-      await attrRows.nth(rowIndex).click();
-      await page.waitForTimeout(50);
-    }
+    test('measure attribute filter in regular GeneVisualizer for comparison', async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
 
-    console.log(
-      `\nRegular GeneVisualizer average: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`,
-    );
+      // Click first pet to open visualization
+      await page.locator('.pet-card').first().click();
+      await page.waitForTimeout(1000);
+
+      // Open stats drawer
+      const statsBtn = page.locator('.view-btn').filter({ hasText: 'Stats' });
+      if ((await statsBtn.count()) > 0) {
+        await statsBtn.click();
+        await page.waitForTimeout(500);
+      }
+
+      // Count gene cells
+      const geneCellCount = await page.evaluate(() => {
+        return document.querySelectorAll('.gene-cell').length;
+      });
+      console.log(`Regular GeneVisualizer gene cells: ${geneCellCount}`);
+
+      const domCount = await page.evaluate(() => {
+        const grid = document.querySelector('.gene-grid-container');
+        return grid ? grid.querySelectorAll('*').length : 0;
+      });
+      console.log(`Regular GeneVisualizer DOM elements in grid: ${domCount}`);
+
+      // Click an attribute row in the stats table to filter
+      const attrRows = page.locator('.attribute-row');
+      const rowCount = await attrRows.count();
+      console.log(`Stats table attribute rows: ${rowCount}`);
+
+      if (rowCount < 2) {
+        test.skip();
+        return;
+      }
+
+      const timings = [];
+      for (let clickNum = 0; clickNum < 3; clickNum++) {
+        const rowIndex = clickNum % rowCount;
+
+        await page.evaluate(() => {
+          window.__perfStart = performance.now();
+        });
+
+        await attrRows.nth(rowIndex).click();
+
+        await page.waitForTimeout(50);
+
+        const elapsed = await page.evaluate(() => {
+          return performance.now() - window.__perfStart;
+        });
+
+        timings.push(elapsed);
+        console.log(`Click ${clickNum + 1}: GeneVisualizer filter took ${elapsed.toFixed(1)}ms`);
+
+        // Click same row again to deselect
+        await attrRows.nth(rowIndex).click();
+        await page.waitForTimeout(50);
+      }
+
+      console.log(
+        `\nRegular GeneVisualizer average: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`,
+      );
+    });
   });
-});

--- a/tests/e2e/perf-comparison.spec.js
+++ b/tests/e2e/perf-comparison.spec.js
@@ -1,0 +1,167 @@
+import { expect, test } from '@playwright/test';
+import { waitForPets } from './helpers.js';
+
+test.describe('Performance: GenomeGridDiff vs GeneVisualizer', () => {
+  test('measure attribute filter click time in comparison grid', async ({ page }) => {
+    await page.goto('/');
+    await waitForPets(page);
+
+    // Navigate to compare tab and select two horses
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+
+    // Pick the first pet (should be a horse or bee)
+    await page.locator('.picker-pet-card').first().click();
+    await page.waitForTimeout(500);
+
+    // Check if we have a second pet available — if species filter hides it, clear and try
+    const pickerCards = await page.locator('.picker-pet-card').count();
+    if (pickerCards === 0) {
+      // Only 1 pet of this species — clear and pick the other
+      await page.locator('.slot-clear').first().click();
+      // Can't compare with demo data (1 bee, 1 horse) — skip
+      test.skip();
+      return;
+    }
+
+    await page.locator('.picker-pet-card').first().click();
+    await page.waitForTimeout(500);
+
+    // Switch to Genome Diff tab
+    await page.locator('.view-tab').filter({ hasText: 'Genome Diff' }).click();
+    await page.waitForTimeout(1000);
+
+    // Collect console logs
+    const logs = [];
+    page.on('console', (msg) => {
+      if (msg.text().includes('[GenomeGridDiff]')) {
+        logs.push(msg.text());
+      }
+    });
+
+    // Check if attribute filter buttons exist
+    const attrBtns = page.locator('.attr-filter-btn');
+    const btnCount = await attrBtns.count();
+    console.log(`Found ${btnCount} attribute filter buttons`);
+
+    if (btnCount < 2) {
+      test.skip();
+      return;
+    }
+
+    // Measure: click an attribute filter and time until paint
+    const timings = [];
+
+    for (let clickNum = 0; clickNum < 3; clickNum++) {
+      // Click the second attribute button (first is "All")
+      const btnIndex = (clickNum % (btnCount - 1)) + 1;
+
+      const startTime = Date.now();
+
+      await page.evaluate(() => {
+        window.__perfStart = performance.now();
+      });
+
+      await attrBtns.nth(btnIndex).click();
+
+      // Wait for any visual update
+      await page.waitForTimeout(50);
+
+      const elapsed = await page.evaluate(() => {
+        return performance.now() - window.__perfStart;
+      });
+
+      timings.push(elapsed);
+      console.log(`Click ${clickNum + 1}: attribute filter took ${elapsed.toFixed(1)}ms (wall clock)`);
+
+      // Reset
+      await attrBtns.first().click();
+      await page.waitForTimeout(50);
+    }
+
+    // Print console logs from the component
+    console.log('\nComponent logs:');
+    for (const log of logs) {
+      console.log(`  ${log}`);
+    }
+
+    console.log(`\nAverage click time: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`);
+
+    // Count total DOM elements in the grid
+    const domCount = await page.evaluate(() => {
+      const grid = document.querySelector('.grid-container');
+      return grid ? grid.querySelectorAll('*').length : 0;
+    });
+    console.log(`Total DOM elements in grid: ${domCount}`);
+
+    const geneCellCount = await page.evaluate(() => {
+      return document.querySelectorAll('.gene-cell').length;
+    });
+    console.log(`Total gene cells: ${geneCellCount}`);
+  });
+
+  test('measure attribute filter in regular GeneVisualizer for comparison', async ({ page }) => {
+    await page.goto('/');
+    await waitForPets(page);
+
+    // Click first pet to open visualization
+    await page.locator('.pet-card').first().click();
+    await page.waitForTimeout(1000);
+
+    // Open stats drawer
+    const statsBtn = page.locator('.view-btn').filter({ hasText: 'Stats' });
+    if ((await statsBtn.count()) > 0) {
+      await statsBtn.click();
+      await page.waitForTimeout(500);
+    }
+
+    // Count gene cells
+    const geneCellCount = await page.evaluate(() => {
+      return document.querySelectorAll('.gene-cell').length;
+    });
+    console.log(`Regular GeneVisualizer gene cells: ${geneCellCount}`);
+
+    const domCount = await page.evaluate(() => {
+      const grid = document.querySelector('.gene-grid-container');
+      return grid ? grid.querySelectorAll('*').length : 0;
+    });
+    console.log(`Regular GeneVisualizer DOM elements in grid: ${domCount}`);
+
+    // Click an attribute row in the stats table to filter
+    const attrRows = page.locator('.attribute-row');
+    const rowCount = await attrRows.count();
+    console.log(`Stats table attribute rows: ${rowCount}`);
+
+    if (rowCount < 2) {
+      test.skip();
+      return;
+    }
+
+    const timings = [];
+    for (let clickNum = 0; clickNum < 3; clickNum++) {
+      const rowIndex = clickNum % rowCount;
+
+      await page.evaluate(() => {
+        window.__perfStart = performance.now();
+      });
+
+      await attrRows.nth(rowIndex).click();
+
+      await page.waitForTimeout(50);
+
+      const elapsed = await page.evaluate(() => {
+        return performance.now() - window.__perfStart;
+      });
+
+      timings.push(elapsed);
+      console.log(`Click ${clickNum + 1}: GeneVisualizer filter took ${elapsed.toFixed(1)}ms`);
+
+      // Click same row again to deselect
+      await attrRows.nth(rowIndex).click();
+      await page.waitForTimeout(50);
+    }
+
+    console.log(
+      `\nRegular GeneVisualizer average: ${(timings.reduce((a, b) => a + b, 0) / timings.length).toFixed(1)}ms`,
+    );
+  });
+});

--- a/tests/unit/comparisonService.test.js
+++ b/tests/unit/comparisonService.test.js
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { compareAttributes } from '$lib/services/comparisonService.js';
+
+const makePet = (overrides) => ({
+  id: 1,
+  name: 'TestPet',
+  species: 'BeeWasp',
+  gender: 'Male',
+  breed: '',
+  breeder: '',
+  content_hash: '',
+  genome_data: '',
+  notes: '',
+  tags: [],
+  created_at: '',
+  updated_at: '',
+  intelligence: 50,
+  toughness: 50,
+  friendliness: 50,
+  ruggedness: 50,
+  enthusiasm: 50,
+  virility: 50,
+  ferocity: 50,
+  temperament: 50,
+  ...overrides,
+});
+
+describe('Comparison Service', () => {
+  describe('compareAttributes', () => {
+    it('returns correct diffs for BeeWasp pets', () => {
+      const petA = makePet({ id: 1, name: 'Buzzy', intelligence: 80, toughness: 30 });
+      const petB = makePet({ id: 2, name: 'Stinger', intelligence: 60, toughness: 70 });
+
+      const results = compareAttributes(petA, petB);
+
+      // Should have 7 attributes for BeeWasp (6 core + ferocity)
+      expect(results.length).toBe(7);
+
+      const intel = results.find((r) => r.key === 'Intelligence');
+      expect(intel).toBeDefined();
+      expect(intel.petAValue).toBe(80);
+      expect(intel.petBValue).toBe(60);
+      expect(intel.diff).toBe(20);
+      expect(intel.winner).toBe('a');
+
+      const tough = results.find((r) => r.key === 'Toughness');
+      expect(tough).toBeDefined();
+      expect(tough.petAValue).toBe(30);
+      expect(tough.petBValue).toBe(70);
+      expect(tough.diff).toBe(-40);
+      expect(tough.winner).toBe('b');
+    });
+
+    it('returns tie for equal attributes', () => {
+      const petA = makePet({ id: 1, intelligence: 50 });
+      const petB = makePet({ id: 2, intelligence: 50 });
+
+      const results = compareAttributes(petA, petB);
+      const intel = results.find((r) => r.key === 'Intelligence');
+      expect(intel.winner).toBe('tie');
+      expect(intel.diff).toBe(0);
+    });
+
+    it('includes species-specific attributes for BeeWasp', () => {
+      const petA = makePet({ id: 1, ferocity: 80 });
+      const petB = makePet({ id: 2, ferocity: 40 });
+
+      const results = compareAttributes(petA, petB);
+      const ferocity = results.find((r) => r.key === 'Ferocity');
+      expect(ferocity).toBeDefined();
+      expect(ferocity.petAValue).toBe(80);
+      expect(ferocity.petBValue).toBe(40);
+      expect(ferocity.winner).toBe('a');
+    });
+
+    it('includes species-specific attributes for Horse', () => {
+      const petA = makePet({ id: 1, species: 'Horse', temperament: 90 });
+      const petB = makePet({ id: 2, species: 'Horse', temperament: 30 });
+
+      const results = compareAttributes(petA, petB);
+      const temperament = results.find((r) => r.key === 'Temperament');
+      expect(temperament).toBeDefined();
+      expect(temperament.winner).toBe('a');
+      expect(temperament.diff).toBe(60);
+    });
+
+    it('returns attribute info with name and icon', () => {
+      const petA = makePet({ id: 1 });
+      const petB = makePet({ id: 2 });
+
+      const results = compareAttributes(petA, petB);
+      const intel = results.find((r) => r.key === 'Intelligence');
+      expect(intel.name).toBe('Intelligence');
+      expect(intel.icon).toBe('🧠');
+    });
+  });
+});

--- a/tests/unit/comparisonStore.test.js
+++ b/tests/unit/comparisonStore.test.js
@@ -1,0 +1,164 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  compareSelectMode,
+  comparisonActions,
+  comparisonPets,
+  comparisonReady,
+  speciesMismatch,
+} from '$lib/stores/comparison.js';
+
+const fakeBee1 = { id: 1, name: 'Buzzy', species: 'BeeWasp' };
+const fakeBee2 = { id: 2, name: 'Stinger', species: 'BeeWasp' };
+const fakeHorse = { id: 3, name: 'Thunder', species: 'Horse' };
+
+describe('Comparison Store', () => {
+  beforeEach(() => {
+    comparisonActions.clear();
+    compareSelectMode.set(false);
+  });
+
+  describe('initial state', () => {
+    it('starts with both slots empty', () => {
+      const [a, b] = get(comparisonPets);
+      expect(a).toBeNull();
+      expect(b).toBeNull();
+    });
+
+    it('starts not ready', () => {
+      expect(get(comparisonReady)).toBe(false);
+    });
+
+    it('starts with no species mismatch', () => {
+      expect(get(speciesMismatch)).toBe(false);
+    });
+
+    it('starts with compare select mode off', () => {
+      expect(get(compareSelectMode)).toBe(false);
+    });
+  });
+
+  describe('addPet', () => {
+    it('fills slot 0 first when both empty', () => {
+      comparisonActions.addPet(fakeBee1);
+      const [a, b] = get(comparisonPets);
+      expect(a).toEqual(fakeBee1);
+      expect(b).toBeNull();
+    });
+
+    it('fills slot 1 second', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      const [a, b] = get(comparisonPets);
+      expect(a).toEqual(fakeBee1);
+      expect(b).toEqual(fakeBee2);
+    });
+
+    it('replaces slot 1 when both full', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      comparisonActions.addPet(fakeHorse);
+      const [a, b] = get(comparisonPets);
+      expect(a).toEqual(fakeBee1);
+      expect(b).toEqual(fakeHorse);
+    });
+  });
+
+  describe('setPet', () => {
+    it('sets a specific slot', () => {
+      comparisonActions.setPet(1, fakeBee2);
+      const [a, b] = get(comparisonPets);
+      expect(a).toBeNull();
+      expect(b).toEqual(fakeBee2);
+    });
+
+    it('can clear a slot with null', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.setPet(0, null);
+      const [a] = get(comparisonPets);
+      expect(a).toBeNull();
+    });
+  });
+
+  describe('removePet', () => {
+    it('clears the correct slot by ID', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      comparisonActions.removePet(fakeBee1.id);
+      const [a, b] = get(comparisonPets);
+      expect(a).toBeNull();
+      expect(b).toEqual(fakeBee2);
+    });
+
+    it('does nothing for unknown ID', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.removePet(999);
+      const [a] = get(comparisonPets);
+      expect(a).toEqual(fakeBee1);
+    });
+  });
+
+  describe('swapPets', () => {
+    it('swaps both slots', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      comparisonActions.swapPets();
+      const [a, b] = get(comparisonPets);
+      expect(a).toEqual(fakeBee2);
+      expect(b).toEqual(fakeBee1);
+    });
+  });
+
+  describe('clear', () => {
+    it('resets both slots', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      comparisonActions.clear();
+      const [a, b] = get(comparisonPets);
+      expect(a).toBeNull();
+      expect(b).toBeNull();
+    });
+  });
+
+  describe('comparisonReady', () => {
+    it('is false with one pet', () => {
+      comparisonActions.addPet(fakeBee1);
+      expect(get(comparisonReady)).toBe(false);
+    });
+
+    it('is true with two pets', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      expect(get(comparisonReady)).toBe(true);
+    });
+  });
+
+  describe('speciesMismatch', () => {
+    it('is false for same species', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeBee2);
+      expect(get(speciesMismatch)).toBe(false);
+    });
+
+    it('is true for different species', () => {
+      comparisonActions.addPet(fakeBee1);
+      comparisonActions.addPet(fakeHorse);
+      expect(get(speciesMismatch)).toBe(true);
+    });
+
+    it('is false with only one pet', () => {
+      comparisonActions.addPet(fakeBee1);
+      expect(get(speciesMismatch)).toBe(false);
+    });
+  });
+
+  describe('toggleSelectMode', () => {
+    it('toggles compare select mode', () => {
+      expect(get(compareSelectMode)).toBe(false);
+      comparisonActions.toggleSelectMode();
+      expect(get(compareSelectMode)).toBe(true);
+      comparisonActions.toggleSelectMode();
+      expect(get(compareSelectMode)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add full pet comparison feature with three views: attribute comparison, gene stats comparison, and chromosome-level genome diff
- Compare tab in top nav, pet picker sidebar, and selection mode in pet list
- Auto breed filter in genome diff respects the existing `horse.autoSelectBreedFilter` setting
- Code quality: extracted shared utilities (`getSpeciesEmoji`, `capitalize`, `geneAnalysis`, `filterCSS`), deduplicated genome loading, removed redundant derived state

## Test plan

- [x] Select two same-species pets and verify attribute comparison shows correct values and winners
- [x] Verify gene stats comparison loads and displays per-attribute breakdowns
- [x] Verify genome diff grid renders with chromosome-level diff and similarity percentage
- [x] Test Auto breed filter: with two same-breed horses it auto-selects; with different breeds it clears
- [ ] Toggle Auto off and verify manual breed buttons become enabled
- [ ] Test comparison selection mode from pet list (checkbox UI, 2-pet limit, species restriction)
- [ ] Verify different-species comparison shows mismatch warning and disables genome tabs
- [ ] Run `pnpm test:e2e` for new comparison E2E tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)