### PR TITLE
chore(release): drop no-op step, read notes from RELEASE_NOTES.md

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,11 +5,15 @@ set -euo pipefail
 # Usage: bash scripts/release.sh <major|minor|patch>
 #
 # Steps:
-#   1. Bumps version in package.json, tauri.conf.json, Cargo.toml, Cargo.lock, docs/index.html
+#   1. Bumps version in package.json, tauri.conf.json, Cargo.toml, Cargo.lock
 #   2. Regenerates screenshots (starts dev server, runs pnpm screenshots)
 #   3. Runs lint and E2E tests
 #   4. Builds changelog from commits since last tag
 #   5. Commits, creates annotated tag, pushes to trigger release workflow
+#
+# Note: docs/index.html used to carry the version in its download links,
+# but those links are now populated at runtime from the GitHub releases
+# API, so there's nothing to bump there anymore.
 
 BUMP_TYPE="${1:-}"
 if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
@@ -77,16 +81,7 @@ fs.writeFileSync(path, updated);
 # Update Cargo.lock
 (cd src-tauri && cargo check --quiet 2>/dev/null || true)
 
-# docs/index.html — escape dots in version for safe regex replacement
-node -e "
-const fs = require('fs');
-const path = 'docs/index.html';
-const content = fs.readFileSync(path, 'utf-8');
-const updated = content.replaceAll('$CURRENT', '$NEW_VERSION');
-fs.writeFileSync(path, updated);
-"
-
-echo "Version bumped to $NEW_VERSION in package.json, tauri.conf.json, Cargo.toml, docs/index.html"
+echo "Version bumped to $NEW_VERSION in package.json, tauri.conf.json, Cargo.toml, Cargo.lock"
 
 # --- Update screenshots ---
 echo "Updating screenshots (starting dev server)..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,22 +2,28 @@
 set -euo pipefail
 
 # Gorgonetics release script
-# Usage: bash scripts/release.sh <major|minor|patch>
+# Usage: bash scripts/release.sh <major|minor|patch> [notes-file]
 #
 # Steps:
 #   1. Bumps version in package.json, tauri.conf.json, Cargo.toml, Cargo.lock
 #   2. Regenerates screenshots (starts dev server, runs pnpm screenshots)
 #   3. Runs lint and E2E tests
-#   4. Builds changelog from commits since last tag
+#   4. Reads release notes from notes-file (defaults to RELEASE_NOTES.md),
+#      falling back to a git-log changelog if neither is present
 #   5. Commits, creates annotated tag, pushes to trigger release workflow
+#
+# Write RELEASE_NOTES.md (human narrative) before running this script — the
+# script uses its contents verbatim for the tag body and appends a Full
+# Changelog compare link.
 #
 # Note: docs/index.html used to carry the version in its download links,
 # but those links are now populated at runtime from the GitHub releases
 # API, so there's nothing to bump there anymore.
 
 BUMP_TYPE="${1:-}"
+NOTES_FILE="${2:-RELEASE_NOTES.md}"
 if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
-  echo "Usage: bash scripts/release.sh <major|minor|patch>"
+  echo "Usage: bash scripts/release.sh <major|minor|patch> [notes-file]"
   exit 1
 fi
 
@@ -125,20 +131,28 @@ pnpm run lint:ci
 echo "Running tests..."
 pnpm test:e2e
 
-# --- Build changelog since last tag ---
-echo "Building changelog..."
+# --- Assemble release notes ---
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-if [[ -n "$LAST_TAG" ]]; then
-  CHANGELOG=$(git log "$LAST_TAG"..HEAD --pretty=format:"- %s" --no-merges | grep -v "Co-Authored-By" || true)
+COMPARE_LINK="**Full Changelog**: https://github.com/gorgonetics/Gorgonetics/compare/${LAST_TAG:-initial}...v$NEW_VERSION"
+
+if [[ -f "$NOTES_FILE" ]]; then
+  echo "Using release notes from $NOTES_FILE"
+  BODY=$(cat "$NOTES_FILE")
 else
-  CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | grep -v "Co-Authored-By" || true)
+  echo "No notes file at $NOTES_FILE — generating changelog from git log"
+  if [[ -n "$LAST_TAG" ]]; then
+    CHANGELOG=$(git log "$LAST_TAG"..HEAD --pretty=format:"- %s" --no-merges | grep -v "Co-Authored-By" || true)
+  else
+    CHANGELOG=$(git log --pretty=format:"- %s" --no-merges | grep -v "Co-Authored-By" || true)
+  fi
+  BODY="## What's Changed
+
+$CHANGELOG"
 fi
 
-RELEASE_NOTES="## What's Changed
+RELEASE_NOTES="$BODY
 
-$CHANGELOG
-
-**Full Changelog**: https://github.com/gorgonetics/Gorgonetics/compare/${LAST_TAG:-initial}...v$NEW_VERSION"
+$COMPARE_LINK"
 
 echo "$RELEASE_NOTES"
 echo ""


### PR DESCRIPTION
Two small improvements to \`scripts/release.sh\`:

## 1. Drop the no-op docs/index.html version-bump block

The download links there have been populated from the GitHub releases API at runtime since v0.4.0, so the \`replaceAll(\$CURRENT, \$NEW_VERSION)\` call was a no-op. Block removed, header comment explains why, confirmation echo updated.

## 2. Read release notes from RELEASE_NOTES.md by default

The auto-built \"## What's Changed\" + one-line-per-commit changelog reads like a raw git log, buries the narrative in commit titles, and pulls in dependabot noise.

New behaviour: default to using \`RELEASE_NOTES.md\` (a narrative we already maintain in prep PRs) verbatim as the tag body, appending only the Full Changelog compare link. The git-log fallback is preserved for the case where no notes file exists.

An optional second positional arg overrides the notes file path:

\`\`\`
bash scripts/release.sh minor                   # uses RELEASE_NOTES.md
bash scripts/release.sh minor ./custom.md       # uses ./custom.md
\`\`\`

## Test plan
- [x] \`bash -n scripts/release.sh\` — syntax check passes.
- [x] \`grep -n '0\\.[0-9]' docs/index.html\` — no hardcoded version strings, confirms the removed block did nothing useful.
- [ ] Next release cut will exercise both changes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)