### PR TITLE
feat(compare): appearance view toggle with per-category filter

### DIFF
--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -12,11 +12,18 @@ const {
   selectedAttributes,
   hiddenAttributes,
   attributeDisplayInfo,
+  selectedAppearances = [],
+  hiddenAppearances = [],
+  appearanceDisplayInfo = [],
+  currentView = 'attribute',
   onBreedChange,
   onAutoBreedToggle,
   onAttributeToggle,
+  onAppearanceToggle,
   onDiffsOnlyChange,
   onResetAttributes,
+  onResetAppearances,
+  onViewChange,
 } = $props();
 </script>
 
@@ -24,6 +31,10 @@ const {
     <div class="diff-summary">
         <span class="similarity-badge">{summary.similarityPercent}% identical</span>
         <span class="summary-detail">{summary.identicalGenes}/{summary.totalGenes} genes match · {summary.differentGenes} diff</span>
+        <div class="view-toggle">
+            <button class="view-btn" class:active={currentView === 'attribute'} onclick={() => onViewChange('attribute')}>Attributes</button>
+            <button class="view-btn" class:active={currentView === 'appearance'} onclick={() => onViewChange('appearance')}>Appearance</button>
+        </div>
         <label class="diff-toggle">
             <input type="checkbox" checked={showDiffsOnly} onchange={(e) => onDiffsOnlyChange(e.target.checked)} />
             Differences only
@@ -36,25 +47,43 @@ const {
                 <button class="breed-btn auto-btn" class:active={autoBreed} onclick={onAutoBreedToggle} title={petsShareBreed ? "Auto-select pets' breed" : "Pets have different breeds"}>Auto</button>
                 <span class="breed-divider"></span>
             {/if}
-            <button class="breed-btn" class:active={!autoBreed && breedFilter === ''} disabled={autoBreed} onclick={() => onBreedChange('')}>All</button>
+            <button class="breed-btn" class:active={(!autoBreed || !petsHaveKnownBreed) && breedFilter === ''} disabled={autoBreed && petsHaveKnownBreed} onclick={() => onBreedChange('')}>All</button>
             {#each Object.entries(HORSE_BREEDS) as [name, abbrev]}
-                <button class="breed-btn" class:active={!autoBreed && breedFilter === name} disabled={autoBreed} onclick={() => onBreedChange(name)} title={name}>{abbrev}</button>
+                <button class="breed-btn" class:active={(!autoBreed || !petsHaveKnownBreed) && breedFilter === name} disabled={autoBreed && petsHaveKnownBreed} onclick={() => onBreedChange(name)} title={name}>{abbrev}</button>
             {/each}
         </div>
     {/if}
-    <div class="attribute-filter">
-        <span class="attr-filter-label">Attribute:</span>
-        <button class="attr-filter-btn" class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0} onclick={onResetAttributes}>All</button>
-        {#each attributeDisplayInfo as attr (attr.key)}
-            <button
-                class="attr-filter-btn"
-                class:active={selectedAttributes.includes(attr.key)}
-                class:hidden-attr={hiddenAttributes.includes(attr.key)}
-                onclick={(e) => onAttributeToggle(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
-                title="{attr.name}"
-            >{attr.icon} {attr.name}</button>
-        {/each}
-    </div>
+    {#if currentView === 'attribute'}
+        <div class="attribute-filter">
+            <span class="attr-filter-label">Attribute:</span>
+            <button class="attr-filter-btn" class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0} onclick={onResetAttributes}>All</button>
+            {#each attributeDisplayInfo as attr (attr.key)}
+                <button
+                    class="attr-filter-btn"
+                    class:active={selectedAttributes.includes(attr.key)}
+                    class:hidden-attr={hiddenAttributes.includes(attr.key)}
+                    onclick={(e) => onAttributeToggle(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
+                    title="{attr.name}"
+                >{attr.icon} {attr.name}</button>
+            {/each}
+        </div>
+    {/if}
+    {#if currentView === 'appearance' && appearanceDisplayInfo.length > 0}
+        <div class="attribute-filter appearance-filter">
+            <span class="attr-filter-label">Appearance:</span>
+            <button class="attr-filter-btn" class:active={selectedAppearances.length === 0 && hiddenAppearances.length === 0} onclick={onResetAppearances}>All</button>
+            {#each appearanceDisplayInfo as ap (ap.key)}
+                <button
+                    class="attr-filter-btn appearance-btn"
+                    class:active={selectedAppearances.includes(ap.key)}
+                    class:hidden-attr={hiddenAppearances.includes(ap.key)}
+                    style:--ap-color={ap.color_indicator}
+                    onclick={(e) => onAppearanceToggle(ap.key, e.ctrlKey || e.metaKey, e.altKey)}
+                    title="{ap.name}{ap.examples ? ' — ' + ap.examples : ''}"
+                ><span class="ap-swatch"></span>{ap.name}</button>
+            {/each}
+        </div>
+    {/if}
 </div>
 
 <div class="grid-instructions">Click chromosome labels to filter · Ctrl+click to multi-select · Alt+click to hide</div>
@@ -64,8 +93,14 @@ const {
     .diff-summary { display: flex; align-items: center; gap: 12px; padding: 10px 16px; background: var(--bg-secondary); border-radius: 8px; flex-wrap: wrap; }
     .similarity-badge { font-size: 14px; font-weight: 700; color: var(--text-primary); padding: 4px 10px; background: var(--bg-tertiary); border-radius: 10px; }
     .summary-detail { font-size: 12px; color: var(--text-secondary); }
-    .diff-toggle { margin-left: auto; display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
+    .diff-toggle { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
     .diff-toggle input { cursor: pointer; }
+
+    .view-toggle { margin-left: auto; display: inline-flex; border: 1px solid var(--border-primary); border-radius: 4px; overflow: hidden; }
+    .view-btn { padding: 3px 10px; border: none; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
+    .view-btn + .view-btn { border-left: 1px solid var(--border-primary); }
+    .view-btn:hover { color: var(--text-secondary); }
+    .view-btn.active { background: var(--accent); color: white; }
 
     .breed-filter { display: flex; align-items: center; gap: 3px; padding: 0 4px; }
     .breed-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
@@ -82,6 +117,10 @@ const {
     .attr-filter-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
     .attr-filter-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
     .attr-filter-btn.hidden-attr { background: var(--error-bg); border-color: var(--error-border); color: var(--error-text); text-decoration: line-through; }
+
+    .appearance-filter { margin-top: 2px; }
+    .appearance-btn { display: inline-flex; align-items: center; gap: 5px; }
+    .ap-swatch { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--ap-color, #6b7280); border: 1px solid rgba(0, 0, 0, 0.2); }
 
     .grid-instructions { font-size: 11px; color: var(--text-tertiary); margin-bottom: 6px; font-style: italic; padding: 0 4px; }
 </style>

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -2,13 +2,18 @@
 import { onDestroy, onMount } from 'svelte';
 import GenomeDiffControls from '$lib/components/comparison/GenomeDiffControls.svelte';
 import GeneTooltip from '$lib/components/gene/GeneTooltip.svelte';
-import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import {
+  getAppearanceAttributes,
+  getAppearanceConfig,
+  getAttributeConfig,
+  normalizeSpecies,
+} from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
-import { blockLetter } from '$lib/services/genomeParser.js';
 import { getPetGenome } from '$lib/services/petService.js';
 import { settings } from '$lib/stores/settings.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { breedFor, effectFor, isNoEffect, parseGenesByBlock } from '$lib/utils/geneAnalysis.js';
 import { capitalize } from '$lib/utils/string.js';
 
 const { petA, petB } = $props();
@@ -17,6 +22,7 @@ let loading = $state(false);
 let error = $state(null);
 let summary = $state(null);
 let showDiffsOnly = $state(false);
+let currentView = $state('attribute');
 
 let effectsDB = {};
 let speciesKey = $state('');
@@ -28,6 +34,8 @@ let blockIndices = $state({});
 
 let allAttributeNames = [];
 let attributeDisplayInfo = $state([]);
+let appearanceDisplayInfo = $state([]);
+let appearanceLookup = new Map();
 
 let chromosomeRows = $state([]);
 let chrBreedRelevance = {};
@@ -39,6 +47,8 @@ let selectedChromosomes = $state([]);
 let hiddenChromosomes = $state([]);
 let selectedAttributes = $state([]);
 let hiddenAttributes = $state([]);
+let selectedAppearances = $state([]);
+let hiddenAppearances = $state([]);
 
 // Auto-breed: use the shared setting and detect from pets' breeds
 const petsHaveKnownBreed = $derived(
@@ -110,6 +120,8 @@ $effect(() => {
   filterStyleEl.textContent = buildFilterCSS({
     selectedAttributes,
     hiddenAttributes,
+    selectedAppearances,
+    hiddenAppearances,
     breedFilter,
     selectedChromosomes,
     hiddenChromosomes,
@@ -128,6 +140,8 @@ async function loadData() {
     hiddenChromosomes = [];
     selectedAttributes = [];
     hiddenAttributes = [];
+    selectedAppearances = [];
+    hiddenAppearances = [];
 
     speciesKey = normalizeSpecies(petA.species);
     const [genomeA, genomeB, efData] = await Promise.all([
@@ -143,8 +157,15 @@ async function loadData() {
     allAttributeNames = config.all_attribute_names.map((n) => capitalize(n));
     attributeDisplayInfo = config.attributes;
 
-    const parsedA = parseGenes(genomeA.genes);
-    const parsedB = parseGenes(genomeB.genes);
+    const apConfig = getAppearanceConfig(speciesKey);
+    appearanceDisplayInfo = apConfig.appearance_attributes.map((a) => ({
+      ...a,
+      key: a.key.replace(/_/g, '-'),
+    }));
+    appearanceLookup = buildAppearanceLookup(speciesKey);
+
+    const parsedA = parseGenesByBlock(genomeA.genes);
+    const parsedB = parseGenesByBlock(genomeB.genes);
 
     const allBlks = new Set();
     const maxGenes = new Map();
@@ -242,82 +263,62 @@ async function loadData() {
   }
 }
 
-/** Build a cell object with pre-computed static CSS class string */
+/** Build a cell object with pre-computed static CSS class strings for both views. */
 function makeCell(gene) {
   const analysis = analyzeGene(gene.id, gene.type);
-  let cls = 'gene-cell gene-' + analysis.effectType + ' ';
-  if (gene.type === '?') cls = 'gene-cell gene-neutral gene-unknown';
-  else if (gene.type === 'D') cls += 'gene-dominant';
-  else if (gene.type === 'R') cls += 'gene-recessive';
-  else if (gene.type === 'x') cls += 'gene-mixed';
-  else cls += 'gene-recessive';
+  const appearance = categorizeAppearance(gene.id);
+
+  let zygosity;
+  if (gene.type === 'D') zygosity = 'gene-dominant';
+  else if (gene.type === 'R') zygosity = 'gene-recessive';
+  else if (gene.type === 'x') zygosity = 'gene-mixed';
+  else zygosity = 'gene-recessive';
+
+  const attributeCls =
+    gene.type === '?' ? 'gene-cell gene-neutral gene-unknown' : `gene-cell gene-${analysis.effectType} ${zygosity}`;
+  const appearanceCls =
+    gene.type === '?'
+      ? 'gene-cell gene-neutral gene-unknown'
+      : `gene-cell gene-${appearance || 'appearance-neutral'} ${zygosity}`;
 
   return {
     id: gene.id,
     type: gene.type,
-    cssClass: cls,
+    attributeCls,
+    appearanceCls,
     attribute: analysis.attribute || '',
+    appearance,
     breed: analysis.breed || '',
     effect: analysis.effect || '',
   };
 }
 
-// --- Gene parsing ---
-
-function parseGenes(genesData) {
-  const parsed = {};
-  for (const [chromosome, geneString] of Object.entries(genesData)) {
-    const blockStrings = geneString.split(' ');
-    const blocks = [];
-    for (let bi = 0; bi < blockStrings.length; bi++) {
-      const bl = blockLetter(bi);
-      const blockGenes = [];
-      for (let i = 0; i < blockStrings[bi].length; i++) {
-        blockGenes.push({ id: `${chromosome}${bl}${i + 1}`, type: blockStrings[bi][i], block: bl, position: i + 1 });
-      }
-      blocks.push({ letter: bl, genes: blockGenes });
-    }
-    parsed[chromosome] = { blocks };
+function buildAppearanceLookup(species) {
+  const attrs = getAppearanceAttributes(species);
+  const byName = new Map();
+  for (const [key, info] of Object.entries(attrs)) {
+    byName.set(info.name.toLowerCase(), key);
   }
-  return parsed;
+  return byName;
+}
+
+function categorizeAppearance(geneId) {
+  const raw = effectsDB[geneId]?.appearance;
+  if (!raw || raw === 'None' || raw.includes('String for me to fill')) return '';
+  const lower = raw.toLowerCase();
+  const matcher = speciesKey === 'horse' ? (name) => lower.startsWith(name) : (name) => lower.includes(name);
+  for (const [name, key] of appearanceLookup) {
+    if (matcher(name)) return key;
+  }
+  return '';
 }
 
 // --- Gene analysis (once per gene) ---
 
-const NO_EFFECT_SENTINELS = new Set([
-  'No gene data found',
-  'No dominant effect',
-  'No recessive effect',
-  'Unknown gene type',
-  'None',
-  'null',
-]);
-
-function isNoEffect(effect) {
-  return !effect || NO_EFFECT_SENTINELS.has(effect);
-}
-
-function getGeneEffect(geneId, geneType) {
-  const data = effectsDB[geneId];
-  if (!data) return 'No gene data found';
-  if (geneType === 'D' || geneType === 'x') {
-    const e = data.effectDominant;
-    return isNoEffect(e) ? 'No dominant effect' : e;
-  }
-  if (geneType === 'R') {
-    const e = data.effectRecessive;
-    return isNoEffect(e) ? 'No recessive effect' : e;
-  }
-  return 'Unknown gene type';
-}
-
-function getGeneBreed(geneId) {
-  return effectsDB[geneId]?.breed || '';
-}
-
 function analyzeGene(geneId, geneType) {
-  const effect = getGeneEffect(geneId, geneType);
-  const breed = getGeneBreed(geneId);
+  const geneData = effectsDB[geneId];
+  const effect = effectFor(geneData, geneType);
+  const breed = breedFor(geneData);
 
   if (isNoEffect(effect)) return { effectType: 'neutral', attribute: null, effect, breed };
 
@@ -345,38 +346,49 @@ function analyzeGene(geneId, geneType) {
 
 // --- Filter UI actions ---
 
-function toggleChromosomeFilter(chr, ctrlKey, altKey) {
+function triStateToggle(key, selected, hidden, ctrlKey, altKey) {
   if (altKey) {
-    hiddenChromosomes = hiddenChromosomes.includes(chr)
-      ? hiddenChromosomes.filter((c) => c !== chr)
-      : [...hiddenChromosomes.filter((c) => c !== chr), chr];
-    selectedChromosomes = selectedChromosomes.filter((c) => c !== chr);
-  } else if (ctrlKey) {
-    selectedChromosomes = selectedChromosomes.includes(chr)
-      ? selectedChromosomes.filter((c) => c !== chr)
-      : [...selectedChromosomes, chr];
-    hiddenChromosomes = hiddenChromosomes.filter((c) => c !== chr);
-  } else {
-    selectedChromosomes = selectedChromosomes.length === 1 && selectedChromosomes[0] === chr ? [] : [chr];
-    hiddenChromosomes = hiddenChromosomes.filter((c) => c !== chr);
+    const nextHidden = hidden.includes(key)
+      ? hidden.filter((k) => k !== key)
+      : [...hidden.filter((k) => k !== key), key];
+    return { selected: selected.filter((k) => k !== key), hidden: nextHidden };
   }
+  if (ctrlKey) {
+    const nextSelected = selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
+    return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
+  }
+  const nextSelected = selected.length === 1 && selected[0] === key ? [] : [key];
+  return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
+}
+
+function toggleChromosomeFilter(chr, ctrlKey, altKey) {
+  ({ selected: selectedChromosomes, hidden: hiddenChromosomes } = triStateToggle(
+    chr,
+    selectedChromosomes,
+    hiddenChromosomes,
+    ctrlKey,
+    altKey,
+  ));
 }
 
 function toggleAttributeFilter(attrKey, ctrlKey, altKey) {
-  if (altKey) {
-    hiddenAttributes = hiddenAttributes.includes(attrKey)
-      ? hiddenAttributes.filter((a) => a !== attrKey)
-      : [...hiddenAttributes.filter((a) => a !== attrKey), attrKey];
-    selectedAttributes = selectedAttributes.filter((a) => a !== attrKey);
-  } else if (ctrlKey) {
-    selectedAttributes = selectedAttributes.includes(attrKey)
-      ? selectedAttributes.filter((a) => a !== attrKey)
-      : [...selectedAttributes, attrKey];
-    hiddenAttributes = hiddenAttributes.filter((a) => a !== attrKey);
-  } else {
-    selectedAttributes = selectedAttributes.length === 1 && selectedAttributes[0] === attrKey ? [] : [attrKey];
-    hiddenAttributes = hiddenAttributes.filter((a) => a !== attrKey);
-  }
+  ({ selected: selectedAttributes, hidden: hiddenAttributes } = triStateToggle(
+    attrKey,
+    selectedAttributes,
+    hiddenAttributes,
+    ctrlKey,
+    altKey,
+  ));
+}
+
+function toggleAppearanceFilter(key, ctrlKey, altKey) {
+  ({ selected: selectedAppearances, hidden: hiddenAppearances } = triStateToggle(
+    key,
+    selectedAppearances,
+    hiddenAppearances,
+    ctrlKey,
+    altKey,
+  ));
 }
 
 // --- Tooltip ---
@@ -384,8 +396,9 @@ function toggleAttributeFilter(attrKey, ctrlKey, altKey) {
 function handleCellEnter(event, cell) {
   if (!cell) return;
   const potentialEffects = [];
-  const dominantEffect = getGeneEffect(cell.id, 'D');
-  const recessiveEffect = getGeneEffect(cell.id, 'R');
+  const cellData = effectsDB[cell.id];
+  const dominantEffect = effectFor(cellData, 'D');
+  const recessiveEffect = effectFor(cellData, 'R');
 
   if (cell.type !== 'D' && !isNoEffect(dominantEffect)) {
     const color = dominantEffect.includes('+') ? '#34d399' : dominantEffect.includes('-') ? '#f87171' : '#666';
@@ -396,7 +409,7 @@ function handleCellEnter(event, cell) {
     potentialEffects.push(`If Recessive: <span style="color: ${color}">${recessiveEffect}</span>`);
   }
 
-  const breed = getGeneBreed(cell.id);
+  const breed = breedFor(cellData);
   if (breed && speciesKey === 'horse') {
     if (breedFilter && breed !== breedFilter) {
       potentialEffects.push(
@@ -444,6 +457,11 @@ function handleCellLeave() {
             {selectedAttributes}
             {hiddenAttributes}
             {attributeDisplayInfo}
+            {selectedAppearances}
+            {hiddenAppearances}
+            {appearanceDisplayInfo}
+            {currentView}
+            onViewChange={(v) => { currentView = v; }}
             onBreedChange={(name) => { breedFilter = breedFilter === name ? '' : name; }}
             onAutoBreedToggle={() => {
                 manualBreedOverride = true;
@@ -455,8 +473,10 @@ function handleCellLeave() {
                 }
             }}
             onAttributeToggle={toggleAttributeFilter}
+            onAppearanceToggle={toggleAppearanceFilter}
             onDiffsOnlyChange={(val) => { showDiffsOnly = val; }}
             onResetAttributes={() => { selectedAttributes = []; hiddenAttributes = []; }}
+            onResetAppearances={() => { selectedAppearances = []; hiddenAppearances = []; }}
         />
 
         <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -488,7 +508,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={cell.cssClass} data-attr={cell.attribute} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}
@@ -506,7 +526,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={cell.cssClass} data-attr={cell.attribute} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -127,6 +127,7 @@ $effect(() => {
     hiddenChromosomes,
     showDiffsOnly,
     isHorse,
+    currentView,
     chrBreedRelevance,
   });
 });

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -9,9 +9,9 @@ import {
   normalizeSpecies,
 } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
-import { blockLetter } from '$lib/services/genomeParser.js';
 import { getPetGenome } from '$lib/services/petService.js';
 import { EFFECT_COLORS } from '$lib/theme/gene-colors.js';
+import { breedFor, effectFor, isNoEffect, parseGenesByBlock } from '$lib/utils/geneAnalysis.js';
 import { handleGridNavigation } from '$lib/utils/keyboard.js';
 import { capitalize } from '$lib/utils/string.js';
 import GeneCell from './GeneCell.svelte';
@@ -19,16 +19,6 @@ import GeneTooltip from './GeneTooltip.svelte';
 
 const ALL_ATTRIBUTES = getAllAttributeDisplayInfo();
 const FALLBACK_APPEARANCE_KEYS = getAllAppearanceDisplayInfo('beewasp').map((a) => a.key.replace(/_/g, '-'));
-
-const NO_DATA = 'No gene data found';
-const NO_DOMINANT = 'No dominant effect';
-const NO_RECESSIVE = 'No recessive effect';
-const UNKNOWN_TYPE = 'Unknown gene type';
-const NO_EFFECT_SENTINELS = new Set([NO_DATA, NO_DOMINANT, NO_RECESSIVE, UNKNOWN_TYPE, 'None', 'null']);
-
-function isNoEffect(effect) {
-  return !effect || NO_EFFECT_SENTINELS.has(effect);
-}
 
 // Build appearance category lookup maps from configService data (avoids long if/else chains)
 function buildAppearanceLookup(species) {
@@ -262,41 +252,7 @@ function loadAppearanceConfigForSpecies(species) {
   appearanceList = config.appearance_attributes || [];
 }
 
-function parseGenes(genesData) {
-  const parsed = {};
-
-  Object.entries(genesData).forEach(([chromosome, geneString]) => {
-    const blockStrings = geneString.split(' ');
-    const allGenes = [];
-    const blocks = [];
-
-    blockStrings.forEach((blockString, blockIndex) => {
-      const bl = blockLetter(blockIndex);
-      const blockGenes = [];
-
-      for (let i = 0; i < blockString.length; i++) {
-        const gene = {
-          id: `${chromosome}${bl}${i + 1}`,
-          type: blockString[i],
-          block: bl,
-          position: i + 1,
-          globalPosition: allGenes.length + 1,
-        };
-        blockGenes.push(gene);
-        allGenes.push(gene);
-      }
-
-      blocks.push({
-        letter: bl,
-        genes: blockGenes,
-      });
-    });
-
-    parsed[chromosome] = { blocks, allGenes };
-  });
-
-  return parsed;
-}
+const parseGenes = parseGenesByBlock;
 
 async function initializeStats() {
   if (currentView === 'attribute') {
@@ -382,19 +338,7 @@ function updateStats(stats, geneAnalysis, geneType) {
 }
 
 function getGeneEffect(speciesKey, geneId, geneType) {
-  if (!geneEffectsDB) return NO_DATA;
-  const geneData = geneEffectsDB[speciesKey]?.[geneId];
-  if (!geneData) return NO_DATA;
-
-  if (geneType === 'D' || geneType === 'x') {
-    const effect = geneData.effectDominant;
-    return isNoEffect(effect) ? NO_DOMINANT : effect;
-  }
-  if (geneType === 'R') {
-    const effect = geneData.effectRecessive;
-    return isNoEffect(effect) ? NO_RECESSIVE : effect;
-  }
-  return UNKNOWN_TYPE;
+  return effectFor(geneEffectsDB?.[speciesKey]?.[geneId], geneType);
 }
 
 function getGeneAppearance(speciesKey, geneId) {
@@ -436,9 +380,7 @@ function extractAttributesFromEffect(effectStr) {
 }
 
 function getGeneBreed(speciesKey, geneId) {
-  if (!geneEffectsDB) return '';
-  const geneData = geneEffectsDB[speciesKey]?.[geneId];
-  return geneData?.breed || '';
+  return breedFor(geneEffectsDB?.[speciesKey]?.[geneId]);
 }
 
 function isGeneRelevantToBreed(speciesKey, geneId) {

--- a/src/lib/utils/filterCSS.js
+++ b/src/lib/utils/filterCSS.js
@@ -9,10 +9,23 @@ const HIDDEN = '{ display: none !important; }';
 const INACTIVE = '{ background-color: #e8e8ec !important; border-color: #d0d0d6 !important; opacity: 0.5 !important; }';
 const DIMMED = '{ opacity: 0.2 !important; }';
 
+function pushInclusionRules(rules, baseSelector, attr, selected, hidden, declaration) {
+  if (selected.length > 0) {
+    let not = '';
+    for (const v of selected) not += `:not([${attr}="${v}"])`;
+    rules.push(`${G} ${baseSelector}[${attr}]${not} ${declaration}`);
+  }
+  for (const v of hidden) {
+    rules.push(`${G} ${baseSelector}[${attr}="${v}"] ${declaration}`);
+  }
+}
+
 /**
  * @param {object} filters
  * @param {string[]} filters.selectedAttributes
  * @param {string[]} filters.hiddenAttributes
+ * @param {string[]} filters.selectedAppearances
+ * @param {string[]} filters.hiddenAppearances
  * @param {string} filters.breedFilter
  * @param {string[]} filters.selectedChromosomes
  * @param {string[]} filters.hiddenChromosomes
@@ -25,6 +38,8 @@ export function buildFilterCSS(filters) {
   const {
     selectedAttributes: sa,
     hiddenAttributes: ha,
+    selectedAppearances: sap = [],
+    hiddenAppearances: hap = [],
     breedFilter: bf,
     selectedChromosomes: sc,
     hiddenChromosomes: hc,
@@ -35,15 +50,8 @@ export function buildFilterCSS(filters) {
 
   const rules = [];
 
-  // Attribute filter
-  if (sa.length > 0) {
-    let not = '';
-    for (const a of sa) not += `:not([data-attr="${a}"])`;
-    rules.push(`${G} .gene-cell[data-attr]${not} ${FILTERED}`);
-  }
-  for (const a of ha) {
-    rules.push(`${G} .gene-cell[data-attr="${a}"] ${FILTERED}`);
-  }
+  pushInclusionRules(rules, '.gene-cell', 'data-attr', sa, ha, FILTERED);
+  pushInclusionRules(rules, '.gene-cell', 'data-appearance', sap, hap, FILTERED);
 
   // Breed filter
   if (horse && bf) {

--- a/src/lib/utils/filterCSS.js
+++ b/src/lib/utils/filterCSS.js
@@ -31,6 +31,7 @@ function pushInclusionRules(rules, baseSelector, attr, selected, hidden, declara
  * @param {string[]} filters.hiddenChromosomes
  * @param {boolean} filters.showDiffsOnly
  * @param {boolean} filters.isHorse
+ * @param {'attribute'|'appearance'} filters.currentView
  * @param {Record<string, { generic: boolean; breeds: Set<string> }>} filters.chrBreedRelevance
  * @returns {string}
  */
@@ -45,13 +46,17 @@ export function buildFilterCSS(filters) {
     hiddenChromosomes: hc,
     showDiffsOnly: sd,
     isHorse: horse,
+    currentView = 'attribute',
     chrBreedRelevance,
   } = filters;
 
   const rules = [];
 
-  pushInclusionRules(rules, '.gene-cell', 'data-attr', sa, ha, FILTERED);
-  pushInclusionRules(rules, '.gene-cell', 'data-appearance', sap, hap, FILTERED);
+  if (currentView === 'attribute') {
+    pushInclusionRules(rules, '.gene-cell', 'data-attr', sa, ha, FILTERED);
+  } else if (currentView === 'appearance') {
+    pushInclusionRules(rules, '.gene-cell', 'data-appearance', sap, hap, FILTERED);
+  }
 
   // Breed filter
   if (horse && bf) {

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -12,7 +12,7 @@ import { capitalize } from '$lib/utils/string.js';
 
 // --- Effect classification helpers ---
 
-const NO_EFFECT_SENTINELS = new Set([
+export const NO_EFFECT_SENTINELS = new Set([
   'No gene data found',
   'No dominant effect',
   'No recessive effect',
@@ -21,36 +21,37 @@ const NO_EFFECT_SENTINELS = new Set([
   'null',
 ]);
 
-function isNoEffect(effect: string | null | undefined): boolean {
+export function isNoEffect(effect: string | null | undefined): boolean {
   return !effect || NO_EFFECT_SENTINELS.has(effect);
 }
 
-function getGeneEffect(
-  geneEffectsDB: Record<string, Record<string, { effectDominant: string; effectRecessive: string; breed: string }>>,
-  speciesKey: string,
-  geneId: string,
-  geneType: string,
-): string {
-  const geneData = geneEffectsDB[speciesKey]?.[geneId];
-  if (!geneData) return 'No gene data found';
+/** Shape of a single gene's effect record within an `effectsDB` map. */
+export interface GeneEffectData {
+  effectDominant: string;
+  effectRecessive: string;
+  breed: string;
+  appearance?: string;
+  notes?: string;
+}
 
+/**
+ * Resolve the displayable effect string for a gene given its data record and type.
+ * Pass the already-indexed `effectsDB[geneId]` — this helper doesn't know about species.
+ */
+export function effectFor(geneData: GeneEffectData | undefined, geneType: string): string {
+  if (!geneData) return 'No gene data found';
   if (geneType === 'D' || geneType === 'x') {
-    const effect = geneData.effectDominant;
-    return isNoEffect(effect) ? 'No dominant effect' : effect;
+    return isNoEffect(geneData.effectDominant) ? 'No dominant effect' : geneData.effectDominant;
   }
   if (geneType === 'R') {
-    const effect = geneData.effectRecessive;
-    return isNoEffect(effect) ? 'No recessive effect' : effect;
+    return isNoEffect(geneData.effectRecessive) ? 'No recessive effect' : geneData.effectRecessive;
   }
   return 'Unknown gene type';
 }
 
-function getGeneBreed(
-  geneEffectsDB: Record<string, Record<string, { breed: string }>>,
-  speciesKey: string,
-  geneId: string,
-): string {
-  return geneEffectsDB[speciesKey]?.[geneId]?.breed || '';
+/** Resolve the breed string for a gene data record (empty string if none). */
+export function breedFor(geneData: { breed?: string } | undefined): string {
+  return geneData?.breed || '';
 }
 
 /** Parsed gene from a genome string. */
@@ -59,35 +60,60 @@ export interface ParsedGene {
   type: string;
   block: string;
   position: number;
+  globalPosition: number;
+}
+
+/** Parsed chromosome grouped by block for grid rendering. */
+export interface ParsedChromosome {
+  blocks: Array<{ letter: string; genes: ParsedGene[] }>;
+  allGenes: ParsedGene[];
 }
 
 /**
- * Parse a genome's gene strings into structured gene objects.
+ * Parse a genome's gene strings into a flat list per chromosome.
  * Input: `genes` from `getPetGenome()` — `Record<string, string>` where
  * each value is like `"RDRD RDRR ?D?? x?xR"`.
  */
 export function parseGenomeGenes(genes: Record<string, string>): Record<string, ParsedGene[]> {
   const result: Record<string, ParsedGene[]> = {};
+  for (const [chromosome, blocks] of Object.entries(parseGenesByBlock(genes))) {
+    result[chromosome] = blocks.allGenes;
+  }
+  return result;
+}
+
+/**
+ * Parse a genome's gene strings grouped by block, for grid/visualizer rendering.
+ * Returns both the block grouping and a flat `allGenes` list per chromosome.
+ */
+export function parseGenesByBlock(genes: Record<string, string>): Record<string, ParsedChromosome> {
+  const result: Record<string, ParsedChromosome> = {};
 
   for (const [chromosome, geneString] of Object.entries(genes)) {
     const blockStrings = geneString.split(' ');
     const allGenes: ParsedGene[] = [];
+    const blocks: Array<{ letter: string; genes: ParsedGene[] }> = [];
 
-    for (let blockIndex = 0; blockIndex < blockStrings.length; blockIndex++) {
-      const bl = blockLetter(blockIndex);
-      const blockString = blockStrings[blockIndex];
+    for (let bi = 0; bi < blockStrings.length; bi++) {
+      const bl = blockLetter(bi);
+      const blockGenes: ParsedGene[] = [];
 
-      for (let i = 0; i < blockString.length; i++) {
-        allGenes.push({
+      for (let i = 0; i < blockStrings[bi].length; i++) {
+        const gene: ParsedGene = {
           id: `${chromosome}${bl}${i + 1}`,
-          type: blockString[i],
+          type: blockStrings[bi][i],
           block: bl,
           position: i + 1,
-        });
+          globalPosition: allGenes.length + 1,
+        };
+        blockGenes.push(gene);
+        allGenes.push(gene);
       }
+
+      blocks.push({ letter: bl, genes: blockGenes });
     }
 
-    result[chromosome] = allGenes;
+    result[chromosome] = { blocks, allGenes };
   }
 
   return result;
@@ -99,7 +125,7 @@ export function parseGenomeGenes(genes: Record<string, string>): Record<string, 
  * Returns a map of attribute key → { positive, negative, dominant, recessive, mixed }.
  * Also returns totalGenes and neutralGenes counts.
  */
-type GeneEffectsDB = Record<string, Record<string, { effectDominant: string; effectRecessive: string; breed: string }>>;
+type GeneEffectsDB = Record<string, Record<string, GeneEffectData>>;
 
 export function computeGeneStats(
   genes: Record<string, string>,
@@ -108,8 +134,9 @@ export function computeGeneStats(
   petBreed?: string,
 ): { stats: Record<string, GeneStatsEntry>; totalGenes: number; neutralGenes: number } {
   const speciesKey = normalizeSpecies(species);
-  const config = getAttributeConfig(speciesKey);
+  const _config = getAttributeConfig(speciesKey);
   const attrNames = getAllAttributeNames(speciesKey).map((name) => capitalize(name));
+  const speciesEffects = geneEffectsDB[speciesKey] ?? {};
 
   const emptyEntry = (): GeneStatsEntry => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
   const stats: Record<string, GeneStatsEntry> = {};
@@ -120,21 +147,20 @@ export function computeGeneStats(
   let totalGenes = 0;
   let neutralGenes = 0;
 
-  const parsedGenome = parseGenomeGenes(genes);
-  const effectsDB = geneEffectsDB;
-
-  for (const [_chromosome, geneList] of Object.entries(parsedGenome)) {
+  for (const [_chromosome, geneList] of Object.entries(parseGenomeGenes(genes))) {
     for (const gene of geneList) {
       if (gene.type === '?') continue;
       totalGenes++;
 
+      const geneData = speciesEffects[gene.id];
+
       // Skip genes from other breeds (horse only)
       if (speciesKey === 'horse' && petBreed && petBreed !== 'Mixed') {
-        const breed = getGeneBreed(effectsDB, speciesKey, gene.id);
+        const breed = breedFor(geneData);
         if (breed && breed !== petBreed) continue;
       }
 
-      const effect = getGeneEffect(effectsDB, speciesKey, gene.id, gene.type);
+      const effect = effectFor(geneData, gene.type);
       if (isNoEffect(effect)) {
         neutralGenes++;
         continue;

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -5,7 +5,7 @@
  * reused by both the visualizer and the comparison service.
  */
 
-import { getAllAttributeNames, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import { getAllAttributeNames, normalizeSpecies } from '$lib/services/configService.js';
 import { blockLetter } from '$lib/services/genomeParser.js';
 import type { GeneStatsEntry } from '$lib/types/index.js';
 import { capitalize } from '$lib/utils/string.js';
@@ -76,8 +76,8 @@ export interface ParsedChromosome {
  */
 export function parseGenomeGenes(genes: Record<string, string>): Record<string, ParsedGene[]> {
   const result: Record<string, ParsedGene[]> = {};
-  for (const [chromosome, blocks] of Object.entries(parseGenesByBlock(genes))) {
-    result[chromosome] = blocks.allGenes;
+  for (const [chromosome, chrData] of Object.entries(parseGenesByBlock(genes))) {
+    result[chromosome] = chrData.allGenes;
   }
   return result;
 }
@@ -134,7 +134,6 @@ export function computeGeneStats(
   petBreed?: string,
 ): { stats: Record<string, GeneStatsEntry>; totalGenes: number; neutralGenes: number } {
   const speciesKey = normalizeSpecies(species);
-  const _config = getAttributeConfig(speciesKey);
   const attrNames = getAllAttributeNames(speciesKey).map((name) => capitalize(name));
   const speciesEffects = geneEffectsDB[speciesKey] ?? {};
 


### PR DESCRIPTION
## Summary

- **Appearance view + filter** — new Attributes/Appearance toggle in the comparison grid, mirroring the gene viewer. In appearance view, each gene is coloured by its appearance category (body-color-hue, scale, coat, …) using the global \`gene-*\` classes from \`GeneCell.svelte\`. Each view has its own filter bar, shown only when that view is active.
- **Shared gene analysis helpers (closes #129)** — \`NO_EFFECT_SENTINELS\`, \`isNoEffect\`, \`effectFor\`, \`breedFor\`, and \`parseGenesByBlock\` now live in \`geneAnalysis.ts\` and are consumed by both \`GenomeGridDiff.svelte\` and \`GeneVisualizer.svelte\`.
- **Breed-filter fix** — manual breed buttons were disabled whenever \`autoBreed\` was on, but the Auto toggle only appears when both pets have a breed recognised in \`HORSE_BREEDS\`. If neither pet matched, the buttons were locked out with nothing clickable. Manual breed buttons are now only disabled when auto-breed is actually in effect.

## Test plan

- [x] \`pnpm lint:ci\` — clean
- [x] \`pnpm test\` — 246 unit tests pass
- [x] \`pnpm test:e2e\` — 105 e2e tests pass (2 perf tests skipped by design)
- [x] Manually compare two horses in both views; toggle attribute/appearance; toggle breed on pets with and without matching \`HORSE_BREEDS\` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)