### PR TITLE
fix: pin pnpm version to 10 in CI workflows

### DIFF
--- a/.chub/.gitignore
+++ b/.chub/.gitignore
@@ -1,0 +1,1 @@
+# .chub/ is git-tracked

--- a/.chub/annotations/playwright--playwright.yaml
+++ b/.chub/annotations/playwright--playwright.yaml
@@ -1,0 +1,8 @@
+id: playwright/playwright
+notes: []
+issues: []
+fixes: []
+practices:
+- author: jlopezpena
+  date: 2026-04-16
+  note: 'E2E tests require copying test assets first: `mkdir -p src/static/assets src/static/data && cp -r assets/* src/static/assets/ && cp -r data/* src/static/data/`. Run with `pnpm test:e2e`. Every new feature must include tests.'

--- a/.chub/annotations/svelte--svelte.yaml
+++ b/.chub/annotations/svelte--svelte.yaml
@@ -1,0 +1,8 @@
+id: svelte/svelte
+notes: []
+issues: []
+fixes: []
+practices:
+- author: jlopezpena
+  date: 2026-04-16
+  note: This project uses Svelte 5 with SvelteKit and static adapter for a Tauri desktop app. No Tailwind — use plain CSS + Svelte scoped styles. Biome is the linter (not ESLint).

--- a/.chub/annotations/vite--vite.yaml
+++ b/.chub/annotations/vite--vite.yaml
@@ -1,0 +1,12 @@
+id: vite/vite
+notes: []
+issues:
+- author: jlopezpena
+  date: 2026-04-16
+  note: 'pnpm v11 removed `onlyBuiltDependencies` in favor of `allowBuilds` in pnpm-workspace.yaml. Never use `version: latest` for pnpm in CI — pin to major version (currently 10). See issue #133 for v11 migration plan. ERR_PNPM_IGNORED_BUILDS means esbuild build scripts are blocked.'
+  severity: high
+fixes:
+- author: jlopezpena
+  date: 2026-04-16
+  note: 'When dependabot PRs fail CI, never close them — dependabot won''t recreate. Instead: (1) diagnose root cause from CI logs, (2) create separate fix PR, (3) merge fix, (4) comment `@dependabot rebase`. Also: always grep CI logs for exact tool versions before debugging — `version: latest` can silently resolve to a new major.'
+practices: []

--- a/.chub/annotations/vitest--vitest.yaml
+++ b/.chub/annotations/vitest--vitest.yaml
@@ -1,0 +1,8 @@
+id: vitest/vitest
+notes: []
+issues: []
+fixes: []
+practices:
+- author: jlopezpena
+  date: 2026-04-16
+  note: Project uses vitest for unit tests alongside Playwright for E2E. Run `pnpm test` for unit tests, `pnpm test:e2e` for E2E. Biome handles linting (`pnpm lint:ci`), not ESLint.

--- a/.chub/config.yaml
+++ b/.chub/config.yaml
@@ -1,0 +1,25 @@
+# Chub project configuration
+# This file is shared with the team via git.
+# It overrides personal settings in ~/.chub/config.yaml.
+
+# sources:
+#   - name: official
+#     url: https://cdn.aichub.org/v1
+#   - name: company
+#     url: https://docs.internal.company.com/chub
+
+# Agent rules for generating CLAUDE.md, .cursorrules, etc.
+# agent_rules:
+#   global:
+#     - "Follow the project coding conventions"
+#   modules: {}
+#   include_pins: true          # list pinned docs so agents know what to fetch
+#   include_context: true       # list project context docs so agents know what to fetch
+#   include_annotation_policy: true  # add standing instructions for agents to write annotations
+#   targets:
+#     - claude.md
+
+# annotation_server:
+#   url: https://annotations.internal.company.com
+#   auto_push: false  # set true to mirror team writes to org tier
+#   cache_ttl_secs: 3600

--- a/.chub/config.yaml
+++ b/.chub/config.yaml
@@ -1,25 +1,17 @@
 # Chub project configuration
 # This file is shared with the team via git.
-# It overrides personal settings in ~/.chub/config.yaml.
-
-# sources:
-#   - name: official
-#     url: https://cdn.aichub.org/v1
-#   - name: company
-#     url: https://docs.internal.company.com/chub
 
 # Agent rules for generating CLAUDE.md, .cursorrules, etc.
