### PR TITLE
feat(pets): pet markers + collapsible/resizable sidebar

### DIFF
--- a/assets/horse/horse_genes_chr08.json
+++ b/assets/horse/horse_genes_chr08.json
@@ -42,7 +42,7 @@
   {
     "gene": "08B2",
     "effectDominant": "None",
-    "effectRecessive": "Temperament-",
+    "effectRecessive": "None",
     "appearance": "Horn",
     "notes": "",
     "breed": ""
@@ -50,7 +50,7 @@
   {
     "gene": "08B3",
     "effectDominant": "None",
-    "effectRecessive": "None",
+    "effectRecessive": "Temperament-",
     "appearance": "Horn",
     "notes": "",
     "breed": ""

--- a/scripts/capture-quickstart-screenshots.mjs
+++ b/scripts/capture-quickstart-screenshots.mjs
@@ -129,7 +129,7 @@ await clearHighlight(page);
 await removeOverlay(page);
 
 // 05 — BeeWasp gene grid (click bee pet)
-await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
 await waitFor(page, ".gene-visualizer, .gallery");
 await shot(page, '05-gene-grid.png');
 
@@ -276,7 +276,7 @@ await page.locator('tr.attribute-row', { hasText: 'Intelligence' }).click();
 await page.waitForTimeout(200);
 
 // 11 — Horse auto-breed filter (select horse pet)
-await page.locator('button', { hasText: 'Sample Horse' }).click();
+await page.locator('.pet-card', { hasText: 'Sample Horse' }).click();
 await waitFor(page, ".gene-visualizer");
 await addOverlay(page);
 await highlight(page, '.breed-filter', { padding: '4px' });
@@ -338,7 +338,7 @@ await page.waitForTimeout(200);
 // 15 — Gallery empty state
 await page.locator('.tab-btn', { hasText: 'Pets' }).click();
 await page.waitForTimeout(200);
-await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
 await waitFor(page, ".gene-visualizer, .gallery");
 await page.locator('.view-btn', { hasText: 'Gallery' }).click();
 await waitFor(page, ".gene-visualizer, .gallery, .gene-editing-view, select");
@@ -375,7 +375,7 @@ await page.waitForTimeout(200);
 await shot(page, '19-dark-mode-overview.png');
 
 // 20 — Dark mode gene grid
-await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
 await waitFor(page, '.gene-visualizer, .gallery');
 await shot(page, '20-dark-mode-gene-grid.png');
 
@@ -452,7 +452,7 @@ await removeOverlay(page);
 const HOME_OUT = 'docs/images';
 
 // screenshot-gene-grid — BeeWasp gene grid with stats open
-await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
 await waitFor(page, ".gene-visualizer, .gallery");
 await page.locator('button', { hasText: 'Stats' }).click();
 await page.waitForTimeout(200);

--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -3,23 +3,95 @@ import ComparisonPetPicker from '$lib/components/comparison/ComparisonPetPicker.
 import GeneEditor from '$lib/components/gene/GeneEditor.svelte';
 import PetList from '$lib/components/pet/PetList.svelte';
 import { activeTab } from '$lib/stores/pets.js';
+import {
+  commitSidebarWidth,
+  MAX_WIDTH,
+  MIN_WIDTH,
+  setSidebarWidth,
+  sidebar,
+  toggleSidebar,
+} from '$lib/stores/sidebar.svelte.js';
+
+let dragging = $state(false);
+
+$effect(() => {
+  if (!dragging) return;
+  const onMove = (ev) => setSidebarWidth(ev.clientX);
+  const onUp = () => {
+    dragging = false;
+    commitSidebarWidth();
+  };
+  window.addEventListener('mousemove', onMove);
+  window.addEventListener('mouseup', onUp);
+  return () => {
+    window.removeEventListener('mousemove', onMove);
+    window.removeEventListener('mouseup', onUp);
+  };
+});
+
+function startDrag(e) {
+  if (e.button !== 0) return;
+  e.preventDefault();
+  dragging = true;
+}
+
+function onHandleKeydown(e) {
+  const step = e.shiftKey ? 32 : 8;
+  if (e.key === 'ArrowLeft') {
+    e.preventDefault();
+    setSidebarWidth(sidebar.width - step);
+    commitSidebarWidth();
+  } else if (e.key === 'ArrowRight') {
+    e.preventDefault();
+    setSidebarWidth(sidebar.width + step);
+    commitSidebarWidth();
+  } else if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    toggleSidebar();
+  }
+}
 </script>
 
-<aside class="master-panel">
-    {#if $activeTab === "pets"}
-        <PetList />
-    {:else if $activeTab === "editor"}
-        <div class="gene-editor-wrapper">
-            <GeneEditor />
-        </div>
-    {:else if $activeTab === "compare"}
-        <ComparisonPetPicker />
-    {/if}
-</aside>
+{#if sidebar.collapsed}
+    <button class="sidebar-rail" title="Expand sidebar" aria-label="Expand sidebar" onclick={toggleSidebar}>
+        ›
+    </button>
+{:else}
+    <aside class="master-panel" style:width="{sidebar.width}px">
+        <button
+            class="sidebar-collapse-btn"
+            title="Collapse sidebar"
+            aria-label="Collapse sidebar"
+            onclick={toggleSidebar}
+        >‹</button>
+        {#if $activeTab === "pets"}
+            <PetList />
+        {:else if $activeTab === "editor"}
+            <div class="gene-editor-wrapper">
+                <GeneEditor />
+            </div>
+        {:else if $activeTab === "compare"}
+            <ComparisonPetPicker />
+        {/if}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class="resize-handle"
+            class:dragging
+            onmousedown={startDrag}
+            onkeydown={onHandleKeydown}
+            role="separator"
+            aria-label="Resize sidebar"
+            aria-orientation="vertical"
+            aria-valuemin={MIN_WIDTH}
+            aria-valuemax={MAX_WIDTH}
+            aria-valuenow={sidebar.width}
+            tabindex="0"
+        ></div>
+    </aside>
+{/if}
 
 <style>
     .master-panel {
-        width: 260px;
         border-right: 1px solid var(--border-primary);
         background: var(--bg-secondary);
         display: flex;
@@ -27,11 +99,77 @@ import { activeTab } from '$lib/stores/pets.js';
         flex-shrink: 0;
         height: 100%;
         overflow: hidden;
+        position: relative;
     }
 
     .gene-editor-wrapper {
         padding: 16px;
         overflow-y: auto;
         flex: 1;
+    }
+
+    .resize-handle {
+        position: absolute;
+        top: 0;
+        right: -3px;
+        width: 6px;
+        height: 100%;
+        cursor: col-resize;
+        background: transparent;
+        z-index: 20;
+    }
+
+    .resize-handle:hover,
+    .resize-handle:focus-visible,
+    .resize-handle.dragging {
+        background: var(--accent);
+        opacity: 0.5;
+        outline: none;
+    }
+
+    .sidebar-collapse-btn {
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        z-index: 15;
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        border: 1px solid var(--border-primary);
+        background: var(--bg-primary);
+        color: var(--text-secondary);
+        border-radius: 4px;
+        font-size: 12px;
+        line-height: 1;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .sidebar-collapse-btn:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    .sidebar-rail {
+        flex-shrink: 0;
+        width: 14px;
+        height: 100%;
+        padding: 0;
+        border: none;
+        border-right: 1px solid var(--border-primary);
+        background: var(--bg-secondary);
+        color: var(--text-tertiary);
+        font-size: 12px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .sidebar-rail:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
     }
 </style>

--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -16,14 +16,25 @@ let dragging = $state(false);
 
 $effect(() => {
   if (!dragging) return;
-  const onMove = (ev) => setSidebarWidth(ev.clientX);
+  let pendingX = null;
+  let frame = 0;
+  const onMove = (ev) => {
+    pendingX = ev.clientX;
+    if (frame) return;
+    frame = requestAnimationFrame(() => {
+      frame = 0;
+      if (pendingX !== null) setSidebarWidth(pendingX);
+    });
+  };
   const onUp = () => {
     dragging = false;
+    if (frame) cancelAnimationFrame(frame);
     commitSidebarWidth();
   };
   window.addEventListener('mousemove', onMove);
   window.addEventListener('mouseup', onUp);
   return () => {
+    if (frame) cancelAnimationFrame(frame);
     window.removeEventListener('mousemove', onMove);
     window.removeEventListener('mouseup', onUp);
   };

--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -10,6 +10,10 @@ function toggleMarker(e, key, value) {
 }
 
 function handleKey(e) {
+  // Ignore keys that bubbled up from inner marker buttons — they handle
+  // Space/Enter themselves; otherwise hitting those on a marker would also
+  // fire the card's own "select pet" action.
+  if (e.currentTarget !== e.target) return;
   if (e.key === 'Enter' || e.key === ' ') {
     e.preventDefault();
     onclick?.(pet);

--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -1,14 +1,32 @@
 <script>
+import { House, PawPrint, Star } from '@lucide/svelte';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
 
-const { pet, selected = false, onclick, onkeydown } = $props();
+const { pet, selected = false, onclick, onkeydown, onToggleMarker } = $props();
+
+function toggleMarker(e, key, value) {
+  e.stopPropagation();
+  onToggleMarker?.(pet.id, key, value);
+}
+
+function handleKey(e) {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    onclick?.(pet);
+    return;
+  }
+  onkeydown?.(e);
+}
 </script>
 
-<button
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
     class="pet-card"
     class:selected
+    role="button"
+    tabindex="0"
     onclick={() => onclick?.(pet)}
-    {onkeydown}
+    onkeydown={handleKey}
 >
     <div class="pet-card-main">
         <div class="pet-card-icon">{getSpeciesEmoji(pet.species)}</div>
@@ -36,10 +54,37 @@ const { pet, selected = false, onclick, onkeydown } = $props();
             {/if}
         </div>
     </div>
-    {#if selected}
-        <span class="selected-indicator">▸</span>
-    {/if}
-</button>
+    <div class="pet-card-side">
+        <button
+            type="button"
+            class="marker-toggle star-toggle"
+            class:active={pet.starred}
+            title={pet.starred ? 'Unstar' : 'Star'}
+            aria-label={pet.starred ? 'Unstar pet' : 'Star pet'}
+            aria-pressed={!!pet.starred}
+            onclick={(e) => toggleMarker(e, 'starred', !pet.starred)}
+        >
+            <Star size={14} fill={pet.starred ? 'currentColor' : 'none'} />
+        </button>
+        <button
+            type="button"
+            class="marker-toggle stable-toggle"
+            class:active={pet.stabled}
+            title={pet.stabled ? 'Remove from stables' : 'Mark as stabled'}
+            aria-label={pet.stabled ? 'Unstable pet' : 'Mark as stabled'}
+            aria-pressed={!!pet.stabled}
+            onclick={(e) => toggleMarker(e, 'stabled', !pet.stabled)}
+        >
+            <House size={14} fill={pet.stabled ? 'currentColor' : 'none'} />
+        </button>
+        {#if pet.is_pet_quality}
+            <PawPrint class="marker-badge pet-quality" size={14} aria-label="Pet quality" />
+        {/if}
+        {#if selected}
+            <span class="selected-indicator">▸</span>
+        {/if}
+    </div>
+</div>
 
 <style>
     .pet-card {
@@ -47,18 +92,24 @@ const { pet, selected = false, onclick, onkeydown } = $props();
         align-items: center;
         justify-content: space-between;
         width: 100%;
-        padding: 10px 12px;
+        padding: 10px 64px 10px 12px;
         background: var(--bg-primary);
         border: 1px solid var(--border-primary);
         border-radius: 8px;
         cursor: pointer;
         transition: all 0.15s ease;
         text-align: left;
+        box-sizing: border-box;
     }
 
     .pet-card:hover {
         background: var(--bg-secondary);
         border-color: var(--border-secondary);
+    }
+
+    .pet-card:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
     }
 
     .pet-card.selected {
@@ -121,5 +172,51 @@ const { pet, selected = false, onclick, onkeydown } = $props();
         color: var(--accent-text);
         font-size: 12px;
         flex-shrink: 0;
+    }
+
+    .pet-card-side {
+        display: flex;
+        align-items: center;
+        gap: 2px;
+        flex-shrink: 0;
+        margin-left: 6px;
+    }
+
+    .marker-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        border: none;
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+        border-radius: 4px;
+        transition: color 0.15s, background 0.15s;
+    }
+
+    .marker-toggle:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+    }
+
+    .marker-toggle:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+    }
+
+    .star-toggle.active {
+        color: #f59e0b;
+    }
+
+    .stable-toggle.active {
+        color: var(--accent);
+    }
+
+    :global(.marker-badge.pet-quality) {
+        color: var(--text-muted);
+        margin-left: 2px;
     }
 </style>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -1,4 +1,5 @@
 <script>
+import { House, PawPrint, Star } from '@lucide/svelte';
 import { untrack } from 'svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
 import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
@@ -37,6 +38,9 @@ let editGender = $state(initial.gender);
 let editBreed = $state(initial.breed);
 const editAttributes = $state(initial.attributes);
 let editTags = $state(untrack(() => [...(pet.tags ?? [])]));
+let editStarred = $state(!!pet.starred);
+let editStabled = $state(!!pet.stabled);
+let editIsPetQuality = $state(!!pet.is_pet_quality);
 let saveError = $state('');
 
 const allTags = $derived($allTagsStore);
@@ -62,6 +66,10 @@ async function handleSave() {
     if (JSON.stringify(editTags) !== JSON.stringify(pet.tags ?? [])) {
       updateData.tags = editTags;
     }
+
+    if (editStarred !== !!pet.starred) updateData.starred = editStarred;
+    if (editStabled !== !!pet.stabled) updateData.stabled = editStabled;
+    if (editIsPetQuality !== !!pet.is_pet_quality) updateData.is_pet_quality = editIsPetQuality;
 
     if (Object.keys(updateData).length > 0) {
       await appState.updatePet(pet.id, updateData);
@@ -144,6 +152,45 @@ function updateAttribute(attrKey, value) {
       <section class="form-section">
         <h3>Tags</h3>
         <TagInput tags={editTags} {allTags} onchange={(t) => { editTags = t; }} />
+      </section>
+
+      <section class="form-section">
+        <h3>Markers</h3>
+        <div class="markers">
+          <button
+            type="button"
+            class="marker star"
+            class:active={editStarred}
+            aria-pressed={editStarred}
+            onclick={() => { editStarred = !editStarred; }}
+          >
+            <Star size={16} fill={editStarred ? 'currentColor' : 'none'} />
+            <span>Starred</span>
+            <span class="marker-hint">favourites</span>
+          </button>
+          <button
+            type="button"
+            class="marker stable"
+            class:active={editStabled}
+            aria-pressed={editStabled}
+            onclick={() => { editStabled = !editStabled; }}
+          >
+            <House size={16} fill={editStabled ? 'currentColor' : 'none'} />
+            <span>Stabled</span>
+            <span class="marker-hint">available in your stables</span>
+          </button>
+          <button
+            type="button"
+            class="marker pet-quality"
+            class:active={editIsPetQuality}
+            aria-pressed={editIsPetQuality}
+            onclick={() => { editIsPetQuality = !editIsPetQuality; }}
+          >
+            <PawPrint size={16} fill={editIsPetQuality ? 'currentColor' : 'none'} />
+            <span>Pet quality</span>
+            <span class="marker-hint">not used for breeding</span>
+          </button>
+        </div>
       </section>
 
       <section class="form-section">
@@ -336,6 +383,53 @@ function updateAttribute(attrKey, value) {
   .attr-field input:focus {
     border-color: var(--accent);
     box-shadow: 0 0 0 2px var(--accent-soft);
+  }
+
+  .markers {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .marker {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-primary);
+    background: var(--bg-primary);
+    color: var(--text-muted);
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    text-align: left;
+  }
+
+  .marker:hover {
+    border-color: var(--border-secondary);
+    color: var(--text-primary);
+  }
+
+  .marker.star.active {
+    color: #f59e0b;
+    border-color: #f59e0b;
+  }
+
+  .marker.stable.active {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .marker.pet-quality.active {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+  }
+
+  .marker-hint {
+    color: var(--text-muted);
+    font-size: 12px;
+    margin-left: auto;
   }
 
   .save-error {

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -73,7 +73,6 @@ async function handleSave() {
 
     if (Object.keys(updateData).length > 0) {
       await appState.updatePet(pet.id, updateData);
-      await appState.loadPets();
       onSave?.(pet.id);
     }
     open = false;

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -87,8 +87,9 @@ function selectPet(pet) {
   appState.selectPet(pet);
 }
 
-// appState.updatePet already reloads the pets store — no explicit loadPets needed.
 async function toggleMarker(petId, key, value) {
+  const pet = $pets.find((p) => p.id === petId);
+  if (pet && pet[key] === value) return;
   await appState.updatePet(petId, { [key]: value });
 }
 

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -37,6 +37,8 @@ function startCompare() {
 
 let searchQuery = $state('');
 let selectedTags = $state([]);
+let starredOnly = $state(false);
+let stabledOnly = $state(true);
 let uploading = $state(false);
 let uploadProgress = $state(null);
 let showEditor = $state(false);
@@ -67,6 +69,8 @@ const filteredPets = $derived.by(() => {
       const petTags = pet.tags ?? [];
       if (!selectedTags.every((t) => petTags.includes(t))) return false;
     }
+    if (starredOnly && !pet.starred) return false;
+    if (stabledOnly && !pet.stabled) return false;
     return true;
   });
 });
@@ -81,6 +85,11 @@ function toggleTagFilter(tag) {
 
 function selectPet(pet) {
   appState.selectPet(pet);
+}
+
+// appState.updatePet already reloads the pets store — no explicit loadPets needed.
+async function toggleMarker(petId, key, value) {
+  await appState.updatePet(petId, { [key]: value });
 }
 
 async function handleUpload() {
@@ -225,6 +234,20 @@ async function handleDrop(e, dropIndex) {
             placeholder="Search pets..."
             bind:value={searchQuery}
         />
+        <div class="marker-filter">
+            <button
+                class="marker-filter-btn"
+                class:active={starredOnly}
+                onclick={() => { starredOnly = !starredOnly; }}
+                title="Show only starred pets"
+            >⭐ Starred</button>
+            <button
+                class="marker-filter-btn"
+                class:active={stabledOnly}
+                onclick={() => { stabledOnly = !stabledOnly; }}
+                title="Show only pets in your stables"
+            >🏠 Stabled</button>
+        </div>
         {#if availableTags.length > 0}
             <div class="tag-filter">
                 {#each availableTags as tag}
@@ -268,6 +291,7 @@ async function handleDrop(e, dropIndex) {
                         selected={$selectedPet?.id === pet.id}
                         onclick={$compareSelectMode ? () => toggleComparisonPet(pet) : selectPet}
                         onkeydown={(e) => handlePetCardKeydown(e, index)}
+                        onToggleMarker={toggleMarker}
                     />
                     <div class="pet-card-actions">
                         <button
@@ -422,6 +446,34 @@ async function handleDrop(e, dropIndex) {
 
     .search-input::placeholder {
         color: var(--text-muted);
+    }
+
+    .marker-filter {
+        display: flex;
+        gap: 4px;
+        margin-top: 8px;
+    }
+
+    .marker-filter-btn {
+        padding: 2px 10px;
+        border: 1px solid var(--border-primary);
+        border-radius: 10px;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
+        font-size: 11px;
+        cursor: pointer;
+        transition: all 0.15s;
+    }
+
+    .marker-filter-btn:hover {
+        border-color: var(--accent);
+        color: var(--accent-text);
+    }
+
+    .marker-filter-btn.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
     }
 
     .tag-filter {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -321,7 +321,7 @@ async function handleDrop(e, dropIndex) {
                     ondrop={(e) => handleDrop(e, filteredPets.length)}
                 ></div>
             {/if}
-        {:else if searchQuery || selectedTags.length > 0 || starredOnly || stabledOnly}
+        {:else if $pets.length > 0 && (searchQuery || selectedTags.length > 0 || starredOnly || stabledOnly)}
             <div class="empty-state">No pets match the current filters</div>
         {:else}
             <div class="empty-state">No pets yet. Upload a genome file to get started.</div>

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -321,7 +321,7 @@ async function handleDrop(e, dropIndex) {
                     ondrop={(e) => handleDrop(e, filteredPets.length)}
                 ></div>
             {/if}
-        {:else if searchQuery || selectedTags.length > 0}
+        {:else if searchQuery || selectedTags.length > 0 || starredOnly || stabledOnly}
             <div class="empty-state">No pets match the current filters</div>
         {:else}
             <div class="empty-state">No pets yet. Upload a genome file to get started.</div>

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -253,6 +253,8 @@ async function importGenesAndPets(
         for (const col of PET_COLUMNS) {
           if (col === 'genome_data') params[col] = genomeData;
           else if (col === 'sort_order') params[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
+          else if (col === 'stabled') params[col] = pet[col] ?? 1;
+          else if (col === 'starred' || col === 'is_pet_quality') params[col] = pet[col] ?? 0;
           else params[col] = pet[col] ?? null;
         }
         await db.execute(petSQL, params);

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -60,6 +60,9 @@ const PET_COLUMNS = [
   'ferocity',
   'temperament',
   'sort_order',
+  'starred',
+  'stabled',
+  'is_pet_quality',
 ];
 
 // --- Export ---

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -122,6 +122,18 @@ const MIGRATIONS: Migration[] = [
       }
     },
   },
+  {
+    version: 8,
+    description: 'Add starred, stabled, is_pet_quality flags to pets',
+    up: async () => {
+      const db = getDb();
+      await db.execute('ALTER TABLE pets ADD COLUMN starred INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE pets ADD COLUMN stabled INTEGER NOT NULL DEFAULT 1');
+      await db.execute('ALTER TABLE pets ADD COLUMN is_pet_quality INTEGER NOT NULL DEFAULT 0');
+      // Existing rows default to stabled=1 via column DEFAULT — the default view
+      // would otherwise be empty for users upgrading with a populated database.
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -72,6 +72,9 @@ function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
   return {
     ...pet,
     tags,
+    starred: Boolean(pet.starred),
+    stabled: Boolean(pet.stabled),
+    is_pet_quality: Boolean(pet.is_pet_quality),
     total_genes: geneCounts.total,
     known_genes: geneCounts.known,
     unknown_genes: geneCounts.unknown,
@@ -216,10 +219,12 @@ export async function uploadPet(
     `INSERT INTO pets
      (name, species, gender, breed, breeder, content_hash, genome_data, notes,
       created_at, updated_at,
-      intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament, sort_order)
+      intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament, sort_order,
+      starred, stabled, is_pet_quality)
      VALUES ($name, $species, $gender, $breed, $breeder, $content_hash, $genome_data, $notes,
              $created_at, $updated_at,
-             $intelligence, $toughness, $friendliness, $ruggedness, $enthusiasm, $virility, $ferocity, $temperament, $sort_order)`,
+             $intelligence, $toughness, $friendliness, $ruggedness, $enthusiasm, $virility, $ferocity, $temperament, $sort_order,
+             $starred, $stabled, $is_pet_quality)`,
     {
       name: petName,
       species: genome.genome_type,
@@ -240,6 +245,9 @@ export async function uploadPet(
       ferocity: attrValues.ferocity ?? 50,
       temperament: attrValues.temperament ?? 50,
       sort_order: nextOrder,
+      starred: 0,
+      stabled: 1,
+      is_pet_quality: 0,
     },
   );
 
@@ -267,7 +275,12 @@ const UPDATABLE_COLUMNS = new Set([
   'virility',
   'ferocity',
   'temperament',
+  'starred',
+  'stabled',
+  'is_pet_quality',
 ]);
+
+const BOOLEAN_COLUMNS = new Set(['starred', 'stabled', 'is_pet_quality']);
 
 /**
  * Update a pet record.
@@ -294,7 +307,13 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
   for (const [field, value] of Object.entries(flat)) {
     if (!UPDATABLE_COLUMNS.has(field)) continue;
     setClauses.push(`${field} = $${field}`);
-    params[field] = field === 'genome_data' && typeof value !== 'string' ? JSON.stringify(value) : value;
+    if (field === 'genome_data' && typeof value !== 'string') {
+      params[field] = JSON.stringify(value);
+    } else if (BOOLEAN_COLUMNS.has(field)) {
+      params[field] = value ? 1 : 0;
+    } else {
+      params[field] = value;
+    }
   }
 
   let changed = false;

--- a/src/lib/stores/sidebar.svelte.ts
+++ b/src/lib/stores/sidebar.svelte.ts
@@ -1,0 +1,52 @@
+/**
+ * Reactive sidebar UI preferences (collapsed + width), persisted to localStorage.
+ * Kept out of settingsService because these are per-device view preferences
+ * that shouldn't sync or participate in backups.
+ */
+
+const WIDTH_KEY = 'ui.sidebarWidth';
+const COLLAPSED_KEY = 'ui.sidebarCollapsed';
+const DEFAULT_WIDTH = 260;
+export const MIN_WIDTH = 200;
+export const MAX_WIDTH = 560;
+
+function readNumber(key: string, fallback: number): number {
+  if (typeof localStorage === 'undefined') return fallback;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function readBoolean(key: string): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  return localStorage.getItem(key) === '1';
+}
+
+function clampWidth(w: number): number {
+  return Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, w));
+}
+
+export const sidebar = $state({
+  width: clampWidth(readNumber(WIDTH_KEY, DEFAULT_WIDTH)),
+  collapsed: readBoolean(COLLAPSED_KEY),
+});
+
+/** Set width without persisting. Use during drag for cheap updates. */
+export function setSidebarWidth(w: number): void {
+  sidebar.width = clampWidth(w);
+}
+
+/** Persist the current width — call once at the end of a drag (or when committing via keyboard). */
+export function commitSidebarWidth(): void {
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(WIDTH_KEY, String(sidebar.width));
+  }
+}
+
+export function toggleSidebar(): void {
+  sidebar.collapsed = !sidebar.collapsed;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(COLLAPSED_KEY, sidebar.collapsed ? '1' : '0');
+  }
+}

--- a/src/lib/stores/sidebar.svelte.ts
+++ b/src/lib/stores/sidebar.svelte.ts
@@ -34,14 +34,19 @@ export const sidebar = $state({
 
 /** Set width without persisting. Use during drag for cheap updates. */
 export function setSidebarWidth(w: number): void {
-  sidebar.width = clampWidth(w);
+  const next = clampWidth(w);
+  if (sidebar.width === next) return;
+  sidebar.width = next;
 }
+
+let lastPersistedWidth: number | null = null;
 
 /** Persist the current width — call once at the end of a drag (or when committing via keyboard). */
 export function commitSidebarWidth(): void {
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem(WIDTH_KEY, String(sidebar.width));
-  }
+  if (typeof localStorage === 'undefined') return;
+  if (lastPersistedWidth === sidebar.width) return;
+  localStorage.setItem(WIDTH_KEY, String(sidebar.width));
+  lastPersistedWidth = sidebar.width;
 }
 
 export function toggleSidebar(): void {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -94,6 +94,10 @@ export interface Pet {
   virility: number;
   ferocity: number;
   temperament: number;
+  // User-toggled flags
+  starred: boolean;
+  stabled: boolean;
+  is_pet_quality: boolean;
   // Computed fields (added by service layer)
   readonly?: boolean;
   is_demo?: boolean;

--- a/tests/e2e/gallery.spec.js
+++ b/tests/e2e/gallery.spec.js
@@ -8,12 +8,12 @@ test.describe('Pet Image Gallery', () => {
   });
 
   test('Gallery button appears in view controls', async ({ page }) => {
-    await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+    await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
   });
 
   test('Clicking Gallery shows the gallery view', async ({ page }) => {
-    await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+    await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
     await page.locator('.view-btn', { hasText: 'Gallery' }).click();
 
@@ -23,7 +23,7 @@ test.describe('Pet Image Gallery', () => {
   });
 
   test('Toggling Gallery hides the gene visualizer', async ({ page }) => {
-    await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+    await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.gene-visualizer')).toBeVisible();
 
     await page.locator('.view-btn', { hasText: 'Gallery' }).click();
@@ -36,7 +36,7 @@ test.describe('Pet Image Gallery', () => {
   });
 
   test('Gallery shows image count', async ({ page }) => {
-    await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+    await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
     await page.locator('.view-btn', { hasText: 'Gallery' }).click();
 
@@ -44,7 +44,7 @@ test.describe('Pet Image Gallery', () => {
   });
 
   test('Upload button exists but requires Tauri for actual upload', async ({ page }) => {
-    await page.locator('button', { hasText: 'Sample Fae Bee' }).first().click();
+    await page.locator('.pet-card', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
 
     await page.locator('.view-btn', { hasText: 'Gallery' }).click();

--- a/tests/unit/petTags.test.js
+++ b/tests/unit/petTags.test.js
@@ -60,8 +60,8 @@ describe('Pet Tags (junction table)', () => {
   });
 
   describe('migration', () => {
-    it('schema version is 7', () => {
-      expect(CURRENT_SCHEMA_VERSION).toBe(7);
+    it('schema version is at least 7 (tags junction table)', () => {
+      expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(7);
     });
   });
 


### PR DESCRIPTION
## Summary

Two quality-of-life improvements for managing large pet collections (200+ pets).

### Pet markers

Three per-pet boolean flags with inline icon toggles on every card:

- **⭐ Starred** — favourites. Hollow star off, filled amber on.
- **🏠 Stabled** — currently available in your stables. Hollow off, filled accent on. Defaults to \`true\` so users upgrading with a populated DB don't end up with an empty list on first launch.
- **🐾 Pet quality** — flagged as not usable for breeding. Shown as a badge on the card; future breeding sims can exclude these.

Click the icon on the card to toggle. The pet editor uses the same icon language in place of the old checkboxes. Filter toolbar in the pet list gets two new buttons — **Starred** and **Stabled** (on by default). Migration v8 adds the columns; INSERT sets defaults explicitly so the feature works in both Tauri SQLite and the in-memory dev/test DB. Backup export/import picks up the new columns via \`PET_COLUMNS\`.

### Collapsible + resizable sidebar

The master panel now has:

- A collapse chevron (‹) that shrinks the panel to a thin rail; click the rail to expand.
- A drag handle on the right edge to resize between 200 and 560 px.
- Keyboard support: arrow keys on the handle resize in 8/32 px steps (Shift for larger).
- Width and collapsed state persist to \`localStorage\` (UI-only preference — not backed up).

## Test plan

- [x] \`pnpm lint:ci\` clean
- [x] 246 unit tests pass
- [x] Manual: toggling star on a card persists and shifts the card's position if \"Starred only\" is on
- [x] Manual: Stabled toggle removes the pet from the default view (re-add via \"Stabled only\" off)
- [x] Manual: Collapse + resize sidebar, reload page, state restored from localStorage
- [ ] Manual: verify backup export includes the 3 new columns (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)