### PR TITLE
perf(backup): batch gene/pet/tag INSERTs during import

### DIFF
--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -15,7 +15,7 @@ import type {
 } from '$lib/types/index.js';
 import { isTauri } from '$lib/utils/environment.js';
 import { now } from '$lib/utils/timestamp.js';
-import { getDb } from './database.js';
+import { getDb, type TxStatement } from './database.js';
 import { saveExportBinaryFile } from './fileService.js';
 import { CURRENT_SCHEMA_VERSION, getSchemaVersion } from './migrationService.js';
 
@@ -217,10 +217,10 @@ export async function importDatabase(source: Uint8Array | LoadedBackup, options:
   return importFromZip(loaded.zip, options);
 }
 
-// SQLite default SQLITE_MAX_VARIABLE_NUMBER is 999. Chunk sizes below keep
-// (chunk_size × column_count) safely under that bound.
-const GENE_INSERT_CHUNK = 80; // 80 × 10 cols = 800 params
-const PET_INSERT_CHUNK = 40; // 40 × 22 cols = 880 params
+// SQLite's default SQLITE_MAX_VARIABLE_NUMBER is 999. Cap each multi-row
+// INSERT under that, with a small safety margin so future column additions
+// don't silently drift over the limit.
+const MAX_SQL_VARS = 900;
 
 type InsertConflictMode = 'fail' | 'replace' | 'ignore';
 
@@ -230,18 +230,23 @@ const INSERT_VERB: Record<InsertConflictMode, string> = {
   ignore: 'INSERT OR IGNORE INTO',
 };
 