-# agent_rules:
-#   global:
-#     - "Follow the project coding conventions"
-#   modules: {}
-#   include_pins: true          # list pinned docs so agents know what to fetch
-#   include_context: true       # list project context docs so agents know what to fetch
-#   include_annotation_policy: true  # add standing instructions for agents to write annotations
-#   targets:
-#     - claude.md
-
-# annotation_server:
-#   url: https://annotations.internal.company.com
-#   auto_push: false  # set true to mirror team writes to org tier
-#   cache_ttl_secs: 3600
+agent_rules:
+  global:
+    - "Follow AGENTS.md for architecture and code standards"
+    - "Use Svelte 5 runes ($props, $state, $derived, $effect) — not legacy reactive syntax"
+    - "All data access through src/lib/services/ — never raw SQL in components"
+    - "Plain CSS + Svelte scoped styles — no Tailwind, no CSS frameworks"
+    - "Biome for linting (not ESLint) — must be fully clean before committing"
+    - "Pin pnpm to major version in CI — never use version: latest"
+    - "Every new feature must include E2E tests"
+  modules: {}
+  include_pins: true
+  include_context: true
+  include_annotation_policy: true

--- a/.chub/context/architecture.md
+++ b/.chub/context/architecture.md
@@ -1,0 +1,9 @@
+---
+name: Project Architecture
+description: "High-level architecture overview"
+tags: architecture
+---
+
+# Architecture Overview
+
+Describe your project architecture here.

--- a/.chub/context/architecture.md
+++ b/.chub/context/architecture.md
@@ -1,9 +1,57 @@
 ---
 name: Project Architecture
-description: "High-level architecture overview"
-tags: architecture
+description: "Gorgonetics app architecture — Tauri v2 + SvelteKit 5 + TypeScript services + SQLite"
+tags: architecture, tauri, svelte, typescript
 ---
 
 # Architecture Overview
 
-Describe your project architecture here.
+Gorgonetics is a Tauri v2 desktop app for genetic breeding analysis in Project Gorgon.
+
+## Layer Diagram
+
+```
+Frontend (Svelte 5 + SvelteKit)
+├── Routes (+layout.svelte, +page.svelte)
+├── Components (pet/, gene/, comparison/, layout/)
+└── Stores (pets.ts, settings.ts, comparison.ts)
+
+Service Layer (TypeScript)
+├── Database access (database.ts — Tauri adapter + in-memory fallback)
+├── Business logic (petService, geneService, comparisonService, etc.)
+└── Utilities (parsing, analysis, configuration)
+
+Tauri Backend (Rust — minimal)
+└── Plugin registration (sql, dialog, fs, updater, process)
+
+SQLite Database (gorgonetics.db)
+└── Tables: genes, pets, pet_images, pet_tags, settings
+```
+
+## Key Data Flows
+
+1. **App startup:** AuthWrapper → `initDatabase()` → `runMigrations()` → `populateGenesIfNeeded()` → `loadDemoPetsIfNeeded()` → `settingsActions.load()`
+2. **Pet upload:** File dialog (Tauri) → genome text parsing → SHA-256 content hash → DB insert
+3. **Gene visualization:** Select species/chromosome → load gene effects (cached) → render interactive color-coded grid
+4. **Pet comparison:** Select two pets → load genomes in parallel (`Promise.all`) → compute attribute diffs + gene stats → side-by-side render
+5. **Export/import:** Select options → ZIP archive (JSZip) → file save dialog; imports support `replace` or `merge` mode with dedup by content_hash
+
+## Database Access Pattern
+
+- **Adapter interface:** `DatabaseAdapter` with `TauriDatabaseAdapter` (production) and `InMemoryDatabase` (tests)
+- **Named parameters:** All queries use `$name` syntax — adapter converts to positional `?` for SQLite
+- **Singleton:** `getDb()` returns the initialized adapter; `initDatabase()` called once in AuthWrapper
+- **Auto-detection:** `isTauri()` check selects the adapter — no config needed
+
+## State Management
+
+- **Svelte stores:** Writable stores for `pets`, `selectedPet`, `loading`, `error`, `activeTab`
+- **Derived stores:** `allTags` computed from pets array
+- **Centralized actions:** `appState` object (loadPets, deletePet, uploadPet, etc.)
+- **Component-level:** Svelte 5 runes (`$props()`, `$state()`, `$derived()`, `$effect()`)
+
+## Master-Detail Layout
+
+- **MasterPanel** (left, 260px): PetList or GeneEditor based on active tab
+- **DetailPane** (right, flex): PetVisualization or GeneEditingView based on selection
+- Navigation driven by store state: `selectedPet`, `geneEditingView`, `activeTab`

