### PR TITLE
perf(images): memoize getImageUrl + appDataDir resolution

### DIFF
--- a/src/lib/services/imageService.ts
+++ b/src/lib/services/imageService.ts
@@ -149,16 +149,8 @@ function invalidateImageUrlsForPet(petId: number): void {
   }
 }
 
-/**
- * Resolve a displayable URL for an image file.
- * Uses Tauri's asset protocol — no file reading or blob URLs needed.
- */
-async function getImageUrl(petId: number, filename: string): Promise<string> {
-  if (!isTauri()) return '';
-  const key = imageUrlCacheKey(petId, filename);
-  const cached = imageUrlCache.get(key);
-  if (cached !== undefined) return cached;
-
+/** Default resolver: hits Tauri APIs to compute the asset-protocol URL. */
+async function tauriImageUrlResolver(petId: number, filename: string): Promise<string> {
   if (!cachedAppDataDir) {
     cachedAppDataDir = import('@tauri-apps/api/path').then(({ appDataDir }) => appDataDir());
   }
@@ -168,7 +160,26 @@ async function getImageUrl(petId: number, filename: string): Promise<string> {
     cachedAppDataDir,
   ]);
   const fullPath = await join(baseDir, 'images', String(petId), filename);
-  const url = convertFileSrc(fullPath);
+  return convertFileSrc(fullPath);
+}
+
+// Indirect through an object so tests can swap in a stub resolver without
+// having to mock the dynamic imports above.
+export const _imageUrlInternals: {
+  resolver: (petId: number, filename: string) => Promise<string>;
+  cache: Map<string, string>;
+} = { resolver: tauriImageUrlResolver, cache: imageUrlCache };
+
+/**
+ * Resolve a displayable URL for an image file.
+ * Uses Tauri's asset protocol — no file reading or blob URLs needed.
+ */
+async function getImageUrl(petId: number, filename: string): Promise<string> {
+  if (!isTauri()) return '';
+  const key = imageUrlCacheKey(petId, filename);
+  const cached = imageUrlCache.get(key);
+  if (cached !== undefined) return cached;
+  const url = await _imageUrlInternals.resolver(petId, filename);
   imageUrlCache.set(key, url);
   return url;
 }

--- a/src/lib/services/imageService.ts
+++ b/src/lib/services/imageService.ts
@@ -123,17 +123,54 @@ export async function getImagesForPet(petId: number): Promise<PetImage[]> {
   return images;
 }
 