-/** Insert a chunk of rows in one statement. Caller is responsible for the transaction. */
-async function batchInsert(
+/**
+ * Build a list of multi-row INSERT statements for `rows`, chunked so that
+ * each statement stays under SQLite's parameter limit. The caller submits
+ * the resulting list via `db.transaction([...])` for real cross-statement
+ * atomicity (the legacy BEGIN/COMMIT pair is a no-op on the Tauri adapter).
+ */
+function buildBatchInserts(
   table: string,
   columns: readonly string[],
   rows: ReadonlyArray<Record<string, unknown>>,
-  chunkSize: number,
   conflict: InsertConflictMode = 'fail',
-): Promise<void> {
-  if (rows.length === 0) return;
-  const db = getDb();
+): TxStatement[] {
+  if (rows.length === 0) return [];
   const verb = INSERT_VERB[conflict];
   const colList = columns.join(', ');
+  const chunkSize = Math.max(1, Math.floor(MAX_SQL_VARS / Math.max(1, columns.length)));
+  const out: TxStatement[] = [];
   for (let i = 0; i < rows.length; i += chunkSize) {
     const chunk = rows.slice(i, i + chunkSize);
     const placeholders = chunk.map((_, j) => `(${columns.map((c) => `$${c}_${j}`).join(', ')})`).join(', ');
@@ -249,8 +254,9 @@ async function batchInsert(
     chunk.forEach((row, j) => {
       for (const col of columns) params[`${col}_${j}`] = row[col] ?? null;
     });
-    await db.execute(`${verb} ${table} (${colList}) VALUES ${placeholders}`, params);
+    out.push({ sql: `${verb} ${table} (${colList}) VALUES ${placeholders}`, params });
   }
+  return out;
 }
 
 /** Shared gene/pet import logic used by both v1 and v2 paths. */
@@ -274,52 +280,51 @@ async function importGenesAndPets(
     sortOrderOffset = maxSortOrder + 1;
   }
 
-  await db.execute('BEGIN');
-  try {
-    if (options.mode === 'replace') {
-      if (options.includeGenes) await db.execute('DELETE FROM genes');
-      if (options.includeImages) await db.execute('DELETE FROM pet_images');
-      if (options.includePets) await db.execute('DELETE FROM pets');
-    }
+  // Build the entire write set ahead of time so it can run inside a single
+  // db.transaction() — that's what gives real cross-statement atomicity on
+  // the Tauri adapter (BEGIN/COMMIT through db.execute() are no-ops there).
+  const statements: TxStatement[] = [];
 
-    if (options.includeGenes && genes && genes.length > 0) {
-      const geneRows = genes.map((g) => {
-        const row: Record<string, unknown> = {};
-        for (const col of GENE_COLUMNS) row[col] = g[col] ?? null;
-        return row;
-      });
-      await batchInsert('genes', GENE_COLUMNS, geneRows, GENE_INSERT_CHUNK, 'replace');
-      genesImported = genes.length;
-    }
-
-    if (options.includePets && pets) {
-      const petRows: Record<string, unknown>[] = [];
-      for (const pet of pets) {
-        if (existingHashes?.has(pet.content_hash as string)) {
-          petsSkipped++;
-          continue;
-        }
-        let genomeData = pet.genome_data;
-        if (typeof genomeData === 'object' && genomeData !== null) genomeData = JSON.stringify(genomeData);
-        const row: Record<string, unknown> = {};
-        for (const col of PET_COLUMNS) {
-          if (col === 'genome_data') row[col] = genomeData;
-          else if (col === 'sort_order') row[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
-          else if (col === 'stabled') row[col] = pet[col] ?? 1;
-          else if (col === 'starred' || col === 'is_pet_quality') row[col] = pet[col] ?? 0;
-          else row[col] = pet[col] ?? null;
-        }
-        petRows.push(row);
-      }
-      await batchInsert('pets', PET_COLUMNS, petRows, PET_INSERT_CHUNK);
-      petsImported = petRows.length;
-    }
-
-    await db.execute('COMMIT');
-  } catch (error) {
-    await db.execute('ROLLBACK');
-    throw error;
+  if (options.mode === 'replace') {
+    if (options.includeGenes) statements.push({ sql: 'DELETE FROM genes' });
+    if (options.includeImages) statements.push({ sql: 'DELETE FROM pet_images' });
+    if (options.includePets) statements.push({ sql: 'DELETE FROM pets' });
   }
+
+  if (options.includeGenes && genes && genes.length > 0) {
+    const geneRows = genes.map((g) => {
+      const row: Record<string, unknown> = {};
+      for (const col of GENE_COLUMNS) row[col] = g[col] ?? null;
+      return row;
+    });
+    statements.push(...buildBatchInserts('genes', GENE_COLUMNS, geneRows, 'replace'));
+    genesImported = genes.length;
+  }
+
+  if (options.includePets && pets) {
+    const petRows: Record<string, unknown>[] = [];
+    for (const pet of pets) {
+      if (existingHashes?.has(pet.content_hash as string)) {
+        petsSkipped++;
+        continue;
+      }
+      let genomeData = pet.genome_data;
+      if (typeof genomeData === 'object' && genomeData !== null) genomeData = JSON.stringify(genomeData);
+      const row: Record<string, unknown> = {};
+      for (const col of PET_COLUMNS) {
+        if (col === 'genome_data') row[col] = genomeData;
+        else if (col === 'sort_order') row[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
+        else if (col === 'stabled') row[col] = pet[col] ?? 1;
+        else if (col === 'starred' || col === 'is_pet_quality') row[col] = pet[col] ?? 0;
+        else row[col] = pet[col] ?? null;
+      }
+      petRows.push(row);
+    }
+    statements.push(...buildBatchInserts('pets', PET_COLUMNS, petRows));
+    petsImported = petRows.length;
+  }
+
+  if (statements.length > 0) await db.transaction(statements);
 
   return { genes: genesImported, pets: petsImported, petsSkipped };
 }
@@ -346,10 +351,13 @@ async function importFromZip(zip: JSZip, options: ImportOptions): Promise<Import
   const allPets = await db.select<{ id: number; content_hash: string }[]>('SELECT id, content_hash FROM pets');
   const hashToId = new Map(allPets.map((p) => [p.content_hash, p.id]));
 
-  // Import pet tags into junction table
+  // Import pet tags into junction table — same atomicity story: build the
+  // statement list and submit via db.transaction() so a partial failure
+  // doesn't leave half the tags written.
   if (options.includePets) {
+    const tagStatements: TxStatement[] = [];
     if (options.mode === 'replace') {
-      await db.execute('DELETE FROM pet_tags');
+      tagStatements.push({ sql: 'DELETE FROM pet_tags' });
     }
 
     const tagInserts: Record<string, unknown>[] = [];
@@ -389,9 +397,9 @@ async function importFromZip(zip: JSZip, options: ImportOptions): Promise<Import
       }
     }
     if (tagInserts.length > 0) {
-      // 2 cols × 400 rows = 800 params, well under SQLITE_MAX_VARIABLE_NUMBER
-      await batchInsert('pet_tags', ['pet_id', 'tag'], tagInserts, 400, 'ignore');
+      tagStatements.push(...buildBatchInserts('pet_tags', ['pet_id', 'tag'], tagInserts, 'ignore'));
     }
+    if (tagStatements.length > 0) await db.transaction(tagStatements);
   }
 
   let imagesImported = 0;

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -217,6 +217,42 @@ export async function importDatabase(source: Uint8Array | LoadedBackup, options:
   return importFromZip(loaded.zip, options);
 }
 
+// SQLite default SQLITE_MAX_VARIABLE_NUMBER is 999. Chunk sizes below keep
+// (chunk_size × column_count) safely under that bound.
+const GENE_INSERT_CHUNK = 80; // 80 × 10 cols = 800 params
+const PET_INSERT_CHUNK = 40; // 40 × 22 cols = 880 params
+
+type InsertConflictMode = 'fail' | 'replace' | 'ignore';
+
+const INSERT_VERB: Record<InsertConflictMode, string> = {
+  fail: 'INSERT INTO',
+  replace: 'INSERT OR REPLACE INTO',
+  ignore: 'INSERT OR IGNORE INTO',
+};
+
+/** Insert a chunk of rows in one statement. Caller is responsible for the transaction. */
+async function batchInsert(
+  table: string,
+  columns: readonly string[],
+  rows: ReadonlyArray<Record<string, unknown>>,
+  chunkSize: number,
+  conflict: InsertConflictMode = 'fail',
+): Promise<void> {
+  if (rows.length === 0) return;
+  const db = getDb();
+  const verb = INSERT_VERB[conflict];
+  const colList = columns.join(', ');
+  for (let i = 0; i < rows.length; i += chunkSize) {
+    const chunk = rows.slice(i, i + chunkSize);
+    const placeholders = chunk.map((_, j) => `(${columns.map((c) => `$${c}_${j}`).join(', ')})`).join(', ');
+    const params: Record<string, unknown> = {};
+    chunk.forEach((row, j) => {
+      for (const col of columns) params[`${col}_${j}`] = row[col] ?? null;
+    });
+    await db.execute(`${verb} ${table} (${colList}) VALUES ${placeholders}`, params);
+  }
+}
+
 /** Shared gene/pet import logic used by both v1 and v2 paths. */
 async function importGenesAndPets(
   genes: Record<string, unknown>[] | null,
@@ -227,11 +263,6 @@ async function importGenesAndPets(
   let genesImported = 0;
   let petsImported = 0;
   let petsSkipped = 0;
-
-  const genePlaceholders = GENE_COLUMNS.map((col) => `$${col}`).join(', ');
-  const geneSQL = `INSERT OR REPLACE INTO genes (${GENE_COLUMNS.join(', ')}) VALUES (${genePlaceholders})`;
-  const petPlaceholders = PET_COLUMNS.map((col) => `$${col}`).join(', ');
-  const petSQL = `INSERT INTO pets (${PET_COLUMNS.join(', ')}) VALUES (${petPlaceholders})`;
 
   let existingHashes: Set<string> | null = null;
   let sortOrderOffset = 0;
@@ -251,16 +282,18 @@ async function importGenesAndPets(
       if (options.includePets) await db.execute('DELETE FROM pets');
     }
 
-    if (options.includeGenes && genes) {
-      for (const gene of genes) {
-        const params: Record<string, unknown> = {};
-        for (const col of GENE_COLUMNS) params[col] = gene[col] ?? null;
-        await db.execute(geneSQL, params);
-      }
+    if (options.includeGenes && genes && genes.length > 0) {
+      const geneRows = genes.map((g) => {
+        const row: Record<string, unknown> = {};
+        for (const col of GENE_COLUMNS) row[col] = g[col] ?? null;
+        return row;
+      });
+      await batchInsert('genes', GENE_COLUMNS, geneRows, GENE_INSERT_CHUNK, 'replace');
       genesImported = genes.length;
     }
 
     if (options.includePets && pets) {
+      const petRows: Record<string, unknown>[] = [];
       for (const pet of pets) {
         if (existingHashes?.has(pet.content_hash as string)) {
           petsSkipped++;
@@ -268,17 +301,18 @@ async function importGenesAndPets(
         }
         let genomeData = pet.genome_data;
         if (typeof genomeData === 'object' && genomeData !== null) genomeData = JSON.stringify(genomeData);
-        const params: Record<string, unknown> = {};
+        const row: Record<string, unknown> = {};
         for (const col of PET_COLUMNS) {
-          if (col === 'genome_data') params[col] = genomeData;
-          else if (col === 'sort_order') params[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
-          else if (col === 'stabled') params[col] = pet[col] ?? 1;
-          else if (col === 'starred' || col === 'is_pet_quality') params[col] = pet[col] ?? 0;
-          else params[col] = pet[col] ?? null;
+          if (col === 'genome_data') row[col] = genomeData;
+          else if (col === 'sort_order') row[col] = ((pet[col] as number) ?? 0) + sortOrderOffset;
+          else if (col === 'stabled') row[col] = pet[col] ?? 1;
+          else if (col === 'starred' || col === 'is_pet_quality') row[col] = pet[col] ?? 0;
+          else row[col] = pet[col] ?? null;
         }
-        await db.execute(petSQL, params);
-        petsImported++;
+        petRows.push(row);
       }
+      await batchInsert('pets', PET_COLUMNS, petRows, PET_INSERT_CHUNK);
+      petsImported = petRows.length;
     }
 
     await db.execute('COMMIT');
@@ -318,6 +352,7 @@ async function importFromZip(zip: JSZip, options: ImportOptions): Promise<Import
       await db.execute('DELETE FROM pet_tags');
     }
 
+    const tagInserts: Record<string, unknown>[] = [];
     const petTagsFile = zip.file('pet_tags.json');
     if (petTagsFile) {
       // New format: pet_tags.json with { content_hash, tag } rows
@@ -329,12 +364,7 @@ async function importFromZip(zip: JSZip, options: ImportOptions): Promise<Import
         const normalized = record.tag.trim().toLowerCase();
         if (!normalized) continue;
         const petId = hashToId.get(record.content_hash);
-        if (petId) {
-          await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
-            pet_id: petId,
-            tag: normalized,
-          });
-        }
+        if (petId) tagInserts.push({ pet_id: petId, tag: normalized });
       }
     } else if (pets) {
       // Backward compat: v6 backups with tags as JSON array on each pet
@@ -353,13 +383,14 @@ async function importFromZip(zip: JSZip, options: ImportOptions): Promise<Import
         }
         for (const tag of tags) {
           if (typeof tag === 'string' && tag.trim()) {
-            await db.execute('INSERT OR IGNORE INTO pet_tags (pet_id, tag) VALUES ($pet_id, $tag)', {
-              pet_id: petId,
-              tag: tag.trim().toLowerCase(),
-            });
+            tagInserts.push({ pet_id: petId, tag: tag.trim().toLowerCase() });
           }
         }
       }
+    }
+    if (tagInserts.length > 0) {
+      // 2 cols × 400 rows = 800 params, well under SQLITE_MAX_VARIABLE_NUMBER
+      await batchInsert('pet_tags', ['pet_id', 'tag'], tagInserts, 400, 'ignore');
     }
   }
 

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -351,5 +351,34 @@ describe('Backup Service', () => {
       expect(result.genes).toBe(0);
       expect(result.pets).toBe(0);
     });
