### PR TITLE
feat(db): M1 — parsed-effect columns on genes + empty pet_genes table

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import { initDatabase } from '$lib/services/database.js';
 import { loadDemoPetsIfNeeded, populateGenesIfNeeded } from '$lib/services/demoService.js';
+import { backfillParsedGeneEffectsIfNeeded } from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import { backfillPositiveGenesIfNeeded } from '$lib/services/petService.js';
 import { appState } from '$lib/stores/pets.js';
@@ -32,6 +33,13 @@ onMount(async () => {
     .catch((err) => {
       console.warn('positive_genes backfill aborted:', err);
     });
+
+  // Backfill parsed dominant/recessive attribute+sign columns on the genes
+  // table. Same off-critical-path pattern — read paths will start using
+  // these columns once they're populated.
+  backfillParsedGeneEffectsIfNeeded().catch((err) => {
+    console.warn('parsed-effects backfill aborted:', err);
+  });
 });
 </script>
 

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -34,9 +34,6 @@ onMount(async () => {
       console.warn('positive_genes backfill aborted:', err);
     });
 
-  // Backfill parsed dominant/recessive attribute+sign columns on the genes
-  // table. Same off-critical-path pattern — read paths will start using
-  // these columns once they're populated.
   backfillParsedGeneEffectsIfNeeded().catch((err) => {
     console.warn('parsed-effects backfill aborted:', err);
   });

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -2,9 +2,79 @@
  * Gene data service for Gorgonetics.
  */
 
+import { parseEffect } from '$lib/utils/geneAnalysis.js';
 import { now } from '$lib/utils/timestamp.js';
 import { normalizeSpecies } from './configService.js';
 import { getDb } from './database.js';
+import { getSetting, setSetting } from './settingsService.js';
+
+const PARSED_EFFECTS_BACKFILL_KEY = 'genes.parsed_effects_backfilled';
+
+function yieldToUI(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * One-shot backfill that populates dominant_attribute / dominant_sign /
+ * recessive_attribute / recessive_sign on every row of the genes table.
+ * Idempotent via a settings flag. Non-blocking: callers should kick this
+ * off after the app is interactive, same pattern as positive_genes
+ * backfill. New rows (upsertGene / updateGene / updateGenesBulk) populate
+ * the parsed columns directly, so this is only needed for users upgrading
+ * from before migration v10.
+ */
+export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
+  const done = await getSetting<boolean>(PARSED_EFFECTS_BACKFILL_KEY);
+  if (done) return;
+
+  const db = getDb();
+  const rows = await db.select<
+    { animal_type: string; gene: string; effectDominant: string | null; effectRecessive: string | null }[]
+  >('SELECT animal_type, gene, effectDominant, effectRecessive FROM genes');
+
+  if (rows.length === 0) {
+    await setSetting(PARSED_EFFECTS_BACKFILL_KEY, true);
+    return;
+  }
+
+  console.info(`parsed-effects backfill: starting for ${rows.length} gene rows`);
+
+  const BATCH = 64;
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const slice = rows.slice(i, i + BATCH);
+    await db.execute('BEGIN');
+    try {
+      for (const row of slice) {
+        const dom = parseEffect(row.effectDominant);
+        const rec = parseEffect(row.effectRecessive);
+        await db.execute(
+          `UPDATE genes
+           SET dominant_attribute = $da, dominant_sign = $ds,
+               recessive_attribute = $ra, recessive_sign = $rs
+           WHERE animal_type = $at AND gene = $g`,
+          {
+            da: dom?.attribute ?? null,
+            ds: dom?.sign ?? null,
+            ra: rec?.attribute ?? null,
+            rs: rec?.sign ?? null,
+            at: row.animal_type,
+            g: row.gene,
+          },
+        );
+      }
+      await db.execute('COMMIT');
+    } catch (e) {
+      await db.execute('ROLLBACK');
+      throw e;
+    }
+    const processed = Math.min(i + BATCH, rows.length);
+    console.info(`parsed-effects backfill: ${processed}/${rows.length}`);
+    await yieldToUI();
+  }
+
+  await setSetting(PARSED_EFFECTS_BACKFILL_KEY, true);
+  console.info('parsed-effects backfill: done');
+}
 
 /**
  * Get list of all animal types.
@@ -72,7 +142,9 @@ export async function getGenesForAnimal(animalType: string): Promise<Record<stri
 }
 
 /**
- * Update a gene's attributes.
+ * Update a gene's attributes. When `effectDominant` or `effectRecessive`
+ * is in the update, the corresponding pre-parsed columns are refreshed so
+ * downstream SQL queries don't have to re-parse the effect string.
  */
 export async function updateGene(animalType: string, gene: string, updates: Record<string, string>): Promise<boolean> {
   const db = getDb();
@@ -84,6 +156,21 @@ export async function updateGene(animalType: string, gene: string, updates: Reco
       setClauses.push(`${field} = $${field}`);
       params[field] = value;
     }
+  }
+
+  if ('effectDominant' in updates) {
+    const parsed = parseEffect(updates.effectDominant);
+    setClauses.push('dominant_attribute = $dominant_attribute');
+    setClauses.push('dominant_sign = $dominant_sign');
+    params.dominant_attribute = parsed?.attribute ?? null;
+    params.dominant_sign = parsed?.sign ?? null;
+  }
+  if ('effectRecessive' in updates) {
+    const parsed = parseEffect(updates.effectRecessive);
+    setClauses.push('recessive_attribute = $recessive_attribute');
+    setClauses.push('recessive_sign = $recessive_sign');
+    params.recessive_attribute = parsed?.attribute ?? null;
+    params.recessive_sign = parsed?.sign ?? null;
   }
 
   if (setClauses.length === 0) return false;
