### PR TITLE
perf(ui): four small audit cleanups

### DIFF
--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -162,7 +162,9 @@ function createSpeciesTemplate(species, headerStructure, chromosomeCount) {
 }
 
 function getOrCreateSpeciesTemplate(species, headerStructure, chromosomeCount) {
-  const cacheKey = `${species}_${chromosomeCount}_${headerStructure.sortedBlocks.length}`;
+  // sortedBlocks.length is fully derived from species + chromosomeCount, so
+  // it adds nothing to cache identity. Drop it from the key.
+  const cacheKey = `${species}_${chromosomeCount}`;
 
   if (speciesTemplateCache.has(cacheKey)) {
     const cached = speciesTemplateCache.get(cacheKey);

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -63,7 +63,9 @@ async function handleSave() {
     }
     if (Object.keys(attributeChanges).length > 0) updateData.attributes = attributeChanges;
 
-    if (JSON.stringify(editTags) !== JSON.stringify(pet.tags ?? [])) {
+    const currentTags = pet.tags ?? [];
+    const tagsChanged = editTags.length !== currentTags.length || editTags.some((t, i) => t !== currentTags[i]);
+    if (tagsChanged) {
       updateData.tags = editTags;
     }
 

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -36,6 +36,10 @@ function startCompare() {
 }
 
 let searchQuery = $state('');
+// Mirror of searchQuery, updated after a small idle window so the
+// $derived.by below doesn't replay the whole filter on every keystroke.
+let debouncedSearchQuery = $state('');
+const SEARCH_DEBOUNCE_MS = 150;
 let selectedTags = $state([]);
 let starredOnly = $state(false);
 let stabledOnly = $state(true);
@@ -57,8 +61,16 @@ $effect(() => {
   }
 });
 
+$effect(() => {
+  const q = searchQuery;
+  const timer = setTimeout(() => {
+    debouncedSearchQuery = q;
+  }, SEARCH_DEBOUNCE_MS);
+  return () => clearTimeout(timer);
+});
+
 const filteredPets = $derived.by(() => {
-  const q = searchQuery ? searchQuery.toLowerCase() : '';
+  const q = debouncedSearchQuery ? debouncedSearchQuery.toLowerCase() : '';
   return $pets.filter((pet) => {
     if (q) {
       if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {

--- a/src/lib/components/stable/StableTable.svelte
+++ b/src/lib/components/stable/StableTable.svelte
@@ -21,7 +21,9 @@ const BREEDS_BY_SPECIES = {
 let editingPet = $state(null);
 let editorOpen = $state(false);
 
-const comparisonIds = $derived(new Set([$comparisonPets[0]?.id, $comparisonPets[1]?.id].filter((id) => id != null)));
+function isInComparison(id) {
+  return $comparisonPets[0]?.id === id || $comparisonPets[1]?.id === id;
+}
 
 function viewPet(pet) {
   appState.selectPet(pet);
@@ -39,7 +41,7 @@ function closeEditor() {
 }
 
 function toggleCompare(pet) {
-  if (comparisonIds.has(pet.id)) comparisonActions.removePet(pet.id);
+  if (isInComparison(pet.id)) comparisonActions.removePet(pet.id);
   else comparisonActions.addPet(pet);
 }
 
@@ -320,10 +322,10 @@ function sortIndicator(colId) {
                                             >✎</button>
                                             <button
                                                 class="row-action-btn"
-                                                class:active={comparisonIds.has(pet.id)}
-                                                title={comparisonIds.has(pet.id) ? 'Remove from comparison' : 'Add to comparison'}
+                                                class:active={isInComparison(pet.id)}
+                                                title={isInComparison(pet.id) ? 'Remove from comparison' : 'Add to comparison'}
                                                 aria-label="Toggle comparison selection for {pet.name}"
-                                                aria-pressed={comparisonIds.has(pet.id)}
+                                                aria-pressed={isInComparison(pet.id)}
                                                 data-action="compare"
                                                 onclick={() => toggleCompare(pet)}
                                             >⚖️</button>


### PR DESCRIPTION
## Summary

Bundles the four audit lows from the perf scan into one PR.

| Issue | File | What changed |
|---|---|---|
| #164 | \`StableTable.svelte\` | Drop the per-render \`new Set([...])\` in \`comparisonIds\`. Use a tiny \`isInComparison(id)\` helper that just checks the two slots directly — same shape as \`PetList\` already uses. |
| #165 | \`PetList.svelte\` | Debounce \`searchQuery\` into \`debouncedSearchQuery\` (150 ms idle) before feeding it to \`filteredPets\`, so typing doesn't replay the predicate over the whole pet list on every keystroke. The visible input value remains immediate. |
| #166 | \`PetEditor.svelte\` | Replace the \`JSON.stringify\`-based tag diff in \`handleSave\` with length + per-element comparison. Order-sensitive in the same way the original was; no string allocations. |
| #167 | \`GeneVisualizer.svelte\` | Drop \`sortedBlocks.length\` from the species-template cache key — it's fully derived from \`species + chromosomeCount\`, so it adds nothing to cache identity. |

Closes #164, #165, #166, #167.

## Test plan
- [x] \`pnpm test\` — 318 tests pass.
- [x] \`pnpm test:e2e\` — 117 tests pass.
- [x] \`pnpm run lint:ci\`, \`pnpm run build\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)