### PR TITLE
feat(stable): stable table view with filters, actions, persisted state

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 import { initDatabase } from '$lib/services/database.js';
 import { loadDemoPetsIfNeeded, populateGenesIfNeeded } from '$lib/services/demoService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
+import { backfillPositiveGenesIfNeeded } from '$lib/services/petService.js';
 import { settingsActions } from '$lib/stores/settings.js';
 
 const { children } = $props();
@@ -13,6 +14,8 @@ onMount(async () => {
   await runMigrations();
   await populateGenesIfNeeded();
   await loadDemoPetsIfNeeded();
+  // Gene-effects DB is populated; safe to backfill positive_genes for existing pets.
+  await backfillPositiveGenesIfNeeded();
   await settingsActions.load();
   ready = true;
 });

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -32,6 +32,13 @@ function switchTab(tab) {
         </button>
         <button
             class="tab-btn"
+            class:active={$activeTab === "stable"}
+            onclick={() => switchTab("stable")}
+        >
+            📋 Stable
+        </button>
+        <button
+            class="tab-btn"
             class:active={$activeTab === "compare"}
             onclick={() => switchTab("compare")}
         >

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -423,7 +423,9 @@ async function handleDrop(e, dropIndex) {
     }
 
     .pet-list-header {
-        padding: 12px;
+        /* Extra right padding carves out space for the MasterPanel collapse button
+           absolutely positioned at top: 6px; right: 6px (24px wide). */
+        padding: 12px 34px 12px 12px;
         border-bottom: 1px solid var(--border-primary);
         flex-shrink: 0;
     }

--- a/src/lib/components/stable/StableTable.svelte
+++ b/src/lib/components/stable/StableTable.svelte
@@ -188,13 +188,12 @@ function sortIndicator(colId) {
 <div class="stable-view" data-testid="stable-view">
     <header class="stable-header">
         <h2 class="stable-title">Stable</h2>
-        <div class="species-tabs" role="tablist" aria-label="Species">
+        <div class="species-tabs" role="group" aria-label="Species">
             {#each SPECIES as species}
                 <button
                     class="species-tab-btn"
                     class:active={stableView.species === species}
-                    role="tab"
-                    aria-selected={stableView.species === species}
+                    aria-pressed={stableView.species === species}
                     data-species={species}
                     onclick={() => { stableView.species = species; }}
                 >

--- a/src/lib/components/stable/StableTable.svelte
+++ b/src/lib/components/stable/StableTable.svelte
@@ -1,0 +1,629 @@
+<script>
+import PetEditor from '$lib/components/pet/PetEditor.svelte';
+import {
+  getAllAttributeNames,
+  getAllAttributes,
+  getSupportedSpecies,
+  normalizeSpecies,
+} from '$lib/services/configService.js';
+import { comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
+import { allTags as allTagsStore, appState, pets } from '$lib/stores/pets.js';
+import { stableView } from '$lib/stores/stable.svelte.js';
+import { HORSE_BREEDS } from '$lib/types/index.js';
+
+const SPECIES = getSupportedSpecies();
+
+const BREEDS_BY_SPECIES = {
+  beewasp: ['Bee', 'Wasp'],
+  horse: Object.keys(HORSE_BREEDS),
+};
+
+let editingPet = $state(null);
+let editorOpen = $state(false);
+
+const comparisonIds = $derived(new Set([$comparisonPets[0]?.id, $comparisonPets[1]?.id].filter((id) => id != null)));
+
+function viewPet(pet) {
+  appState.selectPet(pet);
+  appState.switchTab('pets');
+}
+
+function openEditor(pet) {
+  editingPet = pet;
+  editorOpen = true;
+}
+
+function closeEditor() {
+  editorOpen = false;
+  editingPet = null;
+}
+
+function toggleCompare(pet) {
+  if (comparisonIds.has(pet.id)) comparisonActions.removePet(pet.id);
+  else comparisonActions.addPet(pet);
+}
+
+function startCompare() {
+  appState.switchTab('compare');
+}
+
+/**
+ * Build the column list for the currently selected species. Species-specific
+ * attribute columns (temperament / ferocity) appear only for the species they
+ * belong to; Breed is a shared column that may be blank on species that don't
+ * use it yet.
+ */
+function buildColumns(species) {
+  const attrConfig = getAllAttributes(species);
+  const attrNames = getAllAttributeNames(species);
+  const attrCols = attrNames.map((attr) => {
+    const info = attrConfig[attr];
+    return {
+      id: attr,
+      label: info?.name ?? attr,
+      title: info?.name ?? attr,
+      accessor: (pet) => pet[attr] ?? 0,
+      numeric: true,
+      compact: true,
+      sortable: true,
+    };
+  });
+
+  const attrTotal = (pet) => attrNames.reduce((sum, attr) => sum + (pet[attr] ?? 0), 0);
+
+  return [
+    { id: 'actions', label: 'Actions', accessor: () => '', numeric: false, sortable: false },
+    { id: 'name', label: 'Name', accessor: (pet) => pet.name ?? '', numeric: false, sortable: true },
+    { id: 'gender', label: 'Gender', accessor: (pet) => pet.gender ?? '', numeric: false, sortable: true },
+    { id: 'breed', label: 'Breed', accessor: (pet) => pet.breed ?? '', numeric: false, sortable: true },
+    ...attrCols,
+    {
+      id: 'attr_total',
+      label: 'Total',
+      title: 'Sum of attributes',
+      accessor: attrTotal,
+      numeric: true,
+      compact: true,
+      sortable: true,
+    },
+    {
+      id: 'positive_genes',
+      label: '+ Genes',
+      title: 'Confirmed positive-effect genes',
+      accessor: (pet) => pet.positive_genes ?? 0,
+      numeric: true,
+      sortable: true,
+    },
+  ];
+}
+
+const columns = $derived(buildColumns(stableView.species));
+
+const breedOptions = $derived(BREEDS_BY_SPECIES[stableView.species] ?? []);
+const availableTags = $derived($allTagsStore);
+
+const filteredPets = $derived.by(() => {
+  const q = stableView.search.trim().toLowerCase();
+  const tagSet = new Set(stableView.tags);
+  return $pets.filter((pet) => {
+    if (!pet.stabled) return false;
+    if (normalizeSpecies(pet.species) !== stableView.species) return false;
+    if (q && !(pet.name ?? '').toLowerCase().includes(q)) return false;
+    if (stableView.gender !== 'all' && pet.gender !== stableView.gender) return false;
+    if (stableView.breed !== 'all' && pet.breed !== stableView.breed) return false;
+    if (stableView.starredOnly && !pet.starred) return false;
+    if (stableView.petQualityOnly && !pet.is_pet_quality) return false;
+    if (tagSet.size > 0) {
+      const petTags = pet.tags ?? [];
+      for (const t of tagSet) if (!petTags.includes(t)) return false;
+    }
+    return true;
+  });
+});
+
+// Reset the breed filter when the selected species changes and the chosen
+// breed no longer belongs to that species.
+$effect(() => {
+  if (stableView.breed === 'all') return;
+  if (!breedOptions.includes(stableView.breed)) {
+    stableView.breed = 'all';
+  }
+});
+
+// Drop stale tag filters that no longer exist on any pet.
+$effect(() => {
+  const valid = stableView.tags.filter((t) => availableTags.includes(t));
+  if (valid.length !== stableView.tags.length) {
+    stableView.tags = valid;
+  }
+});
+
+function toggleTagFilter(tag) {
+  if (stableView.tags.includes(tag)) {
+    stableView.tags = stableView.tags.filter((t) => t !== tag);
+  } else {
+    stableView.tags = [...stableView.tags, tag];
+  }
+}
+
+const sortedPets = $derived.by(() => {
+  const col = columns.find((c) => c.id === stableView.sortCol) ?? columns[0];
+  const list = [...filteredPets];
+  list.sort((a, b) => {
+    const av = col.accessor(a);
+    const bv = col.accessor(b);
+    const cmp = col.numeric ? Number(av) - Number(bv) : String(av).localeCompare(String(bv));
+    return stableView.sortDir === 'asc' ? cmp : -cmp;
+  });
+  return list;
+});
+
+// If the currently-sorted column doesn't exist for the newly-selected species
+// (only temperament ↔ ferocity can disappear), fall back to sorting by name.
+$effect(() => {
+  const ids = new Set(columns.map((c) => c.id));
+  if (!ids.has(stableView.sortCol)) {
+    stableView.sortCol = 'name';
+    stableView.sortDir = 'asc';
+  }
+});
+
+function toggleSort(colId) {
+  const col = columns.find((c) => c.id === colId);
+  if (!col || col.sortable === false) return;
+  if (stableView.sortCol === colId) {
+    stableView.sortDir = stableView.sortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    stableView.sortCol = colId;
+    stableView.sortDir = 'asc';
+  }
+}
+
+function sortIndicator(colId) {
+  if (colId !== stableView.sortCol) return '';
+  return stableView.sortDir === 'asc' ? ' ▲' : ' ▼';
+}
+</script>
+
+<div class="stable-view" data-testid="stable-view">
+    <header class="stable-header">
+        <h2 class="stable-title">Stable</h2>
+        <div class="species-tabs" role="tablist" aria-label="Species">
+            {#each SPECIES as species}
+                <button
+                    class="species-tab-btn"
+                    class:active={stableView.species === species}
+                    role="tab"
+                    aria-selected={stableView.species === species}
+                    data-species={species}
+                    onclick={() => { stableView.species = species; }}
+                >
+                    {species}
+                </button>
+            {/each}
+        </div>
+        <span class="count">{sortedPets.length} stabled</span>
+        {#if $comparisonReady}
+            <button class="compare-now-btn" onclick={startCompare} title="Open comparison view">
+                ⚖️ Compare ({[$comparisonPets[0]?.name, $comparisonPets[1]?.name].filter(Boolean).join(' vs ')})
+            </button>
+        {/if}
+    </header>
+
+    <div class="filter-bar">
+        <input
+            class="filter-search"
+            type="search"
+            placeholder="Search by name…"
+            data-testid="stable-search"
+            bind:value={stableView.search}
+        />
+        <label class="filter-select-label">
+            <span>Gender</span>
+            <select class="filter-select" bind:value={stableView.gender} data-testid="stable-gender">
+                <option value="all">All</option>
+                <option value="Male">Male</option>
+                <option value="Female">Female</option>
+            </select>
+        </label>
+        <label class="filter-select-label">
+            <span>Breed</span>
+            <select class="filter-select" bind:value={stableView.breed} data-testid="stable-breed">
+                <option value="all">All</option>
+                {#each breedOptions as breed}
+                    <option value={breed}>{breed}</option>
+                {/each}
+            </select>
+        </label>
+        <button
+            class="filter-pill"
+            class:active={stableView.starredOnly}
+            data-testid="stable-starred"
+            onclick={() => { stableView.starredOnly = !stableView.starredOnly; }}
+            title="Show only starred pets"
+        >⭐ Starred</button>
+        <button
+            class="filter-pill"
+            class:active={stableView.petQualityOnly}
+            data-testid="stable-pet-quality"
+            onclick={() => { stableView.petQualityOnly = !stableView.petQualityOnly; }}
+            title="Show only pet-quality pets"
+        >🏆 Pet quality</button>
+        {#if availableTags.length > 0}
+            <div class="filter-tags">
+                {#each availableTags as tag}
+                    <button
+                        class="filter-pill tag"
+                        class:active={stableView.tags.includes(tag)}
+                        onclick={() => toggleTagFilter(tag)}
+                    >{tag}</button>
+                {/each}
+            </div>
+        {/if}
+    </div>
+
+    <div class="table-scroll">
+        <table class="stable-table">
+            <thead>
+                <tr>
+                    {#each columns as col (col.id)}
+                        <th
+                            class="header-cell"
+                            class:numeric={col.numeric}
+                            class:compact={col.compact}
+                            class:active-sort={stableView.sortCol === col.id}
+                            data-col={col.id}
+                            title={col.title ?? ''}
+                        >
+                            {#if col.sortable === false}
+                                <span class="header-static">{col.label}</span>
+                            {:else}
+                                <button
+                                    type="button"
+                                    class="header-sort-btn"
+                                    onclick={() => toggleSort(col.id)}
+                                    aria-label="Sort by {col.title ?? col.label}"
+                                >
+                                    {col.label}{sortIndicator(col.id)}
+                                </button>
+                            {/if}
+                        </th>
+                    {/each}
+                </tr>
+            </thead>
+            <tbody>
+                {#if sortedPets.length === 0}
+                    <tr>
+                        <td class="empty" colspan={columns.length}>
+                            No stabled {stableView.species} pets.
+                        </td>
+                    </tr>
+                {:else}
+                    {#each sortedPets as pet (pet.id)}
+                        <tr data-pet-id={pet.id}>
+                            {#each columns as col (col.id)}
+                                <td class:numeric={col.numeric} class:compact={col.compact} data-col={col.id}>
+                                    {#if col.id === 'actions'}
+                                        <div class="row-actions">
+                                            <button
+                                                class="row-action-btn"
+                                                title="View genes"
+                                                aria-label="View genes for {pet.name}"
+                                                data-action="view"
+                                                onclick={() => viewPet(pet)}
+                                            >👁</button>
+                                            <button
+                                                class="row-action-btn"
+                                                title="Edit pet"
+                                                aria-label="Edit {pet.name}"
+                                                data-action="edit"
+                                                onclick={() => openEditor(pet)}
+                                            >✎</button>
+                                            <button
+                                                class="row-action-btn"
+                                                class:active={comparisonIds.has(pet.id)}
+                                                title={comparisonIds.has(pet.id) ? 'Remove from comparison' : 'Add to comparison'}
+                                                aria-label="Toggle comparison selection for {pet.name}"
+                                                aria-pressed={comparisonIds.has(pet.id)}
+                                                data-action="compare"
+                                                onclick={() => toggleCompare(pet)}
+                                            >⚖️</button>
+                                        </div>
+                                    {:else}
+                                        {col.accessor(pet)}
+                                    {/if}
+                                </td>
+                            {/each}
+                        </tr>
+                    {/each}
+                {/if}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{#if editingPet}
+    <PetEditor
+        pet={editingPet}
+        bind:open={editorOpen}
+        onClose={closeEditor}
+        onSave={() => {}}
+    />
+{/if}
+
+<style>
+    .stable-view {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        min-height: 0;
+    }
+
+    .stable-header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 12px 16px;
+        border-bottom: 1px solid var(--border-primary);
+        background: var(--bg-primary);
+        flex-shrink: 0;
+    }
+
+    .stable-title {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .species-tabs {
+        display: flex;
+        gap: 4px;
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 3px;
+    }
+
+    .species-tab-btn {
+        padding: 4px 14px;
+        border: none;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--text-tertiary);
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        text-transform: capitalize;
+        transition: all 0.15s ease;
+    }
+
+    .species-tab-btn:hover {
+        color: var(--text-secondary);
+    }
+
+    .species-tab-btn.active {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-sm);
+    }
+
+    .count {
+        margin-left: auto;
+        font-size: 11px;
+        color: var(--text-muted);
+    }
+
+    .table-scroll {
+        flex: 1;
+        overflow: auto;
+        padding: 12px 16px 16px;
+    }
+
+    .stable-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        overflow: hidden;
+    }
+
+    .stable-table th,
+    .stable-table td {
+        padding: 6px 10px;
+        text-align: left;
+        border-bottom: 1px solid var(--border-primary);
+        white-space: nowrap;
+    }
+
+    .stable-table th.numeric,
+    .stable-table td.numeric {
+        text-align: right;
+    }
+
+    .stable-table th.compact,
+    .stable-table td.compact {
+        padding-left: 6px;
+        padding-right: 6px;
+        text-align: center;
+        width: 1%; /* shrink-to-fit */
+    }
+
+    .stable-table th.compact {
+        font-size: 11px;
+        letter-spacing: 0.2px;
+    }
+
+    .stable-table td.compact {
+        font-variant-numeric: tabular-nums;
+    }
+
+    .stable-table thead th {
+        background: var(--bg-tertiary);
+        font-weight: 600;
+        color: var(--text-secondary);
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    .stable-table th.active-sort {
+        color: var(--accent-text);
+    }
+
+    .header-sort-btn {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
+        width: 100%;
+        text-align: inherit;
+    }
+
+    .header-sort-btn:hover {
+        color: var(--accent-text);
+    }
+
+    .stable-table tbody tr:hover {
+        background: var(--bg-secondary);
+    }
+
+    .empty {
+        padding: 24px;
+        text-align: center;
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .header-static {
+        color: var(--text-secondary);
+    }
+
+    .row-actions {
+        display: flex;
+        gap: 2px;
+        justify-content: flex-start;
+    }
+
+    .row-action-btn {
+        width: 24px;
+        height: 24px;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: 4px;
+        background: transparent;
+        color: var(--text-tertiary);
+        font-size: 12px;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.15s ease;
+    }
+
+    .row-action-btn:hover {
+        background: var(--bg-selected);
+        border-color: var(--accent-soft);
+        color: var(--accent-text);
+    }
+
+    .row-action-btn.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
+    }
+
+    .compare-now-btn {
+        padding: 6px 14px;
+        background: var(--accent);
+        border: none;
+        border-radius: 6px;
+        color: white;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s ease;
+    }
+
+    .compare-now-btn:hover {
+        background: var(--accent-hover);
+    }
+
+    .filter-bar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 8px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--border-primary);
+        background: var(--bg-primary);
+        flex-shrink: 0;
+    }
+
+    .filter-search {
+        flex: 0 1 220px;
+        padding: 6px 10px;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 12px;
+        outline: none;
+    }
+
+    .filter-search:focus {
+        border-color: var(--accent);
+        background: var(--bg-primary);
+    }
+
+    .filter-select-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        color: var(--text-tertiary);
+    }
+
+    .filter-select {
+        padding: 4px 8px;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 12px;
+        cursor: pointer;
+    }
+
+    .filter-pill {
+        padding: 3px 10px;
+        border: 1px solid var(--border-primary);
+        border-radius: 10px;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
+        font-size: 11px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .filter-pill:hover {
+        border-color: var(--accent);
+        color: var(--accent-text);
+    }
+
+    .filter-pill.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
+    }
+
+    .filter-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+</style>

--- a/src/lib/services/genomeParser.ts
+++ b/src/lib/services/genomeParser.ts
@@ -181,6 +181,36 @@ export function getAllGenes(genome: Genome): Gene[] {
 }
 
 /**
+ * Convert a parsed Genome into the chromosome → gene-string format used by
+ * the visualization and analysis layers (e.g. "RDRD RDRR ?D?? x?xR").
+ */
+export function genomeToGeneStrings(genome: Genome): Record<string, string> {
+  const geneStrings: Record<string, string> = {};
+  for (const [chromosome, genes] of Object.entries(genome.genes)) {
+    let geneString = '';
+    let currentBlock = '';
+    let currentBlockGenes = '';
+
+    for (const gene of genes as Gene[]) {
+      if (gene.block !== currentBlock) {
+        if (currentBlockGenes) {
+          geneString += `${currentBlockGenes} `;
+        }
+        currentBlock = gene.block;
+        currentBlockGenes = '';
+      }
+      currentBlockGenes += gene.gene_type;
+    }
+    if (currentBlockGenes) {
+      geneString += currentBlockGenes;
+    }
+
+    geneStrings[chromosome] = geneString.trim();
+  }
+  return geneStrings;
+}
+
+/**
  * Convert a genome to JSON string.
  */
 export function genomeToJson(genome: Genome): string {

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -134,6 +134,14 @@ const MIGRATIONS: Migration[] = [
       // would otherwise be empty for users upgrading with a populated database.
     },
   },
+  {
+    version: 9,
+    description: 'Add positive_genes column to pets (backfilled in JS after migrations run)',
+    up: async () => {
+      const db = getDb();
+      await db.execute('ALTER TABLE pets ADD COLUMN positive_genes INTEGER NOT NULL DEFAULT 0');
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -2,13 +2,16 @@
  * Pet data service for Gorgonetics.
  */
 
-import type { Gene, Genome, Pet } from '$lib/types/index.js';
+import type { Genome, Pet } from '$lib/types/index.js';
 import { GENOME_FILE_MARKERS } from '$lib/types/index.js';
+import { computeGeneStats } from '$lib/utils/geneAnalysis.js';
 import { now } from '$lib/utils/timestamp.js';
-import { getDefaultValues } from './configService.js';
+import { getDefaultValues, normalizeSpecies } from './configService.js';
 import { getDb, reorderRows } from './database.js';
-import { isValidGenomeFile, parseGenome } from './genomeParser.js';
+import { getGeneEffectsCached } from './geneService.js';
+import { genomeToGeneStrings, isValidGenomeFile, parseGenome } from './genomeParser.js';
 import { parseStructuredPetName } from './nameParser.js';
+import { getSetting, setSetting } from './settingsService.js';
 
 /**
  * Compute SHA-256 hash of a string.
@@ -66,6 +69,27 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
   return { total, known, unknown };
 }
 
+/**
+ * Count the genes in a genome that confer a confirmed positive attribute
+ * effect, using the same logic as `GeneStatsTable`'s totals row. The genes
+ * table must be populated (ensured by `populateGenesIfNeeded` at startup).
+ */
+export async function computePositiveGenesForGenome(
+  genomeData: string | Genome,
+  breed: string | undefined,
+): Promise<number> {
+  const genome = typeof genomeData === 'string' ? (JSON.parse(genomeData) as Genome) : genomeData;
+  const species = normalizeSpecies(genome.genome_type);
+  if (!species) return 0;
+  const geneStrings = genomeToGeneStrings(genome);
+  const effectsData = await getGeneEffectsCached(species);
+  const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
+  const { stats } = computeGeneStats(geneStrings, species, effectsDB, breed);
+  let total = 0;
+  for (const entry of Object.values(stats)) total += entry.positive;
+  return total;
+}
+
 /** Enrich a raw pet row from the database with computed fields. */
 function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
   const geneCounts = countGenes(pet.genome_data);
@@ -75,6 +99,7 @@ function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
     starred: Boolean(pet.starred),
     stabled: Boolean(pet.stabled),
     is_pet_quality: Boolean(pet.is_pet_quality),
+    positive_genes: Number(pet.positive_genes ?? 0),
     total_genes: geneCounts.total,
     known_genes: geneCounts.known,
     unknown_genes: geneCounts.unknown,
@@ -207,6 +232,8 @@ export async function uploadPet(
   const petBreed = parsed?.breed ?? '';
   const attrValues = parsed?.attributes ?? defaults;
 
+  const positiveGenes = await computePositiveGenesForGenome(genome, petBreed);
+
   const db = getDb();
   const ts = now();
 
@@ -220,11 +247,11 @@ export async function uploadPet(
      (name, species, gender, breed, breeder, content_hash, genome_data, notes,
       created_at, updated_at,
       intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament, sort_order,
-      starred, stabled, is_pet_quality)
+      starred, stabled, is_pet_quality, positive_genes)
      VALUES ($name, $species, $gender, $breed, $breeder, $content_hash, $genome_data, $notes,
              $created_at, $updated_at,
              $intelligence, $toughness, $friendliness, $ruggedness, $enthusiasm, $virility, $ferocity, $temperament, $sort_order,
-             $starred, $stabled, $is_pet_quality)`,
+             $starred, $stabled, $is_pet_quality, $positive_genes)`,
     {
       name: petName,
       species: genome.genome_type,
@@ -248,6 +275,7 @@ export async function uploadPet(
       starred: 0,
       stabled: 1,
       is_pet_quality: 0,
+      positive_genes: positiveGenes,
     },
   );
 
@@ -313,6 +341,19 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
       params[field] = value ? 1 : 0;
     } else {
       params[field] = value;
+    }
+  }
+
+  // If the genome or breed changed, the stored positive_genes count is stale.
+  // Recompute once using the incoming values, falling back to what's in the DB.
+  if (flat.genome_data !== undefined || flat.breed !== undefined) {
+    const current = await getPet(petId);
+    if (current) {
+      const nextGenomeData = (params.genome_data as string | undefined) ?? current.genome_data;
+      const nextBreed = (flat.breed as string | undefined) ?? current.breed ?? '';
+      const positiveGenes = await computePositiveGenesForGenome(nextGenomeData, nextBreed);
+      setClauses.push('positive_genes = $positive_genes');
+      params.positive_genes = positiveGenes;
     }
   }
 
@@ -406,39 +447,12 @@ export async function getPetGenome(
 
   const genome = genomeJson as Genome;
 
-  // Convert genome to the format expected by the frontend
-  // (chromosome -> gene string like "RDRD RDRR ?D?? x?xR")
-  const geneStrings: Record<string, string> = {};
-  for (const [chromosome, genes] of Object.entries(genome.genes)) {
-    let geneString = '';
-    let currentBlock = '';
-    let currentBlockGenes = '';
-
-    for (const gene of genes as Gene[]) {
-      if (gene.block !== currentBlock) {
-        if (currentBlockGenes) {
-          geneString += currentBlockGenes + ' ';
-        }
-        currentBlock = gene.block;
-        currentBlockGenes = '';
-      }
-      currentBlockGenes += gene.gene_type;
-    }
-
-    // Add the last block
-    if (currentBlockGenes) {
-      geneString += currentBlockGenes;
-    }
-
-    geneStrings[chromosome] = geneString.trim();
-  }
-
   return {
     name: pet.name,
     owner: genome.breeder,
     species: genome.genome_type,
     format: genome.format_version,
-    genes: geneStrings,
+    genes: genomeToGeneStrings(genome),
   };
 }
 
@@ -456,4 +470,51 @@ export async function hasPets(): Promise<boolean> {
  */
 export function reorderPets(orderedIds: number[]): Promise<void> {
   return reorderRows('pets', orderedIds);
+}
+
+const POSITIVE_GENES_BACKFILL_KEY = 'pets.positive_genes_backfilled';
+
+/**
+ * One-shot backfill that populates positive_genes for every pet using the
+ * same logic applied at upload time. Idempotent via a settings-table flag;
+ * safe to call on every app startup. Required because the v9 migration only
+ * adds the column with a DEFAULT 0 — the actual count depends on the JS-side
+ * gene-effects database and cannot be computed in SQL.
+ */
+export async function backfillPositiveGenesIfNeeded(): Promise<void> {
+  const done = await getSetting<boolean>(POSITIVE_GENES_BACKFILL_KEY);
+  if (done) return;
+
+  const db = getDb();
+  const rows = await db.select<{ id: number; genome_data: string; breed: string | null }[]>(
+    'SELECT id, genome_data, breed FROM pets',
+  );
+
+  const updates = await Promise.all(
+    rows.map(async (row) => {
+      try {
+        const positive = await computePositiveGenesForGenome(row.genome_data, row.breed ?? '');
+        return { id: row.id, positive };
+      } catch (e) {
+        console.warn(`Backfill failed for pet ${row.id}:`, e);
+        return null;
+      }
+    }),
+  );
+
+  await db.execute('BEGIN');
+  try {
+    for (const update of updates) {
+      if (!update) continue;
+      await db.execute('UPDATE pets SET positive_genes = $pg WHERE id = $id', {
+        pg: update.positive,
+        id: update.id,
+      });
+    }
+    await db.execute('COMMIT');
+  } catch (e) {
+    await db.execute('ROLLBACK');
+    throw e;
+  }
+  await setSetting(POSITIVE_GENES_BACKFILL_KEY, true);
 }

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -78,16 +78,25 @@ export async function computePositiveGenesForGenome(
   genomeData: string | Genome,
   breed: string | undefined,
 ): Promise<number> {
-  const genome = typeof genomeData === 'string' ? (JSON.parse(genomeData) as Genome) : genomeData;
-  const species = normalizeSpecies(genome.genome_type);
-  if (!species) return 0;
-  const geneStrings = genomeToGeneStrings(genome);
-  const effectsData = await getGeneEffectsCached(species);
-  const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
-  const { stats } = computeGeneStats(geneStrings, species, effectsDB, breed);
-  let total = 0;
-  for (const entry of Object.values(stats)) total += entry.positive;
-  return total;
+  // Malformed JSON or unexpected shapes must not crash the caller — upload
+  // and update paths can't afford to abort on bad data. Return 0 and let the
+  // caller persist a safe placeholder.
+  try {
+    const parsed: unknown = typeof genomeData === 'string' ? JSON.parse(genomeData) : genomeData;
+    if (!parsed || typeof parsed !== 'object') return 0;
+    const genome = parsed as Genome;
+    const species = normalizeSpecies(genome.genome_type);
+    if (!species) return 0;
+    const geneStrings = genomeToGeneStrings(genome);
+    const effectsData = await getGeneEffectsCached(species);
+    const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
+    const { stats } = computeGeneStats(geneStrings, species, effectsDB, breed);
+    let total = 0;
+    for (const entry of Object.values(stats)) total += entry.positive;
+    return total;
+  } catch {
+    return 0;
+  }
 }
 
 /** Enrich a raw pet row from the database with computed fields. */

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -2,7 +2,7 @@ import { derived, type Writable, writable } from 'svelte/store';
 import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 
-export type Tab = 'pets' | 'editor' | 'compare';
+export type Tab = 'pets' | 'editor' | 'compare' | 'stable';
 
 export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
@@ -112,7 +112,7 @@ export const appState = {
       geneEditingView.set(null);
     } else if (tab === 'editor') {
       selectedPet.set(null);
-    } else if (tab === 'compare') {
+    } else if (tab === 'compare' || tab === 'stable') {
       selectedPet.set(null);
       geneEditingView.set(null);
     }

--- a/src/lib/stores/stable.svelte.ts
+++ b/src/lib/stores/stable.svelte.ts
@@ -1,0 +1,22 @@
+/**
+ * Reactive state for the Stable Table view. Lives at module scope so that
+ * species selection, sort column, and sort direction survive tab switches —
+ * the StableTable component is unmounted when the user navigates away, but
+ * this state persists for the session.
+ */
+
+import { getSupportedSpecies } from '$lib/services/configService.js';
+
+export type GenderFilter = 'all' | 'Male' | 'Female';
+
+export const stableView = $state({
+  species: getSupportedSpecies()[0],
+  sortCol: 'name',
+  sortDir: 'asc' as 'asc' | 'desc',
+  search: '',
+  gender: 'all' as GenderFilter,
+  breed: 'all' as string,
+  starredOnly: false,
+  petQualityOnly: false,
+  tags: [] as string[],
+});

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -94,6 +94,8 @@ export interface Pet {
   virility: number;
   ferocity: number;
   temperament: number;
+  // Persisted gene-analysis fields (computed at upload time)
+  positive_genes: number;
   // User-toggled flags
   starred: boolean;
   stabled: boolean;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@ import { onMount } from 'svelte';
 import ComparisonView from '$lib/components/comparison/ComparisonView.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
+import StableTable from '$lib/components/stable/StableTable.svelte';
 import { activeTab, appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
 
 onMount(async () => {
@@ -18,7 +19,9 @@ onMount(async () => {
 		</div>
 	{/if}
 
-	{#if $activeTab === 'compare'}
+	{#if $activeTab === 'stable'}
+		<StableTable />
+	{:else if $activeTab === 'compare'}
 		<ComparisonView />
 	{:else if $loading}
 		<div class="center-state">

--- a/tests/e2e/stable-table.spec.js
+++ b/tests/e2e/stable-table.spec.js
@@ -1,0 +1,156 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+async function openStable(page) {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await page.locator('.tab-btn').filter({ hasText: 'Stable' }).click();
+  await expect(page.locator('[data-testid="stable-view"]')).toBeVisible();
+}
+
+test.describe('Stable Table', () => {
+  test('renders the table with columns and at least one stabled pet', async ({ page }) => {
+    await openStable(page);
+    await expect(page.locator('.stable-table')).toBeVisible();
+    // Demo data always ships one beewasp pet; default species is the first
+    // supported species (beewasp), so it should render with a row.
+    await expect(page.locator('.stable-table tbody tr')).not.toHaveCount(0);
+  });
+
+  test('species tabs swap the visible pets and the species-specific column', async ({ page }) => {
+    await openStable(page);
+
+    // Beewasp view must expose a Ferocity column and no Temperament column.
+    await expect(page.locator('.stable-table th[data-col="ferocity"]')).toBeVisible();
+    await expect(page.locator('.stable-table th[data-col="temperament"]')).toHaveCount(0);
+
+    await page.locator('.species-tab-btn[data-species="horse"]').click();
+
+    // Horse view flips the species-specific column.
+    await expect(page.locator('.stable-table th[data-col="temperament"]')).toBeVisible();
+    await expect(page.locator('.stable-table th[data-col="ferocity"]')).toHaveCount(0);
+  });
+
+  test('clicking a header toggles the sort direction', async ({ page }) => {
+    await openStable(page);
+
+    const nameHeader = page.locator('.stable-table th[data-col="name"] .header-sort-btn');
+
+    // Default sort is on name, ascending.
+    await expect(nameHeader).toContainText('▲');
+
+    await nameHeader.click();
+    await expect(nameHeader).toContainText('▼');
+
+    await nameHeader.click();
+    await expect(nameHeader).toContainText('▲');
+  });
+
+  test('sort column falls back to name when switching to a species without that attribute', async ({ page }) => {
+    await openStable(page);
+
+    // Sort by ferocity (beewasp-specific).
+    await page.locator('.stable-table th[data-col="ferocity"] .header-sort-btn').click();
+    await expect(page.locator('.stable-table th[data-col="ferocity"]')).toHaveClass(/active-sort/);
+
+    // Switching to horse drops ferocity; the sort should fall back to name.
+    await page.locator('.species-tab-btn[data-species="horse"]').click();
+    await expect(page.locator('.stable-table th[data-col="name"]')).toHaveClass(/active-sort/);
+  });
+
+  test('positive-genes column is visible and numeric', async ({ page }) => {
+    await openStable(page);
+    const header = page.locator('.stable-table th[data-col="positive_genes"]');
+    await expect(header).toBeVisible();
+    await expect(header).toHaveClass(/numeric/);
+  });
+
+  test('view action switches to Pets tab and opens the visualization', async ({ page }) => {
+    await openStable(page);
+    await page.locator('.stable-table tbody tr button[data-action="view"]').first().click();
+    await expect(page.locator('.tab-btn').filter({ hasText: 'Pets' })).toHaveClass(/active/);
+    await expect(page.locator('.pet-visualization')).toBeVisible();
+  });
+
+  test('edit action opens the pet editor modal', async ({ page }) => {
+    await openStable(page);
+    await page.locator('.stable-table tbody tr button[data-action="edit"]').first().click();
+    await expect(page.getByText('Basic Information')).toBeVisible();
+  });
+
+  test('text search narrows rows by pet name', async ({ page }) => {
+    await openStable(page);
+    const rowsBefore = await page.locator('.stable-table tbody tr[data-pet-id]').count();
+    expect(rowsBefore).toBeGreaterThan(0);
+
+    await page.locator('[data-testid="stable-search"]').fill('zzz-nonexistent-name');
+    await expect(page.locator('.stable-table tbody tr[data-pet-id]')).toHaveCount(0);
+
+    await page.locator('[data-testid="stable-search"]').fill('');
+    await expect(page.locator('.stable-table tbody tr[data-pet-id]')).toHaveCount(rowsBefore);
+  });
+
+  test('gender filter narrows rows and persists across tabs', async ({ page }) => {
+    await openStable(page);
+
+    // The demo beewasp is Female; switching to Male should empty the table.
+    await page.locator('[data-testid="stable-gender"]').selectOption('Male');
+    await expect(page.locator('.stable-table tbody tr[data-pet-id]')).toHaveCount(0);
+
+    // Bounce through another tab; gender filter should still be "Male".
+    await page.locator('.tab-btn').filter({ hasText: 'Pets' }).click();
+    await page.locator('.tab-btn').filter({ hasText: 'Stable' }).click();
+    await expect(page.locator('[data-testid="stable-gender"]')).toHaveValue('Male');
+  });
+
+  test('breed filter resets when switching species', async ({ page }) => {
+    await openStable(page);
+
+    // Switch to horse, pick a horse breed.
+    await page.locator('.species-tab-btn[data-species="horse"]').click();
+    await page.locator('[data-testid="stable-breed"]').selectOption('Standardbred');
+    await expect(page.locator('[data-testid="stable-breed"]')).toHaveValue('Standardbred');
+
+    // Switch back to beewasp — Standardbred is not a beewasp breed, should reset.
+    await page.locator('.species-tab-btn[data-species="beewasp"]').click();
+    await expect(page.locator('[data-testid="stable-breed"]')).toHaveValue('all');
+  });
+
+  test('view state (species + sort) persists across tab switches', async ({ page }) => {
+    await openStable(page);
+
+    // Switch to horse and sort by toughness descending.
+    await page.locator('.species-tab-btn[data-species="horse"]').click();
+    const toughnessHeader = page.locator('.stable-table th[data-col="toughness"] .header-sort-btn');
+    await toughnessHeader.click(); // asc
+    await toughnessHeader.click(); // desc
+    await expect(toughnessHeader).toContainText('▼');
+
+    // Bounce through another tab.
+    await page.locator('.tab-btn').filter({ hasText: 'Pets' }).click();
+    await page.locator('.tab-btn').filter({ hasText: 'Stable' }).click();
+
+    // Horse species and desc sort on toughness should be restored.
+    await expect(page.locator('.species-tab-btn[data-species="horse"]')).toHaveClass(/active/);
+    await expect(page.locator('.stable-table th[data-col="toughness"] .header-sort-btn')).toContainText('▼');
+  });
+
+  test('compare action toggles active state and reveals the compare-now button', async ({ page }) => {
+    await openStable(page);
+    const compareBtn = page.locator('.stable-table tbody tr button[data-action="compare"]').first();
+
+    await expect(compareBtn).not.toHaveClass(/active/);
+    await compareBtn.click();
+    await expect(compareBtn).toHaveClass(/active/);
+
+    // Only one pet selected — compare-now should not appear yet.
+    await expect(page.locator('.compare-now-btn')).toHaveCount(0);
+
+    // Switch species, pick the second pet, then compare-now appears.
+    await page.locator('.species-tab-btn[data-species="horse"]').click();
+    const horseCompare = page.locator('.stable-table tbody tr button[data-action="compare"]').first();
+    await horseCompare.click();
+
+    await expect(page.locator('.compare-now-btn')).toBeVisible();
+  });
+});

--- a/tests/unit/positiveGenes.test.js
+++ b/tests/unit/positiveGenes.test.js
@@ -1,0 +1,135 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+import * as geneService from '$lib/services/geneService.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
+const SAMPLE_HORSE = readFileSync(resolve('data/Genes_SampleHorse.txt'), 'utf-8');
+
+/**
+ * Seed a minimal set of gene effects so computePositiveGenesForGenome has
+ * something to classify. We use chromosome IDs that appear in the sample
+ * genomes (01A1, 01A2, 01B1) and assign them positive effects on core
+ * attributes shared by both species.
+ */
+async function seedPositiveEffects(species) {
+  await geneService.upsertGene(species, '01', '01A1', {
+    effectDominant: 'Toughness+',
+    effectRecessive: 'None',
+  });
+  await geneService.upsertGene(species, '01', '01A2', {
+    effectDominant: 'Intelligence+',
+    effectRecessive: 'None',
+  });
+  await geneService.upsertGene(species, '01', '01B1', {
+    effectDominant: 'Friendliness+',
+    effectRecessive: 'None',
+  });
+  geneService.clearGeneEffectsCache(species);
+}
+
+describe('positive_genes computation', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('stores 0 on upload when no gene effects are known', async () => {
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const pet = await petService.getPet(result.pet_id);
+    expect(pet.positive_genes).toBe(0);
+  });
+
+  it('counts positive-effect genes at upload time once effects are seeded', async () => {
+    await seedPositiveEffects('beewasp');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const pet = await petService.getPet(result.pet_id);
+    // With three seeded positive effects on dominant genes, the count is
+    // bounded by how many of those positions carry D or x in the sample.
+    expect(pet.positive_genes).toBeGreaterThanOrEqual(0);
+    expect(pet.positive_genes).toBeLessThanOrEqual(3);
+  });
+
+  it('horse pets include species-specific effects in the total', async () => {
+    await geneService.upsertGene('horse', '01', '01A1', {
+      effectDominant: 'Temperament+',
+      effectRecessive: 'None',
+    });
+    geneService.clearGeneEffectsCache('horse');
+    const result = await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+    const pet = await petService.getPet(result.pet_id);
+    expect(pet.positive_genes).toBeGreaterThanOrEqual(0);
+  });
+
+  it('updatePet recomputes positive_genes when genome_data changes', async () => {
+    await seedPositiveEffects('beewasp');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const before = await petService.getPet(result.pet_id);
+
+    // Simulate a genome edit by re-writing the stored JSON; recomputation is
+    // what we care about, not the specific resulting value.
+    const genome = JSON.parse(before.genome_data);
+    await petService.updatePet(result.pet_id, { genome_data: JSON.stringify(genome) });
+    const after = await petService.getPet(result.pet_id);
+    expect(after.positive_genes).toBe(before.positive_genes);
+  });
+});
+
+describe('backfillPositiveGenesIfNeeded', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('populates positive_genes for pets inserted before effects were seeded', async () => {
+    // Upload first (effects empty → 0), then seed, then backfill.
+    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const before = await petService.getPet(upload.pet_id);
+    expect(before.positive_genes).toBe(0);
+
+    await seedPositiveEffects('beewasp');
+    // Backfill uses a settings flag to guard re-runs; reset it so the seeded
+    // effects actually drive a recompute in this test.
+    const db = getDb();
+    await db.execute('DELETE FROM settings WHERE key = $k', { k: 'pets.positive_genes_backfilled' });
+    await petService.backfillPositiveGenesIfNeeded();
+
+    const after = await petService.getPet(upload.pet_id);
+    expect(after.positive_genes).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is idempotent — repeated calls do not change the stored count', async () => {
+    await seedPositiveEffects('beewasp');
+    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const first = await petService.getPet(upload.pet_id);
+
+    await petService.backfillPositiveGenesIfNeeded();
+    await petService.backfillPositiveGenesIfNeeded();
+    const second = await petService.getPet(upload.pet_id);
+
+    expect(second.positive_genes).toBe(first.positive_genes);
+  });
+
+  it('skips recomputation once the flag is set', async () => {
+    // First upload + backfill with no effects: count is 0, flag gets set.
+    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    await petService.backfillPositiveGenesIfNeeded();
+    const before = await petService.getPet(upload.pet_id);
+    expect(before.positive_genes).toBe(0);
+
+    // Seed effects now. A fresh backfill would produce a non-zero count, but
+    // the flag is already set so the next call must be a no-op.
+    await seedPositiveEffects('beewasp');
+    await petService.backfillPositiveGenesIfNeeded();
+
+    const after = await petService.getPet(upload.pet_id);
+    expect(after.positive_genes).toBe(0);
+  });
+});

--- a/tests/unit/positiveGenes.test.js
+++ b/tests/unit/positiveGenes.test.js
@@ -7,28 +7,47 @@ import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
 
 const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
-const SAMPLE_HORSE = readFileSync(resolve('data/Genes_SampleHorse.txt'), 'utf-8');
 
 /**
- * Seed a minimal set of gene effects so computePositiveGenesForGenome has
- * something to classify. We use chromosome IDs that appear in the sample
- * genomes (01A1, 01A2, 01B1) and assign them positive effects on core
- * attributes shared by both species.
+ * Deterministic three-gene beewasp genome used by the tests below. After
+ * parsing, the genes land at positions 01A1, 01A2, 01A3 — all dominant (D).
+ * Seeding effects for these exact positions gives tests an exact count to
+ * assert against.
  */
-async function seedPositiveEffects(species) {
-  await geneService.upsertGene(species, '01', '01A1', {
+const MINIMAL_BEEWASP_GENOME = `[Overview]
+Format=1.0
+Character=Tester
+Entity=Minimal Bee
+Genome=BeeWasp
+
+[Genes]
+1=DDD
+`;
+
+/** Genome JSON with no genes — used to force recomputation to drop to 0. */
+const EMPTY_GENOME_JSON = JSON.stringify({
+  format_version: '1.0',
+  breeder: 'Tester',
+  name: 'Empty',
+  genome_type: 'BeeWasp',
+  genes: {},
+});
+
+/**
+ * Seed exactly two positive dominant effects on the minimal genome. Expected
+ * positive_genes count when uploading MINIMAL_BEEWASP_GENOME is therefore 2.
+ */
+async function seedTwoPositiveEffects() {
+  await geneService.upsertGene('beewasp', '01', '01A1', {
     effectDominant: 'Toughness+',
     effectRecessive: 'None',
   });
-  await geneService.upsertGene(species, '01', '01A2', {
+  await geneService.upsertGene('beewasp', '01', '01A2', {
     effectDominant: 'Intelligence+',
     effectRecessive: 'None',
   });
-  await geneService.upsertGene(species, '01', '01B1', {
-    effectDominant: 'Friendliness+',
-    effectRecessive: 'None',
-  });
-  geneService.clearGeneEffectsCache(species);
+  // 01A3 is intentionally left unseeded so it does not contribute.
+  geneService.clearGeneEffectsCache('beewasp');
 }
 
 describe('positive_genes computation', () => {
@@ -45,38 +64,24 @@ describe('positive_genes computation', () => {
     expect(pet.positive_genes).toBe(0);
   });
 
-  it('counts positive-effect genes at upload time once effects are seeded', async () => {
-    await seedPositiveEffects('beewasp');
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+  it('counts seeded positive-effect genes exactly at upload time', async () => {
+    await seedTwoPositiveEffects();
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
     const pet = await petService.getPet(result.pet_id);
-    // With three seeded positive effects on dominant genes, the count is
-    // bounded by how many of those positions carry D or x in the sample.
-    expect(pet.positive_genes).toBeGreaterThanOrEqual(0);
-    expect(pet.positive_genes).toBeLessThanOrEqual(3);
-  });
-
-  it('horse pets include species-specific effects in the total', async () => {
-    await geneService.upsertGene('horse', '01', '01A1', {
-      effectDominant: 'Temperament+',
-      effectRecessive: 'None',
-    });
-    geneService.clearGeneEffectsCache('horse');
-    const result = await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
-    const pet = await petService.getPet(result.pet_id);
-    expect(pet.positive_genes).toBeGreaterThanOrEqual(0);
+    expect(pet.positive_genes).toBe(2);
   });
 
   it('updatePet recomputes positive_genes when genome_data changes', async () => {
-    await seedPositiveEffects('beewasp');
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    await seedTwoPositiveEffects();
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
     const before = await petService.getPet(result.pet_id);
+    expect(before.positive_genes).toBe(2);
 
-    // Simulate a genome edit by re-writing the stored JSON; recomputation is
-    // what we care about, not the specific resulting value.
-    const genome = JSON.parse(before.genome_data);
-    await petService.updatePet(result.pet_id, { genome_data: JSON.stringify(genome) });
+    // Replace the genome with one that has no genes — recompute must drop the
+    // stored count to 0, proving the update hook actually runs.
+    await petService.updatePet(result.pet_id, { genome_data: EMPTY_GENOME_JSON });
     const after = await petService.getPet(result.pet_id);
-    expect(after.positive_genes).toBe(before.positive_genes);
+    expect(after.positive_genes).toBe(0);
   });
 });
 
@@ -89,26 +94,27 @@ describe('backfillPositiveGenesIfNeeded', () => {
   });
 
   it('populates positive_genes for pets inserted before effects were seeded', async () => {
-    // Upload first (effects empty → 0), then seed, then backfill.
-    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    // Upload first with no effects → stored as 0.
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
     const before = await petService.getPet(upload.pet_id);
     expect(before.positive_genes).toBe(0);
 
-    await seedPositiveEffects('beewasp');
-    // Backfill uses a settings flag to guard re-runs; reset it so the seeded
-    // effects actually drive a recompute in this test.
+    // Seed effects, reset the idempotency flag, then backfill. The count must
+    // now reflect the two seeded positive effects — proving backfill ran.
+    await seedTwoPositiveEffects();
     const db = getDb();
     await db.execute('DELETE FROM settings WHERE key = $k', { k: 'pets.positive_genes_backfilled' });
     await petService.backfillPositiveGenesIfNeeded();
 
     const after = await petService.getPet(upload.pet_id);
-    expect(after.positive_genes).toBeGreaterThanOrEqual(0);
+    expect(after.positive_genes).toBe(2);
   });
 
   it('is idempotent — repeated calls do not change the stored count', async () => {
-    await seedPositiveEffects('beewasp');
-    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    await seedTwoPositiveEffects();
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
     const first = await petService.getPet(upload.pet_id);
+    expect(first.positive_genes).toBe(2);
 
     await petService.backfillPositiveGenesIfNeeded();
     await petService.backfillPositiveGenesIfNeeded();
@@ -119,17 +125,24 @@ describe('backfillPositiveGenesIfNeeded', () => {
 
   it('skips recomputation once the flag is set', async () => {
     // First upload + backfill with no effects: count is 0, flag gets set.
-    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
     await petService.backfillPositiveGenesIfNeeded();
     const before = await petService.getPet(upload.pet_id);
     expect(before.positive_genes).toBe(0);
 
-    // Seed effects now. A fresh backfill would produce a non-zero count, but
-    // the flag is already set so the next call must be a no-op.
-    await seedPositiveEffects('beewasp');
+    // Seed effects now. A fresh backfill would produce count=2, but the flag
+    // is already set so the next call must be a no-op.
+    await seedTwoPositiveEffects();
     await petService.backfillPositiveGenesIfNeeded();
 
     const after = await petService.getPet(upload.pet_id);
     expect(after.positive_genes).toBe(0);
+  });
+
+  it('returns 0 without throwing when genome_data is malformed JSON', async () => {
+    // computePositiveGenesForGenome is defensive — called directly to avoid
+    // uploadPet's format validation.
+    const n = await petService.computePositiveGenesForGenome('{not valid json', '');
+    expect(n).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- New **Stable** tab with a per-species table of every stabled pet, columns for each attribute plus Σ-of-attributes and a **+Genes** score (persisted count of confirmed positive-effect genes).
- Filter bar: name search, gender, species-specific breed, starred, pet-quality, tag pills. Species/sort/filters all persist across tab switches for the session.
- Per-row actions: view (opens PetVisualization), edit (PetEditor modal), compare-toggle. A **Compare now** button appears in the header once two pets are selected and switches to the Compare tab.
- Backing changes: new `positive_genes` column (v9 migration) + one-shot JS-side backfill on startup guarded by a settings flag; `uploadPet` / `updatePet` keep it in sync via `computeGeneStats`.
- Extracted `genomeToGeneStrings` into `genomeParser.ts` and had `getPetGenome` reuse it (was inline-duplicated).

## Test plan
- [x] `pnpm test` — 253 unit tests pass (7 new covering upload hook, update recompute, backfill idempotence, skip-when-flag-set).
- [x] `pnpm test:e2e` — 12 new stable-table tests (render, species swap, sort toggle, sort-col fallback, +genes column, view/edit/compare actions, search/gender/breed filters, cross-tab persistence). Full e2e suite green.
- [x] `pnpm lint:ci` — 0 errors.
- [ ] Manual: upload a fresh genome and confirm the +Genes cell populates; bounce between tabs to confirm filter/sort state survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)