@@ -134,21 +221,31 @@ export async function upsertGene(
 ): Promise<void> {
   const db = getDb();
   const ts = now();
+  const effectDominant = data.effectDominant ?? 'None';
+  const effectRecessive = data.effectRecessive ?? 'None';
+  const dom = parseEffect(effectDominant);
+  const rec = parseEffect(effectRecessive);
   await db.execute(
     `INSERT OR REPLACE INTO genes
-     (animal_type, chromosome, gene, effectDominant, effectRecessive, appearance, breed, notes, created_at, updated_at)
-     VALUES ($animal_type, $chromosome, $gene, $effectDominant, $effectRecessive, $appearance, $breed, $notes, $created_at, $updated_at)`,
+     (animal_type, chromosome, gene, effectDominant, effectRecessive, appearance, breed, notes, created_at, updated_at,
+      dominant_attribute, dominant_sign, recessive_attribute, recessive_sign)
+     VALUES ($animal_type, $chromosome, $gene, $effectDominant, $effectRecessive, $appearance, $breed, $notes, $created_at, $updated_at,
+             $dominant_attribute, $dominant_sign, $recessive_attribute, $recessive_sign)`,
     {
       animal_type: animalType,
       chromosome,
       gene,
-      effectDominant: data.effectDominant ?? 'None',
-      effectRecessive: data.effectRecessive ?? 'None',
+      effectDominant,
+      effectRecessive,
       appearance: data.appearance ?? 'None',
       breed: data.breed ?? '',
       notes: data.notes ?? '',
       created_at: ts,
       updated_at: ts,
+      dominant_attribute: dom?.attribute ?? null,
+      dominant_sign: dom?.sign ?? null,
+      recessive_attribute: rec?.attribute ?? null,
+      recessive_sign: rec?.sign ?? null,
     },
   );
 }

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -2,17 +2,14 @@
  * Gene data service for Gorgonetics.
  */
 
-import { parseEffect } from '$lib/utils/geneAnalysis.js';
+import { yieldToUI } from '$lib/utils/async.js';
+import { parsedEffectColumns } from '$lib/utils/geneAnalysis.js';
 import { now } from '$lib/utils/timestamp.js';
 import { normalizeSpecies } from './configService.js';
 import { getDb } from './database.js';
 import { getSetting, setSetting } from './settingsService.js';
 
 const PARSED_EFFECTS_BACKFILL_KEY = 'genes.parsed_effects_backfilled';
-
-function yieldToUI(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 /**
  * One-shot backfill that populates dominant_attribute / dominant_sign /
@@ -45,18 +42,18 @@ export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
     await db.execute('BEGIN');
     try {
       for (const row of slice) {
-        const dom = parseEffect(row.effectDominant);
-        const rec = parseEffect(row.effectRecessive);
+        const dom = parsedEffectColumns(row.effectDominant);
+        const rec = parsedEffectColumns(row.effectRecessive);
         await db.execute(
           `UPDATE genes
            SET dominant_attribute = $da, dominant_sign = $ds,
                recessive_attribute = $ra, recessive_sign = $rs
            WHERE animal_type = $at AND gene = $g`,
           {
-            da: dom?.attribute ?? null,
-            ds: dom?.sign ?? null,
-            ra: rec?.attribute ?? null,
-            rs: rec?.sign ?? null,
+            da: dom.attribute,
+            ds: dom.sign,
+            ra: rec.attribute,
+            rs: rec.sign,
             at: row.animal_type,
             g: row.gene,
           },
@@ -159,18 +156,16 @@ export async function updateGene(animalType: string, gene: string, updates: Reco
   }
 
   if ('effectDominant' in updates) {
-    const parsed = parseEffect(updates.effectDominant);
-    setClauses.push('dominant_attribute = $dominant_attribute');
-    setClauses.push('dominant_sign = $dominant_sign');
-    params.dominant_attribute = parsed?.attribute ?? null;
-    params.dominant_sign = parsed?.sign ?? null;
+    const { attribute, sign } = parsedEffectColumns(updates.effectDominant);
+    setClauses.push('dominant_attribute = $dominant_attribute', 'dominant_sign = $dominant_sign');
+    params.dominant_attribute = attribute;
+    params.dominant_sign = sign;
   }
   if ('effectRecessive' in updates) {
-    const parsed = parseEffect(updates.effectRecessive);
-    setClauses.push('recessive_attribute = $recessive_attribute');
-    setClauses.push('recessive_sign = $recessive_sign');
-    params.recessive_attribute = parsed?.attribute ?? null;
-    params.recessive_sign = parsed?.sign ?? null;
+    const { attribute, sign } = parsedEffectColumns(updates.effectRecessive);
+    setClauses.push('recessive_attribute = $recessive_attribute', 'recessive_sign = $recessive_sign');
+    params.recessive_attribute = attribute;
+    params.recessive_sign = sign;
   }
 
   if (setClauses.length === 0) return false;
@@ -223,8 +218,8 @@ export async function upsertGene(
   const ts = now();
   const effectDominant = data.effectDominant ?? 'None';
   const effectRecessive = data.effectRecessive ?? 'None';
-  const dom = parseEffect(effectDominant);
-  const rec = parseEffect(effectRecessive);
+  const dom = parsedEffectColumns(effectDominant);
+  const rec = parsedEffectColumns(effectRecessive);
   await db.execute(
     `INSERT OR REPLACE INTO genes
      (animal_type, chromosome, gene, effectDominant, effectRecessive, appearance, breed, notes, created_at, updated_at,
@@ -242,10 +237,10 @@ export async function upsertGene(
       notes: data.notes ?? '',
       created_at: ts,
       updated_at: ts,
-      dominant_attribute: dom?.attribute ?? null,
-      dominant_sign: dom?.sign ?? null,
-      recessive_attribute: rec?.attribute ?? null,
-      recessive_sign: rec?.sign ?? null,
+      dominant_attribute: dom.attribute,
+      dominant_sign: dom.sign,
+      recessive_attribute: rec.attribute,
+      recessive_sign: rec.sign,
     },
   );
 }

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -7,38 +7,56 @@ import { parsedEffectColumns } from '$lib/utils/geneAnalysis.js';
 import { now } from '$lib/utils/timestamp.js';
 import { normalizeSpecies } from './configService.js';
 import { getDb } from './database.js';
-import { getSetting, setSetting } from './settingsService.js';
-
-const PARSED_EFFECTS_BACKFILL_KEY = 'genes.parsed_effects_backfilled';
 
 /**
- * One-shot backfill that populates dominant_attribute / dominant_sign /
- * recessive_attribute / recessive_sign on every row of the genes table.
- * Idempotent via a settings flag. Non-blocking: callers should kick this
- * off after the app is interactive, same pattern as positive_genes
- * backfill. New rows (upsertGene / updateGene / updateGenesBulk) populate
- * the parsed columns directly, so this is only needed for users upgrading
- * from before migration v10.
+ * Populate dominant_attribute / dominant_sign / recessive_attribute /
+ * recessive_sign on gene rows whose effect strings would parse to a real
+ * attribute+sign but whose parsed columns are still NULL. Data-driven
+ * guard (probe query) instead of a settings flag — backup restore or
+ * manual gene-table rewrites stay self-healing, and the steady state
+ * skips work after one SELECT.
+ *
+ * Non-blocking: callers should run this off the critical startup path.
+ *
+ * Each UPDATE is conditional on the effect strings still matching what
+ * the backfill read, so a GeneEditor save mid-flight can't be clobbered
+ * by a stale parse.
  */
 export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
-  const done = await getSetting<boolean>(PARSED_EFFECTS_BACKFILL_KEY);
-  if (done) return;
-
   const db = getDb();
   const rows = await db.select<
-    { animal_type: string; gene: string; effectDominant: string | null; effectRecessive: string | null }[]
-  >('SELECT animal_type, gene, effectDominant, effectRecessive FROM genes');
+    {
+      animal_type: string;
+      gene: string;
+      effectDominant: string | null;
+      effectRecessive: string | null;
+      dominant_attribute: string | null;
+      recessive_attribute: string | null;
+    }[]
+  >(
+    `SELECT animal_type, gene, effectDominant, effectRecessive,
+            dominant_attribute, recessive_attribute
+     FROM genes`,
+  );
 
-  if (rows.length === 0) {
-    await setSetting(PARSED_EFFECTS_BACKFILL_KEY, true);
-    return;
-  }
+  const needsWork = rows.filter((row) => {
+    const dom = parsedEffectColumns(row.effectDominant);
+    const rec = parsedEffectColumns(row.effectRecessive);
+    // `== null` catches both SQL NULL (real SQLite) and `undefined` (the
+    // in-memory test adapter when a column was never written).
+    return (
+      (dom.attribute !== null && row.dominant_attribute == null) ||
+      (rec.attribute !== null && row.recessive_attribute == null)
+    );
+  });
 
-  console.info(`parsed-effects backfill: starting for ${rows.length} gene rows`);
+  if (needsWork.length === 0) return;
+
+  console.info(`parsed-effects backfill: ${needsWork.length} rows need updating`);
 
   const BATCH = 64;
-  for (let i = 0; i < rows.length; i += BATCH) {
-    const slice = rows.slice(i, i + BATCH);
+  for (let i = 0; i < needsWork.length; i += BATCH) {
+    const slice = needsWork.slice(i, i + BATCH);
     await db.execute('BEGIN');
     try {
       for (const row of slice) {
@@ -48,7 +66,9 @@ export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
           `UPDATE genes
            SET dominant_attribute = $da, dominant_sign = $ds,
                recessive_attribute = $ra, recessive_sign = $rs
-           WHERE animal_type = $at AND gene = $g`,
+           WHERE animal_type = $at AND gene = $g
+             AND COALESCE(effectDominant, '') = $sed
+             AND COALESCE(effectRecessive, '') = $ser`,
           {
             da: dom.attribute,
             ds: dom.sign,
@@ -56,6 +76,8 @@ export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
             rs: rec.sign,
             at: row.animal_type,
             g: row.gene,
+            sed: row.effectDominant ?? '',
+            ser: row.effectRecessive ?? '',
           },
         );
       }
@@ -64,12 +86,11 @@ export async function backfillParsedGeneEffectsIfNeeded(): Promise<void> {
       await db.execute('ROLLBACK');
       throw e;
     }
-    const processed = Math.min(i + BATCH, rows.length);
-    console.info(`parsed-effects backfill: ${processed}/${rows.length}`);
+    const processed = Math.min(i + BATCH, needsWork.length);
+    console.info(`parsed-effects backfill: ${processed}/${needsWork.length}`);
     await yieldToUI();
   }
 
-  await setSetting(PARSED_EFFECTS_BACKFILL_KEY, true);
   console.info('parsed-effects backfill: done');
 }
 

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -142,6 +142,35 @@ const MIGRATIONS: Migration[] = [
       await db.execute('ALTER TABLE pets ADD COLUMN positive_genes INTEGER NOT NULL DEFAULT 0');
     },
   },
+  {
+    version: 10,
+    description: 'Add parsed-effect columns to genes + pet_genes table for fast SQL-side stats',
+    up: async () => {
+      const db = getDb();
+      // Pre-parsed attribute + sign per effect direction. NULL means the
+      // effect is absent or doesn't target a real attribute (appearance,
+      // potential, no-effect sentinels).
+      await db.execute('ALTER TABLE genes ADD COLUMN dominant_attribute TEXT');
+      await db.execute('ALTER TABLE genes ADD COLUMN dominant_sign TEXT');
+      await db.execute('ALTER TABLE genes ADD COLUMN recessive_attribute TEXT');
+      await db.execute('ALTER TABLE genes ADD COLUMN recessive_sign TEXT');
+
+      // One row per (pet, gene position) — the pet's genome projected into
+      // queryable rows. Populated in a later migration step; M1 only creates
+      // the table so subsequent PRs can write into it without another ALTER.
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS pet_genes (
+          pet_id    INTEGER NOT NULL,
+          gene_id   TEXT    NOT NULL,
+          gene_type TEXT    NOT NULL,
+          PRIMARY KEY (pet_id, gene_id),
+          FOREIGN KEY (pet_id) REFERENCES pets(id) ON DELETE CASCADE
+        )
+      `);
+      await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_genes_pet ON pet_genes(pet_id)');
+      await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_genes_lookup ON pet_genes(gene_id, gene_type)');
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -148,16 +148,13 @@ const MIGRATIONS: Migration[] = [
     up: async () => {
       const db = getDb();
       // Pre-parsed attribute + sign per effect direction. NULL means the
-      // effect is absent or doesn't target a real attribute (appearance,
-      // potential, no-effect sentinels).
+      // effect doesn't target a real attribute (appearance, potential,
+      // no-effect sentinels).
       await db.execute('ALTER TABLE genes ADD COLUMN dominant_attribute TEXT');
       await db.execute('ALTER TABLE genes ADD COLUMN dominant_sign TEXT');
       await db.execute('ALTER TABLE genes ADD COLUMN recessive_attribute TEXT');
       await db.execute('ALTER TABLE genes ADD COLUMN recessive_sign TEXT');
 
-      // One row per (pet, gene position) — the pet's genome projected into
-      // queryable rows. Populated in a later migration step; M1 only creates
-      // the table so subsequent PRs can write into it without another ALTER.
       await db.execute(`
         CREATE TABLE IF NOT EXISTS pet_genes (
           pet_id    INTEGER NOT NULL,

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -4,6 +4,7 @@
 
 import type { Genome, Pet } from '$lib/types/index.js';
 import { GENOME_FILE_MARKERS } from '$lib/types/index.js';
+import { yieldToUI } from '$lib/utils/async.js';
 import { computeGeneStats } from '$lib/utils/geneAnalysis.js';
 import { now } from '$lib/utils/timestamp.js';
 import { getDefaultValues, normalizeSpecies } from './configService.js';
@@ -482,11 +483,6 @@ export function reorderPets(orderedIds: number[]): Promise<void> {
 }
 
 const POSITIVE_GENES_BACKFILL_KEY = 'pets.positive_genes_backfilled';
-
-/** Yield to the event loop so the UI can paint between batches. */
-function yieldToUI(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 /**
  * One-shot backfill that populates positive_genes for every pet using the

--- a/src/lib/utils/async.ts
+++ b/src/lib/utils/async.ts
@@ -1,0 +1,12 @@
+/**
+ * Yield to the browser event loop so any pending UI work (paint, input)
+ * can run before the caller resumes. Used by batched background jobs to
+ * keep the main thread responsive.
+ *
+ * Uses `setTimeout(0)` rather than `queueMicrotask` (microtasks run before
+ * paint, defeating the point) or `requestIdleCallback` (not reliably
+ * available in all Tauri WebView backends).
+ */
+export function yieldToUI(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -51,6 +51,19 @@ export function parseEffect(effect: string | null | undefined): ParsedEffect | n
   return { attribute: match[1].toLowerCase(), sign: match[2] as '+' | '-' };
 }
 
+/**
+ * Parse an effect into the `(attribute, sign)` pair used as bind params
+ * for the genes table's parsed columns — either resolved values or both
+ * nulls when the effect isn't attribute-targeting.
+ */
+export function parsedEffectColumns(effect: string | null | undefined): {
+  attribute: string | null;
+  sign: '+' | '-' | null;
+} {
+  const parsed = parseEffect(effect);
+  return { attribute: parsed?.attribute ?? null, sign: parsed?.sign ?? null };
+}
+
 /** Shape of a single gene's effect record within an `effectsDB` map. */
 export interface GeneEffectData {
   effectDominant: string;

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -25,6 +25,32 @@ export function isNoEffect(effect: string | null | undefined): boolean {
   return !effect || NO_EFFECT_SENTINELS.has(effect);
 }
 
+/**
+ * Pre-parsed representation of a gene effect. Returned by `parseEffect` so
+ * the resolved attribute/sign can be persisted to the genes table and
+ * queried directly — the raw effect string no longer needs re-parsing on
+ * every read.
+ */
+export interface ParsedEffect {
+  attribute: string; // lowercased attribute name, e.g. 'toughness'
+  sign: '+' | '-';
+}
+
+/**
+ * Parse an authored effect string (e.g. "Toughness+", "Intelligence-") into
+ * its structured form. Returns null for anything that shouldn't contribute
+ * to stats: the no-effect sentinels, potential effects, appearance-only
+ * effects, and anything that isn't of the `<Attribute><+|->` shape.
+ */
+export function parseEffect(effect: string | null | undefined): ParsedEffect | null {
+  if (isNoEffect(effect)) return null;
+  const s = effect as string;
+  if (s.includes('?') || s.toLowerCase().includes('potential')) return null;
+  const match = s.match(/^([A-Za-z]+)([+-])$/);
+  if (!match) return null;
+  return { attribute: match[1].toLowerCase(), sign: match[2] as '+' | '-' };
+}
+
 /** Shape of a single gene's effect record within an `effectsDB` map. */
 export interface GeneEffectData {
   effectDominant: string;

--- a/tests/unit/parsedGeneEffects.test.js
+++ b/tests/unit/parsedGeneEffects.test.js
@@ -51,8 +51,8 @@ describe('upsertGene persists parsed columns', () => {
     });
     const db = getDb();
     const rows = await db.select(
-      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE gene = $g',
-      { g: '01A1' },
+      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01A1' },
     );
     expect(rows[0].dominant_attribute).toBe('toughness');
     expect(rows[0].dominant_sign).toBe('+');
@@ -67,8 +67,8 @@ describe('upsertGene persists parsed columns', () => {
     });
     const db = getDb();
     const rows = await db.select(
-      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE gene = $g',
-      { g: '01B1' },
+      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01B1' },
     );
     expect(rows[0].dominant_attribute).toBeNull();
     expect(rows[0].dominant_sign).toBeNull();
@@ -94,7 +94,10 @@ describe('updateGene refreshes parsed columns', () => {
       effectDominant: 'Ferocity-',
     });
     const db = getDb();
-    const rows = await db.select('SELECT dominant_attribute, dominant_sign FROM genes WHERE gene = $g', { g: '01A1' });
+    const rows = await db.select(
+      'SELECT dominant_attribute, dominant_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01A1' },
+    );
     expect(rows[0].dominant_attribute).toBe('ferocity');
     expect(rows[0].dominant_sign).toBe('-');
   });
@@ -108,9 +111,10 @@ describe('updateGene refreshes parsed columns', () => {
       effectRecessive: 'None',
     });
     const db = getDb();
-    const rows = await db.select('SELECT recessive_attribute, recessive_sign FROM genes WHERE gene = $g', {
-      g: '01A1',
-    });
+    const rows = await db.select(
+      'SELECT recessive_attribute, recessive_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01A1' },
+    );
     expect(rows[0].recessive_attribute).toBeNull();
     expect(rows[0].recessive_sign).toBeNull();
   });
@@ -165,21 +169,74 @@ describe('backfillParsedGeneEffectsIfNeeded', () => {
     expect(byGene['01A2'].recessive_sign).toBe('-');
   });
 
-  it('is idempotent — flag guard skips repeat work', async () => {
+  it('steady-state run is a no-op over already-parsed rows', async () => {
+    await insertLegacyGene('01A1', 'Toughness+', 'None');
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+    const db = getDb();
+    const [before] = await db.select('SELECT updated_at FROM genes WHERE animal_type = $at AND gene = $g', {
+      at: 'beewasp',
+      g: '01A1',
+    });
+
+    // Second run should see consistent parsed columns and skip without
+    // issuing UPDATEs — the updated_at timestamp must not move.
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+    const [after] = await db.select('SELECT updated_at FROM genes WHERE animal_type = $at AND gene = $g', {
+      at: 'beewasp',
+      g: '01A1',
+    });
+    expect(after.updated_at).toBe(before.updated_at);
+  });
+
+  it('self-heals when parsed columns are wiped (e.g. backup restore)', async () => {
     await insertLegacyGene('01A1', 'Toughness+', 'None');
     await geneService.backfillParsedGeneEffectsIfNeeded();
 
-    // Corrupt the parsed columns to simulate a later edit that shouldn't
-    // be undone by a second backfill call (the flag is set, so it skips).
+    // Simulate a backup-restore that rewrote genes back to pre-v10 state
+    // (effect strings present, parsed columns NULL). Without a flag guard,
+    // the next backfill call should detect this and heal the row.
     const db = getDb();
-    await db.execute('UPDATE genes SET dominant_attribute = $x WHERE gene = $g', {
-      x: 'corrupted',
-      g: '01A1',
-    });
+    await db.execute(
+      `UPDATE genes
+       SET dominant_attribute = NULL, dominant_sign = NULL,
+           recessive_attribute = NULL, recessive_sign = NULL
+       WHERE animal_type = $at AND gene = $g`,
+      { at: 'beewasp', g: '01A1' },
+    );
     await geneService.backfillParsedGeneEffectsIfNeeded();
 
-    const rows = await db.select('SELECT dominant_attribute FROM genes WHERE gene = $g', { g: '01A1' });
-    expect(rows[0].dominant_attribute).toBe('corrupted');
+    const rows = await db.select(
+      'SELECT dominant_attribute, dominant_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01A1' },
+    );
+    expect(rows[0].dominant_attribute).toBe('toughness');
+    expect(rows[0].dominant_sign).toBe('+');
+  });
+
+  it('skips rows whose effectDominant changed between read and write', async () => {
+    // Can't easily race within a single-threaded test; instead verify the
+    // WHERE guard by pre-inserting a row with consistent parsed state,
+    // editing just the effect string, then confirming backfill won't
+    // overwrite the parsed columns because they already match what a
+    // fresh parse would produce (probe skips it entirely).
+    await insertLegacyGene('01A1', 'Toughness+', 'None');
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+
+    const db = getDb();
+    await db.execute(
+      `UPDATE genes SET effectDominant = $ed,
+         dominant_attribute = $da, dominant_sign = $ds
+       WHERE animal_type = $at AND gene = $g`,
+      { ed: 'Intelligence-', da: 'intelligence', ds: '-', at: 'beewasp', g: '01A1' },
+    );
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+
+    const rows = await db.select(
+      'SELECT dominant_attribute, dominant_sign FROM genes WHERE animal_type = $at AND gene = $g',
+      { at: 'beewasp', g: '01A1' },
+    );
+    expect(rows[0].dominant_attribute).toBe('intelligence');
+    expect(rows[0].dominant_sign).toBe('-');
   });
 
   it('handles an empty genes table gracefully', async () => {

--- a/tests/unit/parsedGeneEffects.test.js
+++ b/tests/unit/parsedGeneEffects.test.js
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+import * as geneService from '$lib/services/geneService.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import { parseEffect } from '$lib/utils/geneAnalysis.js';
+
+describe('parseEffect', () => {
+  it('parses standard attribute+sign strings', () => {
+    expect(parseEffect('Toughness+')).toEqual({ attribute: 'toughness', sign: '+' });
+    expect(parseEffect('Intelligence-')).toEqual({ attribute: 'intelligence', sign: '-' });
+    expect(parseEffect('Ferocity+')).toEqual({ attribute: 'ferocity', sign: '+' });
+    expect(parseEffect('Temperament-')).toEqual({ attribute: 'temperament', sign: '-' });
+  });
+
+  it('returns null for no-effect sentinels', () => {
+    for (const sentinel of ['None', 'No dominant effect', 'No recessive effect', 'No gene data found', 'null']) {
+      expect(parseEffect(sentinel)).toBeNull();
+    }
+  });
+
+  it('returns null for empty, null, and undefined', () => {
+    expect(parseEffect('')).toBeNull();
+    expect(parseEffect(null)).toBeNull();
+    expect(parseEffect(undefined)).toBeNull();
+  });
+
+  it('returns null for potential effects', () => {
+    expect(parseEffect('Toughness?')).toBeNull();
+    expect(parseEffect('Potential Intelligence+')).toBeNull();
+  });
+
+  it("returns null for appearance-style strings that don't match the shape", () => {
+    expect(parseEffect('Body Color Hue')).toBeNull();
+    expect(parseEffect('Tough+ness+')).toBeNull();
+    expect(parseEffect('Toughness')).toBeNull();
+  });
+});
+
+describe('upsertGene persists parsed columns', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('writes dominant_attribute/sign and recessive_attribute/sign', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'Intelligence-',
+    });
+    const db = getDb();
+    const rows = await db.select(
+      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE gene = $g',
+      { g: '01A1' },
+    );
+    expect(rows[0].dominant_attribute).toBe('toughness');
+    expect(rows[0].dominant_sign).toBe('+');
+    expect(rows[0].recessive_attribute).toBe('intelligence');
+    expect(rows[0].recessive_sign).toBe('-');
+  });
+
+  it('writes NULL for no-effect / appearance strings', async () => {
+    await geneService.upsertGene('beewasp', '01', '01B1', {
+      effectDominant: 'None',
+      effectRecessive: 'Body Color Hue',
+    });
+    const db = getDb();
+    const rows = await db.select(
+      'SELECT dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes WHERE gene = $g',
+      { g: '01B1' },
+    );
+    expect(rows[0].dominant_attribute).toBeNull();
+    expect(rows[0].dominant_sign).toBeNull();
+    expect(rows[0].recessive_attribute).toBeNull();
+    expect(rows[0].recessive_sign).toBeNull();
+  });
+});
+
+describe('updateGene refreshes parsed columns', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('rewrites dominant parsed columns when effectDominant changes', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'None',
+    });
+    await geneService.updateGene('beewasp', '01A1', {
+      effectDominant: 'Ferocity-',
+    });
+    const db = getDb();
+    const rows = await db.select('SELECT dominant_attribute, dominant_sign FROM genes WHERE gene = $g', { g: '01A1' });
+    expect(rows[0].dominant_attribute).toBe('ferocity');
+    expect(rows[0].dominant_sign).toBe('-');
+  });
+
+  it('clears parsed columns when effect moves to None', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'Intelligence-',
+    });
+    await geneService.updateGene('beewasp', '01A1', {
+      effectRecessive: 'None',
+    });
+    const db = getDb();
+    const rows = await db.select('SELECT recessive_attribute, recessive_sign FROM genes WHERE gene = $g', {
+      g: '01A1',
+    });
+    expect(rows[0].recessive_attribute).toBeNull();
+    expect(rows[0].recessive_sign).toBeNull();
+  });
+});
+
+describe('backfillParsedGeneEffectsIfNeeded', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  async function insertLegacyGene(gene, effectDominant, effectRecessive) {
+    // Simulate a pre-v10 row: written without parsed columns. Bypass
+    // upsertGene because that now always populates them. All values use
+    // named params — the in-memory test adapter maps columns positionally
+    // to bind params and gets confused by mixed literals.
+    const db = getDb();
+    await db.execute(
+      `INSERT OR REPLACE INTO genes
+       (animal_type, chromosome, gene, effectDominant, effectRecessive, appearance, breed, notes, created_at, updated_at)
+       VALUES ($at, $chr, $g, $ed, $er, $app, $breed, $notes, $created, $updated)`,
+      {
+        at: 'beewasp',
+        chr: '01',
+        g: gene,
+        ed: effectDominant,
+        er: effectRecessive,
+        app: 'None',
+        breed: '',
+        notes: '',
+        created: '2024-01-01',
+        updated: '2024-01-01',
+      },
+    );
+  }
+
+  it('populates parsed columns for legacy rows', async () => {
+    await insertLegacyGene('01A1', 'Toughness+', 'None');
+    await insertLegacyGene('01A2', 'None', 'Intelligence-');
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+
+    const db = getDb();
+    const rows = await db.select(
+      'SELECT gene, dominant_attribute, dominant_sign, recessive_attribute, recessive_sign FROM genes ORDER BY gene',
+    );
+    const byGene = Object.fromEntries(rows.map((r) => [r.gene, r]));
+    expect(byGene['01A1'].dominant_attribute).toBe('toughness');
+    expect(byGene['01A1'].dominant_sign).toBe('+');
+    expect(byGene['01A2'].recessive_attribute).toBe('intelligence');
+    expect(byGene['01A2'].recessive_sign).toBe('-');
+  });
+
+  it('is idempotent — flag guard skips repeat work', async () => {
+    await insertLegacyGene('01A1', 'Toughness+', 'None');
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+
+    // Corrupt the parsed columns to simulate a later edit that shouldn't
+    // be undone by a second backfill call (the flag is set, so it skips).
+    const db = getDb();
+    await db.execute('UPDATE genes SET dominant_attribute = $x WHERE gene = $g', {
+      x: 'corrupted',
+      g: '01A1',
+    });
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+
+    const rows = await db.select('SELECT dominant_attribute FROM genes WHERE gene = $g', { g: '01A1' });
+    expect(rows[0].dominant_attribute).toBe('corrupted');
+  });
+
+  it('handles an empty genes table gracefully', async () => {
+    await geneService.backfillParsedGeneEffectsIfNeeded();
+    const db = getDb();
+    const rows = await db.select('SELECT COUNT(*) as cnt FROM genes');
+    expect(rows[0].cnt).toBe(0);
+  });
+});


### PR DESCRIPTION
First PR in the four-step plan to move gene-stats computation from the JS-side \`computeGeneStats\` JSON-parse loop into SQL aggregates. This one adds the schema and the parsing glue — no reads switch over yet.

## What's in this PR

- **Migration v10**: adds \`dominant_attribute\`, \`dominant_sign\`, \`recessive_attribute\`, \`recessive_sign\` to the \`genes\` table, plus an empty \`pet_genes(pet_id, gene_id, gene_type)\` with FK cascade and two indexes (\`(pet_id)\`, \`(gene_id, gene_type)\`). Existing \`genes.breed\` stays — horse breed filtering will join against it.
- **\`parseEffect\` helper** in \`geneAnalysis.ts\`: resolves an authored effect string to \`{ attribute, sign }\` or \`null\`. Handles NO_EFFECT_SENTINELS, potential effects (\`?\` / \"potential\"), appearance strings, and malformed inputs.
- **Write-side hooks**: \`upsertGene\` / \`updateGene\` always populate the parsed columns whenever \`effectDominant\` / \`effectRecessive\` is written. No extra service-layer call needed at gene-authoring sites.
- **Startup backfill** for existing gene rows, non-blocking from \`AuthWrapper\` (same pattern as the v0.5.1 positive_genes backfill). Batched in groups of 64 with a \`setTimeout(0)\` yield between batches and progress logs. Idempotent via settings flag \`genes.parsed_effects_backfilled\`.

## What's NOT in this PR
- Nothing reads from the new columns / table yet.
- \`pet_genes\` is created but left empty — population from uploaded genomes comes in M2.
- \`GeneStatsTable\` and Stable-table \`+Genes\` still use the old JSON-parse path — they switch over in M3.

## Test plan
- [x] \`pnpm test\` — 265/265 unit (12 new covering parseEffect edge cases, upsert/update column population, backfill correctness, backfill idempotency, empty-table path).
- [x] \`pnpm test:e2e\` — 117/117 pass. No user-facing behaviour changes.
- [x] \`pnpm lint:ci\` — clean.

## Staging reminder
| PR | Status |
|---|---|
| M1 (this) | ← |
| M2: populate \`pet_genes\` on upload/update, backfill for existing pets | next |
| M3: swap GeneStatsTable and Stable-table \`+Genes\` to SQL aggregates; delete \`computeGeneStats\` / \`computePositiveGenesForGenome\` | |
| M4: remove remaining JSON-parse-for-stats calls; keep \`genome_data\` only for the visualizer grid | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)