### PR TITLE
perf(backup): parse import zip once instead of three times (#93)

### DIFF
--- a/src/lib/components/layout/DataMenu.svelte
+++ b/src/lib/components/layout/DataMenu.svelte
@@ -1,6 +1,6 @@
 <script>
 import { onDestroy, tick } from 'svelte';
-import { inspectBackup } from '$lib/services/backupService.js';
+import { loadBackup } from '$lib/services/backupService.js';
 import { pickBackupFile, readBinaryFile } from '$lib/services/fileService.js';
 import ExportDialog from './ExportDialog.svelte';
 import ImportDialog from './ImportDialog.svelte';
@@ -8,10 +8,8 @@ import ImportDialog from './ImportDialog.svelte';
 let menuOpen = $state(false);
 let showExport = $state(false);
 let showImport = $state(false);
-/** @type {import('$lib/types/index.js').GorgonExportMetadata | null} */
-let importMetadata = $state(null);
-/** @type {Uint8Array | null} */
-let importFileData = $state(null);
+/** @type {import('$lib/services/backupService.js').LoadedBackup | null} */
+let loadedBackup = $state(null);
 /** @type {{ type: 'success' | 'error', message: string } | null} */
 let status = $state(null);
 let statusTimer = 0;
@@ -83,9 +81,7 @@ async function openImport() {
     if (!path) return;
 
     const data = await readBinaryFile(path);
-    const metadata = await inspectBackup(data);
-    importFileData = data;
-    importMetadata = metadata;
+    loadedBackup = await loadBackup(data);
     showImport = true;
   } catch (err) {
     status = { type: 'error', message: `Failed to read backup: ${err.message}` };
@@ -172,11 +168,10 @@ function handleClickOutside(event) {
   <ExportDialog onClose={() => { showExport = false; }} onResult={handleResult} />
 {/if}
 
-{#if showImport && importMetadata}
+{#if showImport && loadedBackup}
   <ImportDialog
-    metadata={importMetadata}
-    fileData={importFileData}
-    onClose={() => { showImport = false; importMetadata = null; importFileData = null; }}
+    backup={loadedBackup}
+    onClose={() => { showImport = false; loadedBackup = null; }}
     onResult={handleResult}
   />
 {/if}

--- a/src/lib/components/layout/ImportDialog.svelte
+++ b/src/lib/components/layout/ImportDialog.svelte
@@ -3,7 +3,8 @@ import { importDatabase } from '$lib/services/backupService.js';
 import { appState } from '$lib/stores/pets.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 
-const { metadata, fileData, onClose, onResult } = $props();
+const { backup, onClose, onResult } = $props();
+const metadata = $derived(backup?.metadata ?? null);
 
 /** @type {'replace' | 'merge'} */
 let mode = $state('replace');
@@ -20,7 +21,7 @@ const isV1 = $derived((metadata?.format_version ?? 1) < 2);
 async function handleImport() {
   importing = true;
   try {
-    const result = await importDatabase(fileData, {
+    const result = await importDatabase(backup, {
       mode,
       includeGenes: includeGenes && hasGenes,
       includePets: includePets && hasPets,

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -174,7 +174,12 @@ export async function exportDatabase(options: ExportOptions): Promise<ExportResu
 
 // --- Import ---
 
-export async function inspectBackup(fileData: Uint8Array): Promise<GorgonExportMetadata> {
+export interface LoadedBackup {
+  zip: JSZip;
+  metadata: GorgonExportMetadata;
+}
+
+export async function loadBackup(fileData: Uint8Array): Promise<LoadedBackup> {
   const zip = await JSZip.loadAsync(fileData);
   const metaFile = zip.file('metadata.json');
   if (!metaFile) throw new Error('Backup archive is missing metadata.json.');
@@ -189,13 +194,20 @@ export async function inspectBackup(fileData: Uint8Array): Promise<GorgonExportM
   if (metadata.schema_version > CURRENT_SCHEMA_VERSION) {
     throw new Error(`This backup uses a newer database schema (v${metadata.schema_version}). Please update the app.`);
   }
-  return metadata;
+  return { zip, metadata };
 }
 
-export async function importDatabase(fileData: Uint8Array, options: ImportOptions): Promise<ImportResult> {
-  // Validate before importing
-  await inspectBackup(fileData);
-  return importFromZip(fileData, options);
+export async function inspectBackup(fileData: Uint8Array): Promise<GorgonExportMetadata> {
+  return (await loadBackup(fileData)).metadata;
+}
+
+function isLoadedBackup(source: Uint8Array | LoadedBackup): source is LoadedBackup {
+  return typeof source === 'object' && source !== null && 'zip' in source && 'metadata' in source;
+}
+
+export async function importDatabase(source: Uint8Array | LoadedBackup, options: ImportOptions): Promise<ImportResult> {
+  const loaded = isLoadedBackup(source) ? source : await loadBackup(source);
+  return importFromZip(loaded.zip, options);
 }
 
 /** Shared gene/pet import logic used by both v1 and v2 paths. */
@@ -271,9 +283,7 @@ async function importGenesAndPets(
   return { genes: genesImported, pets: petsImported, petsSkipped };
 }
 
-async function importFromZip(fileData: Uint8Array, options: ImportOptions): Promise<ImportResult> {
-  const zip = await JSZip.loadAsync(fileData);
-
+async function importFromZip(zip: JSZip, options: ImportOptions): Promise<ImportResult> {
   // Extract data from zip
   let genes: Record<string, unknown>[] | null = null;
   let pets: Record<string, unknown>[] | null = null;

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -179,12 +179,7 @@ export interface LoadedBackup {
   metadata: GorgonExportMetadata;
 }
 
-export async function loadBackup(fileData: Uint8Array): Promise<LoadedBackup> {
-  const zip = await JSZip.loadAsync(fileData);
-  const metaFile = zip.file('metadata.json');
-  if (!metaFile) throw new Error('Backup archive is missing metadata.json.');
-  const metaJson = await metaFile.async('string');
-  const metadata = JSON.parse(metaJson) as GorgonExportMetadata;
+function validateMetadata(metadata: GorgonExportMetadata): void {
   if (metadata.format !== EXPORT_FORMAT) throw new Error('Not a Gorgonetics backup file.');
   if (metadata.format_version > EXPORT_FORMAT_VERSION) {
     throw new Error(
@@ -194,6 +189,15 @@ export async function loadBackup(fileData: Uint8Array): Promise<LoadedBackup> {
   if (metadata.schema_version > CURRENT_SCHEMA_VERSION) {
     throw new Error(`This backup uses a newer database schema (v${metadata.schema_version}). Please update the app.`);
   }
+}
+
+export async function loadBackup(fileData: Uint8Array): Promise<LoadedBackup> {
+  const zip = await JSZip.loadAsync(fileData);
+  const metaFile = zip.file('metadata.json');
+  if (!metaFile) throw new Error('Backup archive is missing metadata.json.');
+  const metaJson = await metaFile.async('string');
+  const metadata = JSON.parse(metaJson) as GorgonExportMetadata;
+  validateMetadata(metadata);
   return { zip, metadata };
 }
 
@@ -207,6 +211,9 @@ function isLoadedBackup(source: Uint8Array | LoadedBackup): source is LoadedBack
 
 export async function importDatabase(source: Uint8Array | LoadedBackup, options: ImportOptions): Promise<ImportResult> {
   const loaded = isLoadedBackup(source) ? source : await loadBackup(source);
+  // Re-validate even for pre-loaded backups: the LoadedBackup shape is plain
+  // data and a caller could construct one without going through loadBackup.
+  validateMetadata(loaded.metadata);
   return importFromZip(loaded.zip, options);
 }
 

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -123,20 +123,32 @@ describe('Backup Service', () => {
     it('parses the zip only once when reused via importDatabase', async () => {
       const zipData = await buildZip({ genes: [sampleGene] });
       const loadAsyncSpy = vi.spyOn(JSZip, 'loadAsync');
-      const callsBefore = loadAsyncSpy.mock.calls.length;
+      try {
+        const callsBefore = loadAsyncSpy.mock.calls.length;
 
+        const loaded = await loadBackup(zipData);
+        const result = await importDatabase(loaded, {
+          mode: 'replace',
+          includeGenes: true,
+          includePets: false,
+          includeImages: false,
+        });
+        const callsAfter = loadAsyncSpy.mock.calls.length;
+
+        expect(result.genes).toBe(1);
+        expect(callsAfter - callsBefore).toBe(1);
+      } finally {
+        loadAsyncSpy.mockRestore();
+      }
+    });
+
+    it('importDatabase re-validates metadata even on a pre-loaded backup', async () => {
+      const zipData = await buildZip({ genes: [sampleGene] });
       const loaded = await loadBackup(zipData);
-      const result = await importDatabase(loaded, {
-        mode: 'replace',
-        includeGenes: true,
-        includePets: false,
-        includeImages: false,
-      });
-      const callsAfter = loadAsyncSpy.mock.calls.length;
-
-      expect(result.genes).toBe(1);
-      expect(callsAfter - callsBefore).toBe(1);
-      loadAsyncSpy.mockRestore();
+      const tampered = { zip: loaded.zip, metadata: { ...loaded.metadata, format: 'other-app' } };
+      await expect(
+        importDatabase(tampered, { mode: 'replace', includeGenes: true, includePets: false, includeImages: false }),
+      ).rejects.toThrow('Not a Gorgonetics backup');
     });
 
     it('importDatabase still parses raw bytes when no pre-loaded backup is given', async () => {

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -1,6 +1,6 @@
 import JSZip from 'jszip';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { importDatabase, inspectBackup } from '$lib/services/backupService.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { importDatabase, inspectBackup, loadBackup } from '$lib/services/backupService.js';
 import { closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
 import { CURRENT_SCHEMA_VERSION, runMigrations } from '$lib/services/migrationService.js';
 
@@ -107,6 +107,47 @@ describe('Backup Service', () => {
     it('rejects invalid zip data', async () => {
       const garbage = new Uint8Array([1, 2, 3, 4]);
       await expect(inspectBackup(garbage)).rejects.toThrow();
+    });
+  });
+
+  // --- loadBackup ---
+
+  describe('loadBackup', () => {
+    it('returns both the parsed zip and metadata', async () => {
+      const zipData = await buildZip({ genes: [sampleGene] });
+      const loaded = await loadBackup(zipData);
+      expect(loaded.metadata.format).toBe('gorgonetics-backup');
+      expect(loaded.zip.file('genes.json')).toBeTruthy();
+    });
+
+    it('parses the zip only once when reused via importDatabase', async () => {
+      const zipData = await buildZip({ genes: [sampleGene] });
+      const loadAsyncSpy = vi.spyOn(JSZip, 'loadAsync');
+      const callsBefore = loadAsyncSpy.mock.calls.length;
+
+      const loaded = await loadBackup(zipData);
+      const result = await importDatabase(loaded, {
+        mode: 'replace',
+        includeGenes: true,
+        includePets: false,
+        includeImages: false,
+      });
+      const callsAfter = loadAsyncSpy.mock.calls.length;
+
+      expect(result.genes).toBe(1);
+      expect(callsAfter - callsBefore).toBe(1);
+      loadAsyncSpy.mockRestore();
+    });
+
+    it('importDatabase still parses raw bytes when no pre-loaded backup is given', async () => {
+      const zipData = await buildZip({ genes: [sampleGene] });
+      const result = await importDatabase(zipData, {
+        mode: 'replace',
+        includeGenes: true,
+        includePets: false,
+        includeImages: false,
+      });
+      expect(result.genes).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- `inspectBackup` + `importDatabase` previously decompressed the same zip three times (DataMenu inspection, validation inside `importDatabase`, then `importFromZip`). For large backups this tripled the JSZip work.
- New `loadBackup(fileData)` returns `{ zip, metadata }` once. `inspectBackup` is now a thin wrapper, and `importDatabase` accepts either raw bytes (kept for tests/e2e) or a pre-loaded backup, reusing the parsed `JSZip` instance.
- `DataMenu` calls `loadBackup` when picking a file and forwards the loaded backup to `ImportDialog`, which passes it straight to `importDatabase` — so the user-facing flow now parses the zip exactly once.

Closes #93.

## Test plan
- [x] `pnpm test` (300 unit tests, includes new `loadBackup` tests + a spy verifying `JSZip.loadAsync` runs once when reusing a pre-loaded backup)
- [x] `pnpm test:e2e tests/e2e/backup.spec.js` (8 tests, raw-bytes path still works)
- [x] `pnpm run lint:ci`
- [x] `pnpm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)