### PR TITLE
feat(db): M4 — persist gene counts on pets

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -4,7 +4,11 @@ import { initDatabase } from '$lib/services/database.js';
 import { loadDemoPetsIfNeeded, populateGenesIfNeeded } from '$lib/services/demoService.js';
 import { backfillParsedGeneEffectsIfNeeded } from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
-import { backfillPetGenesIfNeeded, backfillPositiveGenesIfNeeded } from '$lib/services/petService.js';
+import {
+  backfillGeneCountsIfNeeded,
+  backfillPetGenesIfNeeded,
+  backfillPositiveGenesIfNeeded,
+} from '$lib/services/petService.js';
 import { appState } from '$lib/stores/pets.js';
 import { settingsActions } from '$lib/stores/settings.js';
 
@@ -40,13 +44,18 @@ onMount(async () => {
 
   backfillPetGenesIfNeeded()
     .then((wrote) => {
-      // pet_genes isn't read by UI code yet (that's M3), so only reload
-      // if the backfill actually wrote rows — avoids a redundant reload
-      // that would race with the positive_genes backfill's own reload.
       if (wrote) void appState.loadPets();
     })
     .catch((err) => {
       console.warn('pet_genes backfill aborted:', err);
+    });
+
+  backfillGeneCountsIfNeeded()
+    .then((wrote) => {
+      if (wrote) void appState.loadPets();
+    })
+    .catch((err) => {
+      console.warn('gene_counts backfill aborted:', err);
     });
 });
 </script>

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -168,6 +168,16 @@ const MIGRATIONS: Migration[] = [
       await db.execute('CREATE INDEX IF NOT EXISTS idx_pet_genes_lookup ON pet_genes(gene_id, gene_type)');
     },
   },