+
+    it('imports more rows than the batch chunk size in a single round-trip', async () => {
+      // Genes are batched at 80/chunk and pets at 40/chunk. Cross both
+      // boundaries to confirm chunking stitches results together correctly.
+      const manyGenes = Array.from({ length: 150 }, (_, i) => ({
+        ...sampleGene,
+        gene: `01A${String(i).padStart(3, '0')}`,
+      }));
+      const manyPets = Array.from({ length: 95 }, (_, i) => ({
+        ...samplePet,
+        name: `Bee${i}`,
+        content_hash: `hash_${i}`,
+      }));
+      const zipData = await buildZip({ genes: manyGenes, pets: manyPets });
+      const result = await importDatabase(zipData, {
+        mode: 'replace',
+        includeGenes: true,
+        includePets: true,
+        includeImages: false,
+      });
+      expect(result.genes).toBe(150);
+      expect(result.pets).toBe(95);
+
+      const db = getDb();
+      const geneRows = await db.select('SELECT gene FROM genes');
+      const petRows = await db.select('SELECT name FROM pets');
+      expect(geneRows).toHaveLength(150);
+      expect(petRows).toHaveLength(95);
+    });
   });
 });

--- a/tests/unit/backupService.test.js
+++ b/tests/unit/backupService.test.js
@@ -352,9 +352,9 @@ describe('Backup Service', () => {
       expect(result.pets).toBe(0);
     });
 