--- a/.chub/context/ci-cd.md
+++ b/.chub/context/ci-cd.md
@@ -1,0 +1,72 @@
+---
+name: CI/CD & Release
+description: "CI workflows, release process, build matrix, and version sync requirements"
+tags: ci, cd, release, github-actions
+---
+
+# CI/CD & Release
+
+## CI Workflows
+
+### ci.yml (Push to main/develop, PRs)
+Three parallel jobs:
+1. **frontend-quality:** `pnpm lint:ci` (Biome, zero tolerance) + `pnpm build`
+2. **e2e-tests:** Copy test assets → `pnpm test:e2e` (Playwright)
+3. **rust-check:** `cargo check` in src-tauri/
+
+### integration.yml (Push to main/develop, PRs)
+Single job running E2E tests with asset copying.
+
+### release.yml (Tag push `v*` or manual dispatch)
+Build matrix:
+| Platform | Target | Output |
+|----------|--------|--------|
+| macOS (latest) | aarch64-apple-darwin | .app + .dmg |
+| Ubuntu 24.04 | x86_64-unknown-linux-gnu | .deb + .AppImage |
+| Windows (latest) | x86_64-pc-windows-msvc | NSIS installer |
+
+Uses `tauri-apps/tauri-action@v0` with signing keys from GitHub secrets.
+
+### pages.yml
+Deploys docs/ site on release publish.
+
+## CI Requirements
+
+- **pnpm version:** Pinned to major version 10 (not `latest` — v11 breaks `onlyBuiltDependencies`)
+- **Asset copying:** CI must run `cp -r assets/* src/static/assets/ && cp -r data/* src/static/data/` before E2E tests
+- **Biome strictness:** Zero errors, zero warnings, zero infos
+
+## Release Process
+
+```bash
+pnpm release patch   # or: minor, major
+```
+
+The `scripts/release.sh` script:
+1. Bumps version in package.json, tauri.conf.json, Cargo.toml, docs/index.html
+2. Runs `pnpm screenshots` (starts dev server, captures screenshots, kills server)
+3. Runs `pnpm lint:ci` + `pnpm test:e2e`
+4. Generates changelog from git log since last tag
+5. Commits, creates **annotated** tag (lightweight tags won't trigger release workflow)
+6. Pushes — triggers release workflow
+7. **Manual step:** Edit draft release on GitHub and publish
+
+## Version Sync
+
+These files must always have matching version strings:
+- `package.json`
+- `src-tauri/tauri.conf.json`
+- `src-tauri/Cargo.toml`
+- `docs/index.html`
+
+The release script handles this automatically. Manual edits must update all four.
+
+## Cross-Compilation (Windows from macOS)
+
+```bash
+brew install nsis llvm
+rustup target add x86_64-pc-windows-msvc
+cargo install --locked cargo-xwin
+pnpm tauri:build:windows
+```
+First build downloads Windows SDK (~1 GB, cached). Produces NSIS installer only.

--- a/.chub/context/data-model.md
+++ b/.chub/context/data-model.md
@@ -1,0 +1,78 @@
+---
+name: Data Model
+description: "Database schema, species config, gene/genome structures, and migration history"
+tags: database, schema, genes, species
+---
+
+# Data Model
+
+## Database Schema (SQLite)
+
+```sql
+-- Gene effect definitions per species (loaded from bundled JSON templates)
+genes (animal_type, chromosome, gene [PK], effectDominant, effectRecessive,
+       appearance, breed, notes, created_at, updated_at)
+
+-- Pet records with genome data stored as JSON
+pets (id [PK], name, species, gender, breed, breeder, content_hash [UNIQUE],
+      genome_data [JSON], notes, created_at, updated_at, sort_order,
+      intelligence, toughness, friendliness, ruggedness, enthusiasm,
+      virility, ferocity, temperament)
+
+-- Pet image gallery
+pet_images (id [PK], pet_id [FK→pets], filename, original_name, caption,
+            tags [JSON], created_at, sort_order)
+
+-- Tag junction table (migrated from JSON column in v7)
+pet_tags (id [PK], pet_id [FK→pets], tag [UNIQUE composite with pet_id])
+
+-- User preferences (key-value store)
+settings (key [PK], value, updated_at)
+```
+
+## Migration History (PRAGMA user_version)
+
+| Version | Change |
+|---------|--------|
+| v1 | Baseline: genes + pets tables |
+| v2 | Add settings table |
+| v3 | Add pet_images table |
+| v4 | Add sort_order to pets (drag-and-drop) |
+| v5 | Add sort_order to pet_images + index |
+| v6 | Add tags column to pets (legacy JSON) |
+| v7 | Create pet_tags junction table + migrate from JSON |
+
+## Species Configuration
+
+| Species | Chromosomes | Unique Attribute | Core Attributes |
+|---------|------------|------------------|-----------------|
+| BeeWasp | 10 | Ferocity | Toughness, Ruggedness, Enthusiasm, Friendliness, Intelligence, Virility |
+| Horse | 48 | Temperament | Toughness, Ruggedness, Enthusiasm, Friendliness, Intelligence, Virility |
+
+All attributes default to 50. Species are extensible via `configService.ts`.
+
+## Gene/Genome Types
+
+```typescript
+interface Gene {
+  chromosome: string;      // "chr01", "chr02", ...
+  block: string;           // "A", "B", ..., "Z", "AA", ...
+  position: number;        // 1-indexed within block
+  gene_type: GeneType;     // "R" (recessive) | "D" (dominant) | "x" (mixed) | "?" (unknown)
+}
+
+interface Genome {
+  format_version: string;
+  breeder: string;
+  name: string;
+  genome_type: string;     // Species name
+  genes: Record<string, Gene[]>;  // Key: chromosome ID
+}
+```
+
+## Gene Visualization
+
+- **Grid:** Chromosome → Blocks (A–Z, AA–...) → Positions (1–N genes per position)
+- **Effect lookup:** Query cached gene effects DB → classify positive/negative/neutral → color-code
+- **Appearance:** Map effect text to category (e.g., "Body Color Hue" → `--gene-body-hue`)
+- **Views:** Attribute view (stats table) and Appearance view (color grid)

--- a/.chub/context/gotchas.md
+++ b/.chub/context/gotchas.md
@@ -1,0 +1,58 @@
+---
+name: Gotchas & Non-Obvious Behaviors
+description: "Things that will trip you up if you don't know about them"
+tags: gotchas, debugging, pitfalls
+---
+
+# Gotchas & Non-Obvious Behaviors
+
+## Database
+
+- **Named parameters only:** All queries use `$name` syntax, not `?`. The adapter converts these. Using `?` directly breaks queries.
+- **In-memory DB limitations:** The test fallback supports basic CRUD but has constraints:
+  - `ORDER BY` column refs must not use table prefixes (strips `pi.created_at` → `created_at`)
+  - `WHERE` conditions only support `=` equality, not `<`, `>`, `LIKE`
+  - `LIMIT/OFFSET` parsing counts `?` manually to find param offsets
+- **Species normalization:** `normalizeSpecies()` lowercases species strings. All config lookups assume lowercase. Mismatch causes silent missing effects.
+
+## Asset Protocol (Tauri)
+
+Serving local files via `convertFileSrc()` requires **BOTH** in `tauri.conf.json`:
+1. CSP: `img-src` must include `asset: http://asset.localhost`
+2. `app.security.assetProtocol` must have `enable: true` + scope array
+
+Missing either causes **silent failure** — broken images, no error in console.
+
+## Gene Templates
+
+- **Built-in path:** `resources/assets/beewasp/file.json`
+- **Browser dev path:** `/assets/beewasp/file.json` (strips `resources/`)
+- **CI path:** `src/static/assets/` (copied from `assets/` in CI step)
+- Using wrong path silently fails — no gene data, no error
+
+## Gene Effects Caching
+
+`getGeneEffectsCached()` loads effects once per species and caches in memory. Fast after first load, but no cache invalidation — restart required after gene data changes.
+
+## Content Hash Deduplication
+
+Pet `content_hash` is SHA-256 of genome text. Computed on upload, used to reject duplicate imports. The hash, not the name, determines uniqueness.
+
+## CI/CD
+
+- **pnpm version:** `version: latest` in CI resolves to pnpm v11 which removed `onlyBuiltDependencies`. Pin to `version: 10`.
+- **E2E asset copying is critical:** If CI doesn't copy `assets/` and `data/` to `src/static/`, demo pets won't load and tests fail silently.
+- **Annotated tags only:** Release script uses `git tag -a`. Lightweight tags won't trigger the release workflow.
+- **Release requires clean main:** Script exits with error if not on main or if working directory is dirty.
+- **Dependabot PRs:** Never close them — dependabot won't recreate. Fix underlying issues in a separate PR, merge, then `@dependabot rebase`.
+
+## Styling
+
+- **No Tailwind:** Plain CSS + Svelte scoped styles. CSS frameworks are not used.
+- **Biome is strict:** Must pass with zero errors, zero warnings, zero infos. Even style suggestions block commits.
+- **Dark mode:** `[data-theme="dark"]` CSS selector overrides custom properties. Theme respects OS preference, overridable in settings.
+
+## Svelte 5
+
+- Components use runes (`$props()`, `$state()`, `$derived()`, `$effect()`) — not legacy reactive syntax (`$:`, `export let`)
+- Breaking change from Svelte 4 — old patterns silently fail or produce warnings

--- a/.chub/context/styling.md
+++ b/.chub/context/styling.md
@@ -1,0 +1,59 @@
+---
+name: Styling & Theming
+description: "CSS approach, theme tokens, gene colors, and accessibility patterns"
+tags: css, theming, accessibility, design
+---
+
+# Styling & Theming
+
+## Approach
+
+Plain CSS with Svelte scoped `<style>` blocks. No Tailwind, no CSS frameworks. Shared classes live in `src/app.css`.
+
+## Theme System (CSS Custom Properties)
+
+Defined in `src/app.css` with light mode defaults and `[data-theme="dark"]` overrides.
+
+### Token Categories
+
+| Category | Examples |
+|----------|---------|
+| Surfaces | `--bg-primary`, `--bg-secondary`, `--bg-tertiary`, `--bg-hover`, `--bg-selected`, `--bg-overlay` |
+| Text | `--text-primary`, `--text-secondary`, `--text-tertiary`, `--text-muted`, `--text-inverse` |
+| Borders | `--border-primary`, `--border-secondary`, `--border-focus` |
+| Accent | `--accent`, `--accent-hover`, `--accent-soft` |
+| Status | `--error`, `--success`, `--warning` (with `-text`, `-bg`, `-border` variants) |
+| Shadows | `--shadow-sm`, `--shadow-md`, `--shadow-lg`, `--shadow-xl` |
+
+### Global Component Classes
+
+- Buttons: `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-danger`
+- Dialogs: `.dialog`, `.dialog-header`, `.dialog-body`, `.dialog-footer`, `.close-btn`
+- Forms: `.checkbox-row`, `.checkbox-label`, `.checkbox-desc`
+- States: `.loading`, `.error`, `.success`
+
+## Gene Colors
+
+Canonical source: `src/lib/theme/gene-colors.ts`, mirrored in CSS for grid rendering.
+
+| Type | Color |
+|------|-------|
+| Positive effect | #4caf50 (green) |
+| Negative effect | #f44336 (red) |
+| Neutral effect | #95a5a6 (gray) |
+
+Appearance colors are per-species mappings (BeeWasp: body-hue, wing-hue; Horse: coat, markings, etc.).
+
+## Dark Mode
+
+- Detects OS preference via `prefers-color-scheme`
+- User override persisted in `settings` table
+- `[data-theme="dark"]` selector overrides all CSS custom properties
+
+## Accessibility
+
+- `:focus-visible` outline on all interactive elements
+- Skip-to-content link (`.skip-link`)
+- Focus trapping in modals via `focusTrap.ts` utility
+- Semantic HTML + ARIA role attributes
+- Layout uses CSS Grid + Flexbox (no table-based layouts)

--- a/.chub/context/testing.md
+++ b/.chub/context/testing.md
@@ -1,0 +1,56 @@
+---
+name: Testing Strategy
+description: "E2E test structure, helpers, database setup, and CI integration"
+tags: testing, playwright, vitest, e2e
+---
+
+# Testing Strategy
+
+## E2E Tests (Playwright)
+
+- **Location:** `tests/e2e/` (10 spec files, ~30 tests)
+- **Config:** `playwright.config.js` — `baseURL: http://localhost:5174`, auto-starts `pnpm dev`
+- **Execution:** Sequential (`fullyParallel: false`), 1 retry on failure
+- **Browser:** Chromium only
+- **Reports:** HTML report (never auto-opened), screenshots on failure only
+
+### Helpers
+
+```javascript
+waitForAppReady()   // Waits for loading screen to disappear
+waitForPets()       // Waits for pet list to populate
+openGeneEditor()    // Navigates to gene editor tab
+openEditor()        // Opens pet editor modal
+```
+
+### Database in Tests
+
+Tests use the in-memory database fallback (no Tauri dependency). Demo data (Sample Fae Bee, Sample Horse) is auto-loaded by `demoService` on startup.
+
+### Asset Requirements
+
+CI must copy assets before running tests:
+```bash
+mkdir -p src/static/assets src/static/data
+cp -r assets/* src/static/assets/
+cp -r data/* src/static/data/
+```
+
+Without this, gene templates and demo genomes won't load — tests fail silently with empty data.
+
+## Unit Tests (Vitest)
+
+- **Location:** `tests/unit/`
+- **Run:** `pnpm test` (Vitest)
+- **Database:** Uses `InMemoryDatabase` adapter directly
+- **Coverage:** Service layer functions (parsing, comparison, stats)
+
+## Quality Gates (CI enforced)
+
+```bash
+pnpm lint:ci        # Biome — zero diagnostics (errors + warnings + infos)
+cargo check         # Rust compilation (from src-tauri/)
+pnpm test:e2e       # Playwright E2E
+```
+
+All three must pass before merging.

--- a/.chub/pins.yaml
+++ b/.chub/pins.yaml
@@ -1,0 +1,13 @@
+pins:
+- id: svelte/svelte
+  lang: javascript
+- id: playwright/playwright
+  lang: javascript
+- id: jest/jest
+  lang: javascript
+- id: vite/vite
+  lang: javascript
+- id: typescript/jsdom
+  lang: javascript
+- id: vitest/vitest
+  lang: javascript

--- a/.chub/profiles/base.yaml
+++ b/.chub/profiles/base.yaml
@@ -1,4 +1,13 @@
 name: Base
-description: "Shared rules for all roles"
-rules: []
-context: []
+description: "Shared rules for all roles working on Gorgonetics"
+rules:
+  - "Read AGENTS.md before making changes"
+  - "Run pnpm lint:ci and pnpm test:e2e before committing"
+  - "Use $lib/ import alias for all internal imports"
+  - "Database access only through service layer (src/lib/services/)"
+  - "Check chub annotations before working with pinned dependencies"
+context:
+  - architecture.md
+  - data-model.md
+  - ci-cd.md
+  - gotchas.md

--- a/.chub/profiles/base.yaml
+++ b/.chub/profiles/base.yaml
@@ -1,0 +1,4 @@
+name: Base
+description: "Shared rules for all roles"
+rules: []
+context: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -44,7 +44,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -93,7 +93,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,30 @@ data/                   # Sample genome text files
 tests/e2e/              # Playwright E2E tests
 ```
 
+## Context Hub (chub)
+
+This project uses [chub](https://chub.nrl.ai) for shared AI context — pinned docs, annotations, and lessons learned.
+
+### Mandatory: Keep chub annotations up to date
+
+When working in this codebase, proactively maintain chub annotations:
+
+- **After discovering a bug or gotcha** with a dependency: `chub annotate <doc-id> --kind issue`
+- **After finding a workaround**: `chub annotate <doc-id> --kind fix`
+- **After validating a useful pattern**: `chub annotate <doc-id> --kind practice`
+
+Before starting work, check existing annotations for relevant context:
+```bash
+chub context --task "your task description"
+```
+
+When adding new dependencies, pin their docs:
+```bash
+chub detect --pin
+```
+
+Do not wait to be asked — treat annotation maintenance the same as running lint before committing.
+
 ## Species & Data
 
 - **Beewasp**: 10 chromosomes, attributes: Ferocity + 6 core


### PR DESCRIPTION
## Summary
- Pins `pnpm` version from `latest` to `10` in all CI workflows (ci, integration, release)
- `version: latest` now resolves to pnpm v11 which removed `onlyBuiltDependencies` in favor of `allowBuilds`, causing `ERR_PNPM_IGNORED_BUILDS` CI failures
- Once merged, dependabot's pnpm/action-setup v5→v6 PR (#121) should pass CI after rebase

## Related
- #133 — tracks the full pnpm v11 migration

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, ask dependabot to rebase #121 and verify it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)