+// Asset-protocol URLs for `appDataDir/images/<petId>/<filename>` are stable
+// for the lifetime of the app session, but resolving each one costs two
+// Tauri IPC calls (appDataDir + join) plus a synchronous transform. Galleries
+// re-derive these on every render, so we memoise.
+//
+// Cache entries are keyed by `petId/filename`. The cache is cleared on
+// image deletion (deleteImage / deleteAllImagesForPet) so a re-uploaded
+// image with the same name doesn't serve a stale URL.
+const imageUrlCache = new Map<string, string>();
+let cachedAppDataDir: Promise<string> | null = null;
+
+function imageUrlCacheKey(petId: number, filename: string): string {
+  return `${petId}/${filename}`;
+}
+
+function invalidateImageUrl(petId: number, filename: string): void {
+  imageUrlCache.delete(imageUrlCacheKey(petId, filename));
+}
+
+function invalidateImageUrlsForPet(petId: number): void {
+  const prefix = `${petId}/`;
+  for (const key of imageUrlCache.keys()) {
+    if (key.startsWith(prefix)) imageUrlCache.delete(key);
+  }
+}
+
 /**
  * Resolve a displayable URL for an image file.
  * Uses Tauri's asset protocol — no file reading or blob URLs needed.
  */
 async function getImageUrl(petId: number, filename: string): Promise<string> {
   if (!isTauri()) return '';
-  const { appDataDir, join } = await import('@tauri-apps/api/path');
-  const { convertFileSrc } = await import('@tauri-apps/api/core');
-  const baseDir = await appDataDir();
+  const key = imageUrlCacheKey(petId, filename);
+  const cached = imageUrlCache.get(key);
+  if (cached !== undefined) return cached;
+
+  if (!cachedAppDataDir) {
+    cachedAppDataDir = import('@tauri-apps/api/path').then(({ appDataDir }) => appDataDir());
+  }
+  const [{ join }, { convertFileSrc }, baseDir] = await Promise.all([
+    import('@tauri-apps/api/path'),
+    import('@tauri-apps/api/core'),
+    cachedAppDataDir,
+  ]);
   const fullPath = await join(baseDir, 'images', String(petId), filename);
-  return convertFileSrc(fullPath);
+  const url = convertFileSrc(fullPath);
+  imageUrlCache.set(key, url);
+  return url;
 }
 
 /**
@@ -149,6 +186,7 @@ export async function deleteImage(imageId: number, petId: number, filename: stri
     }
   }
 
+  invalidateImageUrl(petId, filename);
   const db = getDb();
   await db.execute('DELETE FROM pet_images WHERE id = $id', { id: imageId });
 }
@@ -167,6 +205,7 @@ export async function deleteAllImagesForPet(petId: number): Promise<void> {
     }
   }
 
+  invalidateImageUrlsForPet(petId);
   const db = getDb();
   await db.execute('DELETE FROM pet_images WHERE pet_id = $pet_id', { pet_id: petId });
 }

--- a/tests/unit/imageService.test.js
+++ b/tests/unit/imageService.test.js
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// isTauri is read by both database init (we want false there, so it picks
+// the in-memory adapter) and imageService.getImageUrl (we want true so the
+// asset-protocol path runs and populates the cache). Make it stateful so
+// each test can flip it after DB init.
+let mockIsTauriValue = false;
+vi.mock('$lib/utils/environment.js', () => ({
+  isTauri: () => mockIsTauriValue,
+}));
+
+// Stub the fs plugin so deleteImage / deleteAllImagesForPet don't try to
+// touch the real filesystem when invalidating the cache.
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  remove: vi.fn(async () => {}),
+  BaseDirectory: { AppData: 0 },
+}));
+
+const { closeDatabase, getDb, initDatabase } = await import('$lib/services/database.js');
+const { runMigrations } = await import('$lib/services/migrationService.js');
+const imageService = await import('$lib/services/imageService.js');
+const { _imageUrlInternals } = imageService;
+
+// Replace the real Tauri-backed resolver with a deterministic spy. The cache
+// only calls the resolver on a miss, so the spy's call count tells us
+// directly whether a (petId, filename) pair was cached.
+const resolverSpy = vi.fn(async (petId, filename) => `asset://${petId}/${filename}`);
+const originalResolver = _imageUrlInternals.resolver;
+
+async function seedPet() {
+  const db = getDb();
+  const result = await db.execute(
+    `INSERT INTO pets (name, species, gender, breed, breeder, content_hash, genome_data, notes, created_at, updated_at,
+      intelligence, toughness, friendliness, ruggedness, enthusiasm, virility, ferocity, temperament, sort_order,
+      starred, stabled, is_pet_quality)
+     VALUES ($name, $species, $gender, '', '', $content_hash, '{}', '', '2026-01-01', '2026-01-01',
+      50, 50, 50, 50, 50, 50, 50, 50, 0,
+      0, 1, 0)`,
+    { name: 'Test', species: 'BeeWasp', gender: 'Female', content_hash: `hash_${Math.random()}` },
+  );
+  return result.lastInsertId;
+}
+
+async function seedImage(petId, filename) {
+  const db = getDb();
+  const result = await db.execute(
+    `INSERT INTO pet_images (pet_id, filename, original_name, caption, tags, created_at, sort_order)
+     VALUES ($pet_id, $filename, $filename, '', '[]', '2026-01-01', 0)`,
+    { pet_id: petId, filename },
+  );
+  return result.lastInsertId;
+}
+
+describe('imageService — getImageUrl cache', () => {
+  beforeEach(async () => {
+    resolverSpy.mockClear();
+    _imageUrlInternals.resolver = resolverSpy;
+    _imageUrlInternals.cache.clear();
+    mockIsTauriValue = false; // initDatabase needs this so it picks the in-memory adapter
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    mockIsTauriValue = true; // now flip so getImageUrl exercises the asset-protocol path
+  });
+
+  it('reuses the cached URL on repeat calls for the same image', async () => {
+    const petId = await seedPet();
+    await seedImage(petId, 'a.png');
+
+    const first = await imageService.getImagesForPet(petId);
+    const second = await imageService.getImagesForPet(petId);
+
+    expect(first[0].url).toBe(second[0].url);
+    expect(resolverSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteImage invalidates that image's cached URL", async () => {
+    const petId = await seedPet();
+    const imageId = await seedImage(petId, 'b.png');
+
+    await imageService.getImagesForPet(petId);
+    expect(resolverSpy).toHaveBeenCalledTimes(1);
+
+    await imageService.deleteImage(imageId, petId, 'b.png');
+    // Re-seed the same filename and confirm the URL is recomputed.
+    await seedImage(petId, 'b.png');
+    await imageService.getImagesForPet(petId);
+
+    expect(resolverSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('deleteAllImagesForPet drops every cache entry for that pet', async () => {
+    const petId = await seedPet();
+    await seedImage(petId, 'c.png');
+    await seedImage(petId, 'd.png');
+
+    await imageService.getImagesForPet(petId);
+    expect(resolverSpy).toHaveBeenCalledTimes(2);
+
+    await imageService.deleteAllImagesForPet(petId);
+    await seedImage(petId, 'c.png');
+    await seedImage(petId, 'd.png');
+    await imageService.getImagesForPet(petId);
+
+    expect(resolverSpy).toHaveBeenCalledTimes(4);
+  });
+
+  it('keeps separate cache entries per pet', async () => {
+    const petA = await seedPet();
+    const petB = await seedPet();
+    await seedImage(petA, 'shared.png');
+    await seedImage(petB, 'shared.png');
+
+    await imageService.getImagesForPet(petA);
+    await imageService.getImagesForPet(petB);
+
+    // Same filename, different petIds — two distinct cache entries.
+    expect(resolverSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Make sure other test files that import imageService get the real resolver back.
+_imageUrlInternals.resolver = originalResolver;


### PR DESCRIPTION
## Summary

\`getImagesForPet\` calls \`getImageUrl(petId, filename)\` for every image on every render. Each call did two Tauri IPC round-trips (\`appDataDir\` + \`join\`) plus a synchronous \`convertFileSrc\` — repeated work for stable inputs.

- Cache the asset-protocol URL in a \`Map\` keyed by \`petId/filename\`.
- Reuse the \`appDataDir()\` promise across calls.
- Clear the cache per-image in \`deleteImage\` and per-pet in \`deleteAllImagesForPet\` so a re-uploaded image with the same name can't serve a stale URL.

Closes #162.

## Test plan
- [x] \`pnpm test\` — 314 tests pass.
- [x] \`pnpm run lint:ci\`, \`pnpm run build\`.

## Notes
The cache is process-scoped — galleries that re-mount, scroll, or filter no longer pay the IPC cost for already-seen images. Asset-protocol URLs do not expire while the app session is alive, so no TTL is needed beyond the explicit invalidation on delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)