### PR TITLE
fix: approve esbuild build scripts for pnpm v10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
     "game-tool"
   ],
   "author": "Javier Lopez Pena",
-  "license": "MIT"
+  "license": "MIT",
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `pnpm.onlyBuiltDependencies` config to `package.json` to whitelist `esbuild` build scripts
- pnpm v10+ (used by `pnpm/action-setup@v6`) blocks build scripts by default, causing `ERR_PNPM_IGNORED_BUILDS` CI failures
- Once merged, dependabot's `pnpm/action-setup` v5→v6 PR will be able to pass CI after rebase

## Test plan
- [ ] CI passes on this PR (existing pnpm v9 is unaffected by this config)
- [ ] After merge, dependabot recreates the pnpm/action-setup v6 PR and CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)