-    it('imports more rows than the batch chunk size in a single round-trip', async () => {
-      // Genes are batched at 80/chunk and pets at 40/chunk. Cross both
-      // boundaries to confirm chunking stitches results together correctly.
+    it('imports more rows than the batch chunk size across chunk boundaries', async () => {
+      // Cross both gene (~90/chunk) and pet (~40/chunk) chunk boundaries to
+      // confirm chunking stitches results together correctly.
       const manyGenes = Array.from({ length: 150 }, (_, i) => ({
         ...sampleGene,
         gene: `01A${String(i).padStart(3, '0')}`,


### PR DESCRIPTION
## Summary

\`importGenesAndPets\` and the \`pet_tags\` loop previously issued one \`db.execute()\` per row inside the import transaction. A backup with 1k pets meant 1k IPC round-trips.

Adopt the same chunked multi-row INSERT pattern \`petService.writePetGenes\` already uses. Chunk sizes are picked to keep \`rows × cols\` under SQLite's default 999-parameter limit:

| Table | Chunk × cols | Conflict mode |
|---|---|---|
| \`genes\` | 80 × 10 = 800 params | \`INSERT OR REPLACE\` |
| \`pets\` | 40 × 22 = 880 params | \`INSERT\` |
| \`pet_tags\` | 400 × 2 = 800 params | \`INSERT OR IGNORE\` |

Factored a small \`batchInsert\` helper that takes an explicit conflict mode (\`'fail' | 'replace' | 'ignore'\`) so the call sites stay declarative.

Closes #160.

## Test plan
- [x] \`pnpm test\` — 310 unit tests pass (one new: imports 150 genes + 95 pets in a single round-trip, exceeding both chunk boundaries; verifies stitching works).
- [x] \`pnpm test:e2e tests/e2e/backup.spec.js\` — 8 backup-flow tests pass.
- [x] \`pnpm run lint:ci\`, \`pnpm run build\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)