### PR TITLE
perf(pets,images): replace SELECT-all sort_order with MAX query

### DIFF
--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -131,6 +131,21 @@ class InMemoryDatabase implements DatabaseAdapter {
       return unique.map((v) => ({ [col]: v })) as T;
     }
 
+    // SELECT IFNULL(MAX(col), default) + addend AS alias FROM table [WHERE ...]
+    const maxAggMatch = q.match(/select\s+ifnull\(max\((\w+)\),\s*(-?\d+)\)\s*\+\s*(\d+)\s+as\s+(\w+)\s+from\s+(\w+)/i);
+    if (maxAggMatch) {
+      const [, col, def, addend, alias, table] = maxAggMatch;
+      const rows = this.getTable(table);
+      const filtered = this.applyWhere(rows, q, values);
+      const max = filtered.reduce<number | null>((m, r) => {
+        const v = r[col];
+        if (typeof v !== 'number') return m;
+        return m === null || v > m ? v : m;
+      }, null);
+      const base = max === null ? Number(def) : max;
+      return [{ [alias]: base + Number(addend) }] as T;
+    }
+
     // SELECT * FROM table
     const selectMatch = q.match(/select\s+.+?\s+from\s+(\w+)/);
     if (selectMatch) {

--- a/src/lib/services/imageService.ts
+++ b/src/lib/services/imageService.ts
@@ -68,14 +68,10 @@ export async function uploadImage(petId: number, sourcePath: string): Promise<Pe
     const db = getDb();
     const originalName = getBasename(sourcePath);
     const ts = now();
-    // TODO: This queries all sort_orders per image, making bulk upload O(N*existing).
-    // Fix by accepting an optional startOrder param or adding a batch uploadImages() that
-    // queries once and increments locally. Not worth optimizing until galleries are large.
-    const orderRows = await db.select<{ sort_order: number }[]>(
-      'SELECT sort_order FROM pet_images WHERE pet_id = $pet_id',
+    const [{ next: nextOrder }] = await db.select<{ next: number }[]>(
+      'SELECT IFNULL(MAX(sort_order), -1) + 1 AS next FROM pet_images WHERE pet_id = $pet_id',
       { pet_id: petId },
     );
-    const nextOrder = orderRows.length > 0 ? Math.max(...orderRows.map((r) => r.sort_order ?? 0)) + 1 : 0;
     const result = await db.execute(
       `INSERT INTO pet_images (pet_id, filename, original_name, caption, tags, created_at, sort_order)
        VALUES ($pet_id, $filename, $original_name, $caption, $tags, $created_at, $sort_order)`,

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -408,10 +408,9 @@ export async function uploadPet(
   const db = getDb();
   const ts = now();
 
-  // TODO: This queries all sort_orders per upload, making bulk upload O(N*existing).
-  // Same issue as imageService — fix by querying once before the loop.
-  const orderRows = await db.select<{ sort_order: number }[]>('SELECT sort_order FROM pets');
-  const nextOrder = orderRows.length > 0 ? Math.max(...orderRows.map((r) => r.sort_order ?? 0)) + 1 : 0;
+  const [{ next: nextOrder }] = await db.select<{ next: number }[]>(
+    'SELECT IFNULL(MAX(sort_order), -1) + 1 AS next FROM pets',
+  );
 
   // Atomic with the pet_genes projection: a half-written pet (row in
   // `pets` but no rows in `pet_genes`) would block retries via the

--- a/tests/unit/petService.test.js
+++ b/tests/unit/petService.test.js
@@ -90,6 +90,14 @@ describe('Pet Service', () => {
       expect(items.map((p) => p.name).sort()).toEqual(['Sample Fae Bee', 'Sample Horse']);
     });
 
+    it('assigns monotonically increasing sort_order across uploads', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+      await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      const db = getDb();
+      const rows = await db.select('SELECT sort_order FROM pets ORDER BY id');
+      expect(rows.map((r) => r.sort_order)).toEqual([0, 1]);
+    });
+
     it('returns error for duplicates during sequential upload', async () => {
       const result1 = await petService.uploadPet(SAMPLE_BEEWASP, 'First', 'Female');
       expect(result1.status).toBe('success');


### PR DESCRIPTION
## Summary

\`uploadPet\` (src/lib/services/petService.ts) and \`addImage\` (src/lib/services/imageService.ts) both fetched every existing \`sort_order\` row and computed the max in JS — making each upload O(N·existing) on the wire. Both had explicit TODOs flagging the issue.

Replace with a single scalar query:

\`\`\`sql
SELECT IFNULL(MAX(sort_order), -1) + 1 AS next FROM pets;
SELECT IFNULL(MAX(sort_order), -1) + 1 AS next FROM pet_images WHERE pet_id = \$pet_id;
\`\`\`

Teach the in-memory test database to recognise that aggregate shape (it had no \`MAX\`/\`IFNULL\` support before — added a targeted matcher rather than a generic aggregate parser, since this is the only shape we need today).

Closes #158, #159.

## Test plan
- [x] \`pnpm test\` — 302 unit tests pass (one new: asserts sort_order values are monotonically increasing across uploads).
- [x] \`pnpm run lint:ci\`.
- [x] Behaviour preserved: empty table → \`nextOrder = 0\`; non-empty → \`MAX + 1\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)