### PR TITLE
feat(db): M3 — read gene stats from pet_genes + parsed columns

### DIFF
--- a/src/lib/services/comparisonService.ts
+++ b/src/lib/services/comparisonService.ts
@@ -4,7 +4,7 @@
 
 import { getAllAttributeNames, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
-import { getPetGenome } from '$lib/services/petService.js';
+import { getPetGeneStats, getPetGenome } from '$lib/services/petService.js';
 import type {
   AttributeComparisonResult,
   ChromosomeDiff,
@@ -12,7 +12,7 @@ import type {
   GeneStatsComparisonResult,
   Pet,
 } from '$lib/types/index.js';
-import { computeGeneStats, parseGenomeGenes } from '$lib/utils/geneAnalysis.js';
+import { parseGenomeGenes } from '$lib/utils/geneAnalysis.js';
 import { capitalize } from '$lib/utils/string.js';
 
 async function loadGenomePair(petA: Pet, petB: Pet) {
@@ -27,6 +27,8 @@ async function loadGenomePair(petA: Pet, petB: Pet) {
   }
   return { species, genomeA, genomeB, effectsData };
 }
+
+const emptyStatsEntry = () => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
 
 /**
  * Compare attributes between two same-species pets.
@@ -60,21 +62,19 @@ export function compareAttributes(petA: Pet, petB: Pet): AttributeComparisonResu
 }
 
 /**
- * Compare gene stats between two same-species pets.
- * Loads genome data and gene effects, then computes per-attribute stats for both.
+ * Compare gene stats between two same-species pets. Reads pre-aggregated
+ * stats from `pet_genes` joined against parsed-effect columns on `genes`,
+ * so this no longer parses genome JSON for the per-attribute breakdown.
  */
 export async function compareGeneStats(petA: Pet, petB: Pet): Promise<GeneStatsComparisonResult[]> {
-  const { species, genomeA, genomeB, effectsData } = await loadGenomePair(petA, petB);
-
-  const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
-
-  const statsA = computeGeneStats(genomeA.genes, species, effectsDB, petA.breed);
-  const statsB = computeGeneStats(genomeB.genes, species, effectsDB, petB.breed);
+  const species = normalizeSpecies(petA.species);
+  const [statsA, statsB] = await Promise.all([
+    getPetGeneStats(petA.id, species, petA.breed),
+    getPetGeneStats(petB.id, species, petB.breed),
+  ]);
 
   const config = getAttributeConfig(species);
   const attrNames = getAllAttributeNames(species);
-
-  const emptyEntry = () => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
 
   return attrNames.map((attrName) => {
     const key = capitalize(attrName);
@@ -84,8 +84,8 @@ export async function compareGeneStats(petA: Pet, petB: Pet): Promise<GeneStatsC
       key,
       name: info?.name ?? key,
       icon: info?.icon ?? '',
-      petA: statsA.stats[key] ?? emptyEntry(),
-      petB: statsB.stats[key] ?? emptyEntry(),
+      petA: statsA.stats[key] ?? emptyStatsEntry(),
+      petB: statsB.stats[key] ?? emptyStatsEntry(),
     };
   });
 }

--- a/src/lib/services/comparisonService.ts
+++ b/src/lib/services/comparisonService.ts
@@ -4,7 +4,7 @@
 
 import { getAllAttributeNames, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
-import { getPetGeneStats, getPetGenome } from '$lib/services/petService.js';
+import { emptyStatsEntry, getPetGeneStats, getPetGenome } from '$lib/services/petService.js';
 import type {
   AttributeComparisonResult,
   ChromosomeDiff,
@@ -27,8 +27,6 @@ async function loadGenomePair(petA: Pet, petB: Pet) {
   }
   return { species, genomeA, genomeB, effectsData };
 }
-
-const emptyStatsEntry = () => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
 
 /**
  * Compare attributes between two same-species pets.
@@ -61,11 +59,7 @@ export function compareAttributes(petA: Pet, petB: Pet): AttributeComparisonResu
   });
 }
 
-/**
- * Compare gene stats between two same-species pets. Reads pre-aggregated
- * stats from `pet_genes` joined against parsed-effect columns on `genes`,
- * so this no longer parses genome JSON for the per-attribute breakdown.
- */
+/** Compare per-attribute gene stats between two same-species pets. */
 export async function compareGeneStats(petA: Pet, petB: Pet): Promise<GeneStatsComparisonResult[]> {
   const species = normalizeSpecies(petA.species);
   const [statsA, statsB] = await Promise.all([

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -308,11 +308,7 @@ export async function getGeneEffectsCached(species: string) {
   return promise;
 }
 
-/**
- * Pre-parsed gene record used by stats aggregation. Populated from the
- * genes table's dominant_/recessive_attribute and _sign columns — the
- * effect string never has to be re-parsed at stats time.
- */
+/** Pre-parsed gene effect record sourced from the genes table. */
 export interface ParsedGeneRecord {
   dominantAttribute: string | null;
   dominantSign: '+' | '-' | null;
@@ -324,10 +320,19 @@ export interface ParsedGeneRecord {
 const parsedGenesCache = new Map<string, Promise<Record<string, ParsedGeneRecord>>>();
 
 /**
- * Cached `gene_id → ParsedGeneRecord` map for a species. Reads pre-parsed
- * attribute/sign columns straight off the genes table — stats aggregation
- * never has to re-parse effect strings.
+ * True when a gene should be excluded from a horse pet's stats because
+ * the gene is breed-locked to a different breed than the pet. Mixed-
+ * breed pets and unbreed-tagged genes pass through.
  */
+export function isHorseBreedFiltered(
+  species: string,
+  petBreed: string | undefined,
+  geneBreed: string | null | undefined,
+): boolean {
+  return species === 'horse' && !!petBreed && petBreed !== 'Mixed' && !!geneBreed && geneBreed !== petBreed;
+}
+
+/** Cached `gene_id → ParsedGeneRecord` map for a species. */
 export async function getParsedGenesCached(species: string): Promise<Record<string, ParsedGeneRecord>> {
   const normalized = normalizeSpecies(species);
   const existing = parsedGenesCache.get(normalized);
@@ -364,11 +369,7 @@ export async function getParsedGenesCached(species: string): Promise<Record<stri
   return promise;
 }
 
-/**
- * Invalidate cached gene effects (and parsed-genes lookup) for a species.
- * Call after editing genes — the parsed columns travel with the effect
- * strings, so both caches must drop together.
- */
+/** Invalidate cached gene effects (raw and parsed) for a species, or all if omitted. */
 export function clearGeneEffectsCache(species?: string) {
   if (species) {
     const normalized = normalizeSpecies(species);

--- a/src/lib/services/geneService.ts
+++ b/src/lib/services/geneService.ts
@@ -309,13 +309,74 @@ export async function getGeneEffectsCached(species: string) {
 }
 
 /**
- * Invalidate cached gene effects for a species (call after editing genes).
+ * Pre-parsed gene record used by stats aggregation. Populated from the
+ * genes table's dominant_/recessive_attribute and _sign columns — the
+ * effect string never has to be re-parsed at stats time.
+ */
+export interface ParsedGeneRecord {
+  dominantAttribute: string | null;
+  dominantSign: '+' | '-' | null;
+  recessiveAttribute: string | null;
+  recessiveSign: '+' | '-' | null;
+  breed: string;
+}
+
+const parsedGenesCache = new Map<string, Promise<Record<string, ParsedGeneRecord>>>();
+
+/**
+ * Cached `gene_id → ParsedGeneRecord` map for a species. Reads pre-parsed
+ * attribute/sign columns straight off the genes table — stats aggregation
+ * never has to re-parse effect strings.
+ */
+export async function getParsedGenesCached(species: string): Promise<Record<string, ParsedGeneRecord>> {
+  const normalized = normalizeSpecies(species);
+  const existing = parsedGenesCache.get(normalized);
+  if (existing) return existing;
+  const promise = (async () => {
+    const db = getDb();
+    const rows = await db.select<
+      {
+        gene: string;
+        dominant_attribute: string | null;
+        dominant_sign: string | null;
+        recessive_attribute: string | null;
+        recessive_sign: string | null;
+        breed: string | null;
+      }[]
+    >(
+      `SELECT gene, dominant_attribute, dominant_sign, recessive_attribute, recessive_sign, breed
+       FROM genes WHERE animal_type = $animalType`,
+      { animalType: normalized },
+    );
+    const map: Record<string, ParsedGeneRecord> = {};
+    for (const r of rows) {
+      map[r.gene] = {
+        dominantAttribute: r.dominant_attribute ?? null,
+        dominantSign: (r.dominant_sign as '+' | '-' | null) ?? null,
+        recessiveAttribute: r.recessive_attribute ?? null,
+        recessiveSign: (r.recessive_sign as '+' | '-' | null) ?? null,
+        breed: r.breed ?? '',
+      };
+    }
+    return map;
+  })();
+  parsedGenesCache.set(normalized, promise);
+  return promise;
+}
+
+/**
+ * Invalidate cached gene effects (and parsed-genes lookup) for a species.
+ * Call after editing genes — the parsed columns travel with the effect
+ * strings, so both caches must drop together.
  */
 export function clearGeneEffectsCache(species?: string) {
   if (species) {
-    geneEffectsCache.delete(normalizeSpecies(species));
+    const normalized = normalizeSpecies(species);
+    geneEffectsCache.delete(normalized);
+    parsedGenesCache.delete(normalized);
   } else {
     geneEffectsCache.clear();
+    parsedGenesCache.clear();
   }
 }
 

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -2,14 +2,14 @@
  * Pet data service for Gorgonetics.
  */
 
-import type { Genome, Pet } from '$lib/types/index.js';
+import type { GeneStatsEntry, Genome, Pet } from '$lib/types/index.js';
 import { GENOME_FILE_MARKERS } from '$lib/types/index.js';
 import { yieldToUI } from '$lib/utils/async.js';
-import { computeGeneStats } from '$lib/utils/geneAnalysis.js';
+import { capitalize } from '$lib/utils/string.js';
 import { now } from '$lib/utils/timestamp.js';
-import { getDefaultValues, normalizeSpecies } from './configService.js';
+import { getAllAttributeNames, getDefaultValues, normalizeSpecies } from './configService.js';
 import { getDb, reorderRows, withTransaction } from './database.js';
-import { getGeneEffectsCached } from './geneService.js';
+import { getParsedGenesCached } from './geneService.js';
 import { genomeToGeneStrings, isValidGenomeFile, parseGenome } from './genomeParser.js';
 import { parseStructuredPetName } from './nameParser.js';
 import { getSetting, setSetting } from './settingsService.js';
@@ -72,32 +72,105 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
 
 /**
  * Count the genes in a genome that confer a confirmed positive attribute
- * effect, using the same logic as `GeneStatsTable`'s totals row. The genes
- * table must be populated (ensured by `populateGenesIfNeeded` at startup).
+ * effect. Reads pre-parsed attribute/sign columns on the genes table.
+ *
+ * Defensive: malformed JSON or unexpected shapes return 0 instead of
+ * throwing — upload/update can't afford to abort on a single bad row.
  */
 export async function computePositiveGenesForGenome(
   genomeData: string | Genome,
   breed: string | undefined,
 ): Promise<number> {
-  // Malformed JSON or unexpected shapes must not crash the caller — upload
-  // and update paths can't afford to abort on bad data. Return 0 and let the
-  // caller persist a safe placeholder.
   try {
     const parsed: unknown = typeof genomeData === 'string' ? JSON.parse(genomeData) : genomeData;
     if (!parsed || typeof parsed !== 'object') return 0;
     const genome = parsed as Genome;
     const species = normalizeSpecies(genome.genome_type);
     if (!species) return 0;
-    const geneStrings = genomeToGeneStrings(genome);
-    const effectsData = await getGeneEffectsCached(species);
-    const effectsDB = effectsData ? { [species]: effectsData.effects } : {};
-    const { stats } = computeGeneStats(geneStrings, species, effectsDB, breed);
-    let total = 0;
-    for (const entry of Object.values(stats)) total += entry.positive;
-    return total;
+    const parsedGenes = await getParsedGenesCached(species);
+    let count = 0;
+    for (const chrGenes of Object.values(genome.genes ?? {})) {
+      if (!Array.isArray(chrGenes)) continue;
+      for (const g of chrGenes) {
+        if (!g || typeof g !== 'object') continue;
+        const type = g.gene_type;
+        if (!type || type === '?') continue;
+        const geneId = `${g.chromosome}${g.block}${g.position}`;
+        const gd = parsedGenes[geneId];
+        if (!gd) continue;
+        if (species === 'horse' && breed && breed !== 'Mixed' && gd.breed && gd.breed !== breed) continue;
+        const sign = type === 'R' ? gd.recessiveSign : gd.dominantSign;
+        if (sign === '+') count++;
+      }
+    }
+    return count;
   } catch {
     return 0;
   }
+}
+
+/**
+ * Compute per-attribute gene stats for one pet by aggregating pet_genes
+ * rows against the cached parsed-effect columns from the genes table.
+ *
+ * Horse breed filter: a breed-mismatched gene increments `totalGenes` but
+ * contributes to neither `stats` nor `neutralGenes` — it's silently
+ * dropped (this matches what the visualizer and stats table expect).
+ */
+export async function getPetGeneStats(
+  petId: number,
+  species: string,
+  breed?: string,
+): Promise<{ stats: Record<string, GeneStatsEntry>; totalGenes: number; neutralGenes: number }> {
+  const speciesKey = normalizeSpecies(species);
+  const db = getDb();
+  const rows = await db.select<{ gene_id: string; gene_type: string }[]>(
+    'SELECT gene_id, gene_type FROM pet_genes WHERE pet_id = $pid',
+    { pid: petId },
+  );
+  const parsedGenes = await getParsedGenesCached(speciesKey);
+  const attrNames = getAllAttributeNames(speciesKey).map((n) => capitalize(n));
+  const stats: Record<string, GeneStatsEntry> = {};
+  for (const a of attrNames) {
+    stats[a] = { positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 };
+  }
+
+  let totalGenes = 0;
+  let neutralGenes = 0;
+
+  for (const row of rows) {
+    if (row.gene_type === '?') continue;
+    totalGenes++;
+
+    const gd = parsedGenes[row.gene_id];
+
+    if (speciesKey === 'horse' && breed && breed !== 'Mixed' && gd?.breed && gd.breed !== breed) {
+      continue;
+    }
+
+    const isRecessive = row.gene_type === 'R';
+    const attribute = isRecessive ? gd?.recessiveAttribute : gd?.dominantAttribute;
+    const sign = isRecessive ? gd?.recessiveSign : gd?.dominantSign;
+
+    if (!attribute || !sign) {
+      neutralGenes++;
+      continue;
+    }
+
+    const entry = stats[capitalize(attribute)];
+    if (!entry) {
+      neutralGenes++;
+      continue;
+    }
+
+    if (sign === '+') entry.positive++;
+    if (sign === '-') entry.negative++;
+    if (row.gene_type === 'D') entry.dominant++;
+    else if (row.gene_type === 'R') entry.recessive++;
+    else if (row.gene_type === 'x') entry.mixed++;
+  }
+
+  return { stats, totalGenes, neutralGenes };
 }
 
 /** Enrich a raw pet row from the database with computed fields. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -5,11 +5,12 @@
 import type { GeneStatsEntry, Genome, Pet } from '$lib/types/index.js';
 import { GENOME_FILE_MARKERS } from '$lib/types/index.js';
 import { yieldToUI } from '$lib/utils/async.js';
+import { toGeneId } from '$lib/utils/geneAnalysis.js';
 import { capitalize } from '$lib/utils/string.js';
 import { now } from '$lib/utils/timestamp.js';
-import { getAllAttributeNames, getDefaultValues, normalizeSpecies } from './configService.js';
+import { getAttributeConfig, getDefaultValues, normalizeSpecies } from './configService.js';
 import { getDb, reorderRows, withTransaction } from './database.js';
-import { getParsedGenesCached } from './geneService.js';
+import { getParsedGenesCached, isHorseBreedFiltered } from './geneService.js';
 import { genomeToGeneStrings, isValidGenomeFile, parseGenome } from './genomeParser.js';
 import { parseStructuredPetName } from './nameParser.js';
 import { getSetting, setSetting } from './settingsService.js';
@@ -70,12 +71,15 @@ function countGenes(genomeData: unknown): { total: number; known: number; unknow
   return { total, known, unknown };
 }
 
+/** Build an empty stats entry — exported so the comparison view can fall back on it. */
+export function emptyStatsEntry(): GeneStatsEntry {
+  return { positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 };
+}
+
 /**
  * Count the genes in a genome that confer a confirmed positive attribute
- * effect. Reads pre-parsed attribute/sign columns on the genes table.
- *
- * Defensive: malformed JSON or unexpected shapes return 0 instead of
- * throwing — upload/update can't afford to abort on a single bad row.
+ * effect. Returns 0 on malformed input — upload/update can't abort on a
+ * single bad row.
  */
 export async function computePositiveGenesForGenome(
   genomeData: string | Genome,
@@ -95,10 +99,9 @@ export async function computePositiveGenesForGenome(
         if (!g || typeof g !== 'object') continue;
         const type = g.gene_type;
         if (!type || type === '?') continue;
-        const geneId = `${g.chromosome}${g.block}${g.position}`;
-        const gd = parsedGenes[geneId];
+        const gd = parsedGenes[toGeneId(g)];
         if (!gd) continue;
-        if (species === 'horse' && breed && breed !== 'Mixed' && gd.breed && gd.breed !== breed) continue;
+        if (isHorseBreedFiltered(species, breed, gd.breed)) continue;
         const sign = type === 'R' ? gd.recessiveSign : gd.dominantSign;
         if (sign === '+') count++;
       }
@@ -110,12 +113,9 @@ export async function computePositiveGenesForGenome(
 }
 
 /**
- * Compute per-attribute gene stats for one pet by aggregating pet_genes
- * rows against the cached parsed-effect columns from the genes table.
- *
- * Horse breed filter: a breed-mismatched gene increments `totalGenes` but
- * contributes to neither `stats` nor `neutralGenes` — it's silently
- * dropped (this matches what the visualizer and stats table expect).
+ * Per-attribute gene stats for one pet, aggregated from pet_genes against
+ * the cached parsed-effect columns. Breed-mismatched horse genes count
+ * toward `totalGenes` but contribute to neither `stats` nor `neutralGenes`.
  */
 export async function getPetGeneStats(
   petId: number,
@@ -129,10 +129,9 @@ export async function getPetGeneStats(
     { pid: petId },
   );
   const parsedGenes = await getParsedGenesCached(speciesKey);
-  const attrNames = getAllAttributeNames(speciesKey).map((n) => capitalize(n));
   const stats: Record<string, GeneStatsEntry> = {};
-  for (const a of attrNames) {
-    stats[a] = { positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 };
+  for (const attr of getAttributeConfig(speciesKey).attributes) {
+    stats[attr.key] = emptyStatsEntry();
   }
 
   let totalGenes = 0;
@@ -144,27 +143,20 @@ export async function getPetGeneStats(
 
     const gd = parsedGenes[row.gene_id];
 
-    if (speciesKey === 'horse' && breed && breed !== 'Mixed' && gd?.breed && gd.breed !== breed) {
-      continue;
-    }
+    if (isHorseBreedFiltered(speciesKey, breed, gd?.breed)) continue;
 
     const isRecessive = row.gene_type === 'R';
     const attribute = isRecessive ? gd?.recessiveAttribute : gd?.dominantAttribute;
     const sign = isRecessive ? gd?.recessiveSign : gd?.dominantSign;
 
-    if (!attribute || !sign) {
-      neutralGenes++;
-      continue;
-    }
-
-    const entry = stats[capitalize(attribute)];
-    if (!entry) {
+    const entry = attribute ? stats[capitalize(attribute)] : undefined;
+    if (!entry || !sign) {
       neutralGenes++;
       continue;
     }
 
     if (sign === '+') entry.positive++;
-    if (sign === '-') entry.negative++;
+    else entry.negative++;
     if (row.gene_type === 'D') entry.dominant++;
     else if (row.gene_type === 'R') entry.recessive++;
     else if (row.gene_type === 'x') entry.mixed++;
@@ -582,7 +574,7 @@ async function writePetGenes(petId: number, genome: Genome): Promise<void> {
   const entries: Array<{ geneId: string; geneType: string }> = [];
   for (const chrGenes of Object.values(genome.genes)) {
     for (const g of chrGenes) {
-      entries.push({ geneId: `${g.chromosome}${g.block}${g.position}`, geneType: g.gene_type });
+      entries.push({ geneId: toGeneId(g), geneType: g.gene_type });
     }
   }
 

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -5,10 +5,7 @@
  * reused by both the visualizer and the comparison service.
  */
 
-import { getAllAttributeNames, normalizeSpecies } from '$lib/services/configService.js';
 import { blockLetter } from '$lib/services/genomeParser.js';
-import type { GeneStatsEntry } from '$lib/types/index.js';
-import { capitalize } from '$lib/utils/string.js';
 
 // --- Effect classification helpers ---
 
@@ -156,91 +153,4 @@ export function parseGenesByBlock(genes: Record<string, string>): Record<string,
   }
 
   return result;
-}
-
-/**
- * Compute per-attribute gene stats for a pet's genome.
- *
- * Returns a map of attribute key → { positive, negative, dominant, recessive, mixed }.
- * Also returns totalGenes and neutralGenes counts.
- */
-type GeneEffectsDB = Record<string, Record<string, GeneEffectData>>;
-
-export function computeGeneStats(
-  genes: Record<string, string>,
-  species: string,
-  geneEffectsDB: GeneEffectsDB,
-  petBreed?: string,
-): { stats: Record<string, GeneStatsEntry>; totalGenes: number; neutralGenes: number } {
-  const speciesKey = normalizeSpecies(species);
-  const attrNames = getAllAttributeNames(speciesKey).map((name) => capitalize(name));
-  const speciesEffects = geneEffectsDB[speciesKey] ?? {};
-
-  const emptyEntry = (): GeneStatsEntry => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
-  const stats: Record<string, GeneStatsEntry> = {};
-  for (const attr of attrNames) {
-    stats[attr] = emptyEntry();
-  }
-
-  let totalGenes = 0;
-  let neutralGenes = 0;
-
-  for (const [_chromosome, geneList] of Object.entries(parseGenomeGenes(genes))) {
-    for (const gene of geneList) {
-      if (gene.type === '?') continue;
-      totalGenes++;
-
-      const geneData = speciesEffects[gene.id];
-
-      // Skip genes from other breeds (horse only)
-      if (speciesKey === 'horse' && petBreed && petBreed !== 'Mixed') {
-        const breed = breedFor(geneData);
-        if (breed && breed !== petBreed) continue;
-      }
-
-      const effect = effectFor(geneData, gene.type);
-      if (isNoEffect(effect)) {
-        neutralGenes++;
-        continue;
-      }
-
-      const effectStr = effect || '';
-      const isPotential = effectStr.includes('?') || effectStr.toLowerCase().includes('potential');
-      if (isPotential) {
-        neutralGenes++;
-        continue;
-      }
-
-      const hasPlus = effectStr.includes('+');
-      const hasMinus = effectStr.includes('-');
-
-      if (!hasPlus && !hasMinus) {
-        neutralGenes++;
-        continue;
-      }
-
-      // Find which attribute this effect targets
-      let matchedAttr: string | null = null;
-      for (const attrName of attrNames) {
-        if (effectStr.includes(attrName)) {
-          matchedAttr = attrName;
-          break;
-        }
-      }
-
-      if (!matchedAttr || !stats[matchedAttr]) {
-        neutralGenes++;
-        continue;
-      }
-
-      const entry = stats[matchedAttr];
-      if (hasPlus) entry.positive++;
-      if (hasMinus) entry.negative++;
-      if (gene.type === 'D') entry.dominant++;
-      else if (gene.type === 'R') entry.recessive++;
-      else if (gene.type === 'x') entry.mixed++;
-    }
-  }
-
-  return { stats, totalGenes, neutralGenes };
 }

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -1,8 +1,6 @@
 /**
- * Shared gene analysis utility.
- *
- * Extracts the stats computation logic from GeneVisualizer so it can be
- * reused by both the visualizer and the comparison service.
+ * Effect-string and genome-string parsing helpers shared across the
+ * gene services and the visualizer.
  */
 
 import { blockLetter } from '$lib/services/genomeParser.js';

--- a/src/lib/utils/geneAnalysis.ts
+++ b/src/lib/utils/geneAnalysis.ts
@@ -90,6 +90,11 @@ export function breedFor(geneData: { breed?: string } | undefined): string {
   return geneData?.breed || '';
 }
 
+/** Build the canonical `chromosome+block+position` gene id. */
+export function toGeneId(g: { chromosome: string; block: string; position: number }): string {
+  return `${g.chromosome}${g.block}${g.position}`;
+}
+
 /** Parsed gene from a genome string. */
 export interface ParsedGene {
   id: string;

--- a/tests/unit/petGeneStats.test.js
+++ b/tests/unit/petGeneStats.test.js
@@ -5,9 +5,9 @@ import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
 
 /**
- * Three-gene beewasp genome at 01A1 / 01A2 / 01A3, all dominant. Stats
- * tests seed effects on these positions and assert the SQL aggregate
- * picks them up via pre-parsed columns rather than re-parsing JSON.
+ * Three-gene beewasp genome at 01A1 / 01A2 / 01A3, all dominant. Tests
+ * seed effects on these positions and assert getPetGeneStats picks them
+ * up from the pre-parsed columns on the genes table.
  */
 const MINIMAL_BEEWASP_GENOME = `[Overview]
 Format=1.0

--- a/tests/unit/petGeneStats.test.js
+++ b/tests/unit/petGeneStats.test.js
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, initDatabase } from '$lib/services/database.js';
+import * as geneService from '$lib/services/geneService.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+/**
+ * Three-gene beewasp genome at 01A1 / 01A2 / 01A3, all dominant. Stats
+ * tests seed effects on these positions and assert the SQL aggregate
+ * picks them up via pre-parsed columns rather than re-parsing JSON.
+ */
+const MINIMAL_BEEWASP_GENOME = `[Overview]
+Format=1.0
+Character=Tester
+Entity=Minimal Bee
+Genome=BeeWasp
+
+[Genes]
+1=DDD
+`;
+
+async function seedMixedEffects() {
+  await geneService.upsertGene('beewasp', '01', '01A1', {
+    effectDominant: 'Toughness+',
+    effectRecessive: 'None',
+  });
+  await geneService.upsertGene('beewasp', '01', '01A2', {
+    effectDominant: 'Intelligence+',
+    effectRecessive: 'None',
+  });
+  await geneService.upsertGene('beewasp', '01', '01A3', {
+    effectDominant: 'Toughness-',
+    effectRecessive: 'None',
+  });
+  geneService.clearGeneEffectsCache('beewasp');
+}
+
+describe('getPetGeneStats reads pre-parsed columns', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('aggregates per-attribute counts from pet_genes joined with parsed effects', async () => {
+    await seedMixedEffects();
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const { stats, totalGenes, neutralGenes } = await petService.getPetGeneStats(result.pet_id, 'BeeWasp');
+
+    expect(totalGenes).toBe(3);
+    expect(neutralGenes).toBe(0);
+    expect(stats.Intelligence).toMatchObject({ positive: 1, negative: 0, dominant: 1 });
+    expect(stats.Toughness).toMatchObject({ positive: 1, negative: 1, dominant: 2 });
+  });
+
+  it('classifies genes with no parsed effect as neutral', async () => {
+    // Only seed two of the three positions; the third has no genes-table
+    // entry and must fall through to the neutral bucket.
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'None',
+    });
+    await geneService.upsertGene('beewasp', '01', '01A2', {
+      effectDominant: 'Intelligence+',
+      effectRecessive: 'None',
+    });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const { stats, totalGenes, neutralGenes } = await petService.getPetGeneStats(result.pet_id, 'BeeWasp');
+
+    expect(totalGenes).toBe(3);
+    expect(neutralGenes).toBe(1);
+    expect(stats.Intelligence.positive).toBe(1);
+    expect(stats.Toughness.positive).toBe(1);
+  });
+
+  it('returns an empty stats record for a pet with no pet_genes rows', async () => {
+    // No upload → no pet_genes rows. Stats must still return a fully
+    // initialized attribute map so consumers can render zero rows.
+    const { stats, totalGenes, neutralGenes } = await petService.getPetGeneStats(9999, 'BeeWasp');
+    expect(totalGenes).toBe(0);
+    expect(neutralGenes).toBe(0);
+    expect(stats.Intelligence).toMatchObject({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+  });
+});
+
+describe('getParsedGenesCached reflects gene edits', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it('invalidates when clearGeneEffectsCache is called', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'None',
+    });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    let map = await geneService.getParsedGenesCached('BeeWasp');
+    expect(map['01A1']?.dominantSign).toBe('+');
+    expect(map['01A1']?.dominantAttribute).toBe('toughness');
+
+    // Edit the gene to a negative effect and invalidate.
+    await geneService.upsertGene('beewasp', '01', '01A1', {
+      effectDominant: 'Toughness-',
+      effectRecessive: 'None',
+    });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    map = await geneService.getParsedGenesCached('BeeWasp');
+    expect(map['01A1']?.dominantSign).toBe('-');
+  });
+});


### PR DESCRIPTION
## Summary

Third stage of the gene-stats refactor: swap the JSON-parse + effect-string regex hot paths for SQL-side aggregation.

`positive_genes` computation (upload, update, backfill) and the comparison view's per-attribute stats now read pre-parsed `dominant_attribute` / `dominant_sign` / `recessive_attribute` / `recessive_sign` columns straight off the genes table, joined against the pet's `pet_genes` rows. No more regex matching against effect strings, no more JSON-parsing the genome to count.

### What's in this PR

- `getParsedGenesCached(species)` in `geneService.ts` — `gene_id → ParsedGeneRecord` map. Hooked into the existing `clearGeneEffectsCache` so a single invalidation point covers both caches.
- `getPetGeneStats(petId, species, breed)` in `petService.ts` — returns `{ stats, totalGenes, neutralGenes }` matching the old `computeGeneStats` shape, so call sites stay drop-in compatible. Horse breed-filter behavior preserved (mismatched genes increment `totalGenes` but contribute to neither `stats` nor `neutralGenes`).
- `compareGeneStats` parallelizes the two pets via the new SQL aggregator.
- `computePositiveGenesForGenome` rewritten to walk the in-memory genome but resolve effects through the parsed cache (no regex, no effect-string lookup).
- `computeGeneStats` and its `getAllAttributeNames` / `capitalize` / `normalizeSpecies` imports deleted from `geneAnalysis.ts`.

### Not in this PR

The visualizer (`GeneVisualizer.analyzeGeneEffect`) still has its own JSON-walking analysis — but that's tightly bound to the grid rendering pipeline and stays for M4 along with the rest of the JSON-parse-for-stats sweep.

## Test plan

- [x] `pnpm test` — 279/279 passing (4 new tests in `tests/unit/petGeneStats.test.js`)
- [x] `pnpm lint:ci` — clean
- [x] `pnpm build` — clean
- [ ] Manual smoke: upload a beewasp, open compare view between two pets, confirm per-attribute stats match what the visualizer's stats panel shows
- [ ] Manual smoke: edit a gene effect, reopen the same pet's compare view, confirm the change is reflected after `clearGeneEffectsCache` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)