+  {
+    version: 11,
+    description: 'Add total_genes/known_genes/unknown_genes columns to pets (backfilled in JS)',
+    up: async () => {
+      const db = getDb();
+      await db.execute('ALTER TABLE pets ADD COLUMN total_genes INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE pets ADD COLUMN known_genes INTEGER NOT NULL DEFAULT 0');
+      await db.execute('ALTER TABLE pets ADD COLUMN unknown_genes INTEGER NOT NULL DEFAULT 0');
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -741,7 +741,9 @@ export async function backfillGeneCountsIfNeeded(): Promise<boolean> {
   if (done) return false;
 
   const db = getDb();
-  const rows = await db.select<{ id: number; genome_data: string }[]>('SELECT id, genome_data FROM pets');
+  const rows = await db.select<
+    { id: number; genome_data: string; total_genes: number; known_genes: number; unknown_genes: number }[]
+  >('SELECT id, genome_data, total_genes, known_genes, unknown_genes FROM pets');
 
   if (rows.length === 0) {
     await setSetting(GENE_COUNTS_BACKFILL_KEY, true);
@@ -750,31 +752,44 @@ export async function backfillGeneCountsIfNeeded(): Promise<boolean> {
 
   console.info(`gene_counts backfill: starting for ${rows.length} pets`);
 
-  const BATCH = 16;
   const updates: { id: number; counts: GeneCountSummary }[] = [];
+  const BATCH = 16;
   for (let i = 0; i < rows.length; i += BATCH) {
-    const slice = rows.slice(i, i + BATCH);
-    for (const row of slice) {
-      updates.push({ id: row.id, counts: countGenes(row.genome_data) });
+    for (const row of rows.slice(i, i + BATCH)) {
+      const counts = countGenes(row.genome_data);
+      const cur = { total: row.total_genes ?? 0, known: row.known_genes ?? 0, unknown: row.unknown_genes ?? 0 };
+      if (counts.total === cur.total && counts.known === cur.known && counts.unknown === cur.unknown) continue;
+      updates.push({ id: row.id, counts });
     }
     const processed = Math.min(i + BATCH, rows.length);
-    console.info(`gene_counts backfill: ${processed}/${rows.length} computed`);
+    console.info(`gene_counts backfill: ${processed}/${rows.length} scanned, ${updates.length} need update`);
     await yieldToUI();
   }
 
-  let wrote = false;
-  await withTransaction(async () => {
-    for (const u of updates) {
-      await db.execute('UPDATE pets SET total_genes = $t, known_genes = $k, unknown_genes = $u WHERE id = $id', {
-        t: u.counts.total,
-        k: u.counts.known,
-        u: u.counts.unknown,
-        id: u.id,
-      });
-      wrote = true;
-    }
-  });
+  if (updates.length === 0) {
+    await setSetting(GENE_COUNTS_BACKFILL_KEY, true);
+    console.info('gene_counts backfill: nothing to write');
+    return false;
+  }
+
+  for (let i = 0; i < updates.length; i += BATCH) {
+    const slice = updates.slice(i, i + BATCH);
+    await withTransaction(async () => {
+      for (const u of slice) {
+        await db.execute('UPDATE pets SET total_genes = $t, known_genes = $k, unknown_genes = $u WHERE id = $id', {
+          t: u.counts.total,
+          k: u.counts.known,
+          u: u.counts.unknown,
+          id: u.id,
+        });
+      }
+    });
+    const processed = Math.min(i + BATCH, updates.length);
+    console.info(`gene_counts backfill: ${processed}/${updates.length} written`);
+    if (processed < updates.length) await yieldToUI();
+  }
+
   await setSetting(GENE_COUNTS_BACKFILL_KEY, true);
   console.info('gene_counts backfill: done');
-  return wrote;
+  return true;
 }

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -26,49 +26,37 @@ async function sha256(content: string): Promise<string> {
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
-/**
- * Count genes in a genome, categorizing as known vs unknown.
- */
-function countGenes(genomeData: unknown): { total: number; known: number; unknown: number } {
+type GeneCountSummary = { total: number; known: number; unknown: number };
+
+const EMPTY_GENE_COUNTS: GeneCountSummary = { total: 0, known: 0, unknown: 0 };
+
+/** Count total / known / unknown genes from a parsed Genome. */
+function countGenesFromGenome(genome: Genome): GeneCountSummary {
   let total = 0;
   let known = 0;
   let unknown = 0;
-
-  if (typeof genomeData === 'string') {
-    try {
-      genomeData = JSON.parse(genomeData);
-    } catch {
-      return { total: 0, known: 0, unknown: 0 };
+  for (const chrGenes of Object.values(genome.genes ?? {})) {
+    if (!Array.isArray(chrGenes)) continue;
+    for (const g of chrGenes) {
+      if (!g || typeof g !== 'object') continue;
+      total++;
+      const t = g.gene_type;
+      if (t === '?' || (typeof t === 'string' && t.toUpperCase() === 'UNKNOWN')) unknown++;
+      else known++;
     }
   }
-
-  if (typeof genomeData !== 'object' || genomeData === null) {
-    return { total: 0, known: 0, unknown: 0 };
-  }
-
-  const data = genomeData as Record<string, unknown>;
-
-  // Standard Genome model structure with Gene objects
-  if (data.genes && typeof data.genes === 'object') {
-    const genesMap = data.genes as Record<string, unknown[]>;
-    for (const chromosomeGenes of Object.values(genesMap)) {
-      if (!Array.isArray(chromosomeGenes)) continue;
-      for (const gene of chromosomeGenes) {
-        if (typeof gene === 'object' && gene !== null) {
-          const geneObj = gene as Record<string, unknown>;
-          total++;
-          const geneType = geneObj.gene_type;
-          if (geneType === '?' || (typeof geneType === 'string' && geneType.toUpperCase() === 'UNKNOWN')) {
-            unknown++;
-          } else {
-            known++;
-          }
-        }
-      }
-    }
-  }
-
   return { total, known, unknown };
+}
+
+/** Count genes in a genome (string or parsed). Returns zeros on malformed input. */
+function countGenes(genomeData: unknown): GeneCountSummary {
+  try {
+    const parsed: unknown = typeof genomeData === 'string' ? JSON.parse(genomeData) : genomeData;
+    if (!parsed || typeof parsed !== 'object') return EMPTY_GENE_COUNTS;
+    return countGenesFromGenome(parsed as Genome);
+  } catch {
+    return EMPTY_GENE_COUNTS;
+  }
 }
 
 /** Build an empty stats entry — exported so the comparison view can fall back on it. */
@@ -167,7 +155,7 @@ export async function getPetGeneStats(
 
 /** Enrich a raw pet row from the database with computed fields. */
 function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
-  const geneCounts = countGenes(pet.genome_data);
+  const unknownGenes = Number(pet.unknown_genes ?? 0);
   return {
     ...pet,
     tags,
@@ -175,10 +163,10 @@ function enrichPet(pet: Record<string, unknown>, tags: string[]): Pet {
     stabled: Boolean(pet.stabled),
     is_pet_quality: Boolean(pet.is_pet_quality),
     positive_genes: Number(pet.positive_genes ?? 0),
-    total_genes: geneCounts.total,
-    known_genes: geneCounts.known,
-    unknown_genes: geneCounts.unknown,
-    has_unknown_genes: geneCounts.unknown > 0,
+    total_genes: Number(pet.total_genes ?? 0),
+    known_genes: Number(pet.known_genes ?? 0),
+    unknown_genes: unknownGenes,
+    has_unknown_genes: unknownGenes > 0,
     readonly: false,
     is_demo: false,
   } as Pet;
@@ -308,6 +296,7 @@ export async function uploadPet(
   const attrValues = parsed?.attributes ?? defaults;
 
   const positiveGenes = await computePositiveGenesForGenome(genome, petBreed);
+  const geneCounts = countGenesFromGenome(genome);
 
   const db = getDb();
   const ts = now();
@@ -327,11 +316,11 @@ export async function uploadPet(
        (name, species, gender, breed, breeder, content_hash, genome_data, notes,
         created_at, updated_at,
         intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament, sort_order,
-        starred, stabled, is_pet_quality, positive_genes)
+        starred, stabled, is_pet_quality, positive_genes, total_genes, known_genes, unknown_genes)
        VALUES ($name, $species, $gender, $breed, $breeder, $content_hash, $genome_data, $notes,
                $created_at, $updated_at,
                $intelligence, $toughness, $friendliness, $ruggedness, $enthusiasm, $virility, $ferocity, $temperament, $sort_order,
-               $starred, $stabled, $is_pet_quality, $positive_genes)`,
+               $starred, $stabled, $is_pet_quality, $positive_genes, $total_genes, $known_genes, $unknown_genes)`,
       {
         name: petName,
         species: genome.genome_type,
@@ -356,6 +345,9 @@ export async function uploadPet(
         stabled: 1,
         is_pet_quality: 0,
         positive_genes: positiveGenes,
+        total_genes: geneCounts.total,
+        known_genes: geneCounts.known,
+        unknown_genes: geneCounts.unknown,
       },
     );
     if (res.lastInsertId) {
@@ -446,6 +438,14 @@ export async function updatePet(petId: number, updates: Record<string, unknown>)
       const positiveGenes = await computePositiveGenesForGenome(nextGenome ?? nextGenomeData, nextBreed);
       setClauses.push('positive_genes = $positive_genes');
       params.positive_genes = positiveGenes;
+
+      if (flat.genome_data !== undefined) {
+        const counts = nextGenome ? countGenesFromGenome(nextGenome) : EMPTY_GENE_COUNTS;
+        setClauses.push('total_genes = $total_genes', 'known_genes = $known_genes', 'unknown_genes = $unknown_genes');
+        params.total_genes = counts.total;
+        params.known_genes = counts.known;
+        params.unknown_genes = counts.unknown;
+      }
     }
   }
 
@@ -726,4 +726,55 @@ export async function backfillPositiveGenesIfNeeded(): Promise<void> {
   }
   await setSetting(POSITIVE_GENES_BACKFILL_KEY, true);
   console.info('positive_genes backfill: done');
+}
+
+const GENE_COUNTS_BACKFILL_KEY = 'pets.gene_counts_backfilled';
+
+/**
+ * One-shot backfill that populates total_genes/known_genes/unknown_genes
+ * for existing pets — the v11 migration only adds the columns with
+ * DEFAULT 0. Idempotent via a settings flag. Non-blocking, batched, with
+ * yields between batches so the UI stays responsive.
+ */
+export async function backfillGeneCountsIfNeeded(): Promise<boolean> {
+  const done = await getSetting<boolean>(GENE_COUNTS_BACKFILL_KEY);
+  if (done) return false;
+
+  const db = getDb();
+  const rows = await db.select<{ id: number; genome_data: string }[]>('SELECT id, genome_data FROM pets');
+
+  if (rows.length === 0) {
+    await setSetting(GENE_COUNTS_BACKFILL_KEY, true);
+    return false;
+  }
+
+  console.info(`gene_counts backfill: starting for ${rows.length} pets`);
+
+  const BATCH = 16;
+  const updates: { id: number; counts: GeneCountSummary }[] = [];
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const slice = rows.slice(i, i + BATCH);
+    for (const row of slice) {
+      updates.push({ id: row.id, counts: countGenes(row.genome_data) });
+    }
+    const processed = Math.min(i + BATCH, rows.length);
+    console.info(`gene_counts backfill: ${processed}/${rows.length} computed`);
+    await yieldToUI();
+  }
+
+  let wrote = false;
+  await withTransaction(async () => {
+    for (const u of updates) {
+      await db.execute('UPDATE pets SET total_genes = $t, known_genes = $k, unknown_genes = $u WHERE id = $id', {
+        t: u.counts.total,
+        k: u.counts.known,
+        u: u.counts.unknown,
+        id: u.id,
+      });
+      wrote = true;
+    }
+  });
+  await setSetting(GENE_COUNTS_BACKFILL_KEY, true);
+  console.info('gene_counts backfill: done');
+  return wrote;
 }

--- a/tests/unit/geneCounts.test.js
+++ b/tests/unit/geneCounts.test.js
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
+
+const MINIMAL_BEEWASP_GENOME = `[Overview]
+Format=1.0
+Character=Tester
+Entity=Minimal Bee
+Genome=BeeWasp
+
+[Genes]
+1=DD?
+`;
+
+describe('uploadPet persists gene-count columns', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+  });
+
+  it('writes total/known/unknown counts at upload time', async () => {
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const pet = await petService.getPet(result.pet_id);
+    expect(pet.total_genes).toBe(3);
+    expect(pet.known_genes).toBe(2);
+    expect(pet.unknown_genes).toBe(1);
+    expect(pet.has_unknown_genes).toBe(true);
+  });
+
+  it('handles a realistic sample genome', async () => {
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const pet = await petService.getPet(result.pet_id);
+    expect(pet.total_genes).toBeGreaterThan(0);
+    expect(pet.known_genes + pet.unknown_genes).toBe(pet.total_genes);
+  });
+});
+
+describe('updatePet refreshes gene-count columns when genome_data changes', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+  });
+
+  it('rewrites counts when genome_data is replaced', async () => {
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const before = await petService.getPet(result.pet_id);
+    expect(before.total_genes).toBe(3);
+
+    // Empty-genome JSON forces counts to 0 — proves the update hook ran.
+    const empty = JSON.stringify({
+      format_version: '1.0',
+      breeder: 'Tester',
+      name: 'Empty',
+      genome_type: 'BeeWasp',
+      genes: {},
+    });
+    await petService.updatePet(result.pet_id, { genome_data: empty });
+
+    const after = await petService.getPet(result.pet_id);
+    expect(after.total_genes).toBe(0);
+    expect(after.known_genes).toBe(0);
+    expect(after.unknown_genes).toBe(0);
+    expect(after.has_unknown_genes).toBe(false);
+  });
+});
+
+describe('backfillGeneCountsIfNeeded', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+  });
+
+  it('populates counts for pets inserted before the column existed', async () => {
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const db = getDb();
+
+    // Simulate a pre-v11 row by zeroing the columns and clearing the flag.
+    await db.execute('UPDATE pets SET total_genes = 0, known_genes = 0, unknown_genes = 0 WHERE id = $id', {
+      id: upload.pet_id,
+    });
+    await db.execute('DELETE FROM settings WHERE key = $k', { k: 'pets.gene_counts_backfilled' });
+
+    const wrote = await petService.backfillGeneCountsIfNeeded();
+    expect(wrote).toBe(true);
+
+    const pet = await petService.getPet(upload.pet_id);
+    expect(pet.total_genes).toBe(3);
+    expect(pet.known_genes).toBe(2);
+    expect(pet.unknown_genes).toBe(1);
+  });
+
+  it('is idempotent — second call short-circuits via the flag', async () => {
+    await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const first = await petService.backfillGeneCountsIfNeeded();
+    const second = await petService.backfillGeneCountsIfNeeded();
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+});

--- a/tests/unit/geneCounts.test.js
+++ b/tests/unit/geneCounts.test.js
@@ -83,7 +83,10 @@ describe('backfillGeneCountsIfNeeded', () => {
     const db = getDb();
 
     // Simulate a pre-v11 row by zeroing the columns and clearing the flag.
-    await db.execute('UPDATE pets SET total_genes = 0, known_genes = 0, unknown_genes = 0 WHERE id = $id', {
+    await db.execute('UPDATE pets SET total_genes = $t, known_genes = $k, unknown_genes = $u WHERE id = $id', {
+      t: 0,
+      k: 0,
+      u: 0,
       id: upload.pet_id,
     });
     await db.execute('DELETE FROM settings WHERE key = $k', { k: 'pets.gene_counts_backfilled' });
@@ -97,11 +100,27 @@ describe('backfillGeneCountsIfNeeded', () => {
     expect(pet.unknown_genes).toBe(1);
   });
 
-  it('is idempotent — second call short-circuits via the flag', async () => {
+  it('returns false when every pet already has matching counts', async () => {
+    // uploadPet writes the counts at insert time, so the backfill has
+    // nothing to do — wrote=false avoids a spurious appState reload.
     await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
-    const first = await petService.backfillGeneCountsIfNeeded();
-    const second = await petService.backfillGeneCountsIfNeeded();
-    expect(first).toBe(true);
-    expect(second).toBe(false);
+    expect(await petService.backfillGeneCountsIfNeeded()).toBe(false);
+  });
+
+  it('second call short-circuits via the flag', async () => {
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const db = getDb();
+
+    // Zero the columns so the first call has real work to do.
+    await db.execute('UPDATE pets SET total_genes = $t, known_genes = $k, unknown_genes = $u WHERE id = $id', {
+      t: 0,
+      k: 0,
+      u: 0,
+      id: upload.pet_id,
+    });
+    await db.execute('DELETE FROM settings WHERE key = $k', { k: 'pets.gene_counts_backfilled' });
+
+    expect(await petService.backfillGeneCountsIfNeeded()).toBe(true);
+    expect(await petService.backfillGeneCountsIfNeeded()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Final stage of the gene-stats refactor: drop the JSON-parse hot path on the pet list.

`enrichPet` was JSON-parsing every pet's full `genome_data` to derive `total_genes`/`known_genes`/`unknown_genes` — this fired on every row of every list query (and the stable table reads them via `pet.unknown_genes`). With big stables that's a non-trivial per-render cost.

After this PR, the only path that still parses `genome_data` is the visualizer grid, which needs the chromosome/block/position structure to render. Everything else reads from columns.

### What's in this PR

- **v11 migration**: add `total_genes`, `known_genes`, `unknown_genes` columns to `pets` (NOT NULL DEFAULT 0).
- **uploadPet**: computes counts at write time alongside `positive_genes`, single genome traversal.
- **updatePet**: recomputes counts whenever `genome_data` changes — atomic with the existing `pet_genes` rewrite + `positive_genes` recompute.
- **enrichPet**: now reads the columns directly; no JSON.parse on list reads.
- **backfillGeneCountsIfNeeded**: populates pre-existing rows in batches with yields, idempotent via a settings flag.
- **AuthWrapper**: fires the new backfill non-blockingly alongside `positive_genes`, `parsed_effects`, and `pet_genes`.
- **countGenesFromGenome(genome)**: helper that takes an already-parsed `Genome` so upload/update don't double-parse.

### What's not in this PR

I considered decoupling the visualizer's stats drawer from `GeneVisualizer`'s render-time accumulator — but the visualizer already walks every gene to render the grid, so its stats are essentially free. Adding a separate `getPetGeneStats` call would actively duplicate work and the appearance view would need its own SQL aggregator. Holding off unless there's a concrete reason.

## Test plan

- [x] `pnpm test` — 284/284 passing (5 new tests in `tests/unit/geneCounts.test.js`)
- [x] `pnpm lint:ci` — clean
- [x] `pnpm build` — clean
- [ ] Manual smoke: upload a fresh pet, confirm `unknown_genes`/`has_unknown_genes` flow into the warning badge and the stable table without lag
- [ ] Manual smoke: open a 200+ pet stable on a clean checkout (so the backfill must run), verify the list renders immediately and counts populate as the backfill finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)