### PR TITLE
build(theme): generate gene-color CSS vars from JSON at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "vite dev",
-    "build": "vite build",
+    "gen:gene-colors-css": "node scripts/gen-gene-colors-css.mjs",
+    "dev": "pnpm gen:gene-colors-css && vite dev",
+    "build": "pnpm gen:gene-colors-css && vite build",
     "preview": "vite preview",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",

--- a/scripts/gen-gene-colors-css.mjs
+++ b/scripts/gen-gene-colors-css.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Build-time generator that turns `src/lib/theme/gene-colors-data.json`
+ * into `src/lib/theme/gene-colors.generated.css`. Runs as a `predev` /
+ * `prebuild` hook so the CSS file is always in sync with the JSON.
+ *
+ * The generated file is committed (so cold checkouts can build without
+ * running this first) but is treated as derived — edit `gene-colors-data.json`
+ * to change a colour, never the .generated.css.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const inputPath = resolve(repoRoot, 'src/lib/theme/gene-colors-data.json');
+const outputPath = resolve(repoRoot, 'src/lib/theme/gene-colors.generated.css');
+
+const data = JSON.parse(readFileSync(inputPath, 'utf-8'));
+
+function emitSection(title, vars) {
+  const lines = [`  /* ${title} */`];
+  for (const [k, v] of Object.entries(vars)) {
+    lines.push(`  --gene-${k}: ${v};`);
+  }
+  return lines.join('\n');
+}
+
+const css = `/*
+ * AUTO-GENERATED — do not edit.
+ * Source: src/lib/theme/gene-colors-data.json
+ * Regenerate: pnpm gen:gene-colors-css (also runs as predev / prebuild)
+ */
+:root {
+${emitSection('Effect colors', data.effects)}
+
+${emitSection('BeeWasp appearance colors', data.beewaspAppearance)}
+
+${emitSection('Horse appearance colors', data.horseAppearance)}
+}
+`;
+
+const previous = (() => {
+  try {
+    return readFileSync(outputPath, 'utf-8');
+  } catch {
+    return null;
+  }
+})();
+
+if (previous !== css) {
+  writeFileSync(outputPath, css);
+  console.log(`gen-gene-colors-css: wrote ${outputPath}`);
+} else {
+  console.log('gen-gene-colors-css: up-to-date');
+}

--- a/scripts/gen-gene-colors-css.mjs
+++ b/scripts/gen-gene-colors-css.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 /**
  * Build-time generator that turns `src/lib/theme/gene-colors-data.json`
- * into `src/lib/theme/gene-colors.generated.css`. Runs as a `predev` /
- * `prebuild` hook so the CSS file is always in sync with the JSON.
+ * into `src/lib/theme/gene-colors.generated.css`. Wired as the first step
+ * of `pnpm dev` and `pnpm build` (chained with `&&`) so the CSS file is
+ * always in sync with the JSON. Also exposed as `pnpm gen:gene-colors-css`
+ * for manual runs.
  *
  * The generated file is committed (so cold checkouts can build without
  * running this first) but is treated as derived — edit `gene-colors-data.json`
@@ -30,7 +32,7 @@ function emitSection(title, vars) {
 const css = `/*
  * AUTO-GENERATED — do not edit.
  * Source: src/lib/theme/gene-colors-data.json
- * Regenerate: pnpm gen:gene-colors-css (also runs as predev / prebuild)
+ * Regenerate: pnpm gen:gene-colors-css (also runs from pnpm dev / pnpm build)
  */
 :root {
 ${emitSection('Effect colors', data.effects)}

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,8 @@
+/* Gene-effect / appearance colors. Generated from gene-colors-data.json by
+   scripts/gen-gene-colors-css.mjs (runs as part of `pnpm dev` / `pnpm build`).
+   To change a colour, edit the JSON — do not redeclare these variables here. */
+@import "./lib/theme/gene-colors.generated.css";
+
 /* Minimal CSS reset */
 *,
 *::before,
@@ -149,54 +154,11 @@ textarea {
   --toggle-on: #3b82f6;
   --toggle-thumb: #ffffff;
 
-  /* Gene neutral colors lightened for dark backgrounds.
-     These override the :root values — keep aligned with gene-colors.ts
-     if that module ever reads CSS vars instead of hardcoded values. */
+  /* Gene neutral colors lightened for dark backgrounds. These override the
+     base values from gene-colors.generated.css; not generated themselves
+     because they're a theme-specific tweak, not part of the canonical palette. */
   --gene-neutral: #b0b8c4;
   --gene-appearance-neutral: #b0b8c4;
-}
-
-/* Gene colors — canonical source: src/lib/theme/gene-colors.ts */
-/* These must stay in sync. The TS module is the source of truth. */
-:root {
-  /* Effect colors */
-  --gene-positive: #4caf50;
-  --gene-negative: #f44336;
-  --gene-neutral: #95a5a6;
-  --gene-potential-positive: #3498db;
-  --gene-potential-negative: #9b59b6;
-
-  /* BeeWasp appearance colors */
-  --gene-body-hue: #ff9800;
-  --gene-body-saturation: #ff6f00;
-  --gene-body-intensity: #ffcc02;
-  --gene-wing-hue: #2196f3;
-  --gene-wing-saturation: #1976d2;
-  --gene-wing-intensity: #0d47a1;
-  --gene-body-scale: #9c27b0;
-  --gene-wing-scale: #7b1fa2;
-  --gene-head-scale: #8e24aa;
-  --gene-tail-scale: #ab47bc;
-  --gene-antenna-scale: #ba68c8;
-  --gene-leg-deformity: #e91e63;
-  --gene-antenna-deformity: #c2185b;
-  --gene-particles: #00bcd4;
-  --gene-particle-location: #0097a7;
-  --gene-glow: #8bc34a;
-  --gene-appearance-neutral: #95a5a6;
-
-  /* Horse appearance colors */
-  --gene-scale: #2980b9;
-  --gene-attributes: #e74c3c;
-  --gene-selector: #8e44ad;
-  --gene-horn: #1abc9c;
-  --gene-aura: #3498db;
-  --gene-coat: #2ecc71;
-  --gene-face-markings: #f39c12;
-  --gene-hair: #9b59b6;
-  --gene-leg-markings: #34495e;
-  --gene-magical: #e67e22;
-  --gene-markings: #16a085;
 }
 
 /* --- Shared button styles --- */

--- a/src/lib/theme/gene-colors-data.json
+++ b/src/lib/theme/gene-colors-data.json
@@ -1,0 +1,49 @@
+{
+  "effects": {
+    "positive": "#4caf50",
+    "negative": "#f44336",
+    "neutral": "#95a5a6",
+    "potential-positive": "#3498db",
+    "potential-negative": "#9b59b6"
+  },
+  "beewaspAppearance": {
+    "body-hue": "#ff9800",
+    "body-saturation": "#ff6f00",
+    "body-intensity": "#ffcc02",
+    "wing-hue": "#2196f3",
+    "wing-saturation": "#1976d2",
+    "wing-intensity": "#0d47a1",
+    "body-scale": "#9c27b0",
+    "wing-scale": "#7b1fa2",
+    "head-scale": "#8e24aa",
+    "tail-scale": "#ab47bc",
+    "antenna-scale": "#ba68c8",
+    "leg-deformity": "#e91e63",
+    "antenna-deformity": "#c2185b",
+    "particles": "#00bcd4",
+    "particle-location": "#0097a7",
+    "glow": "#8bc34a",
+    "appearance-neutral": "#95a5a6"
+  },
+  "horseAppearance": {
+    "scale": "#2980b9",
+    "attributes": "#e74c3c",
+    "selector": "#8e44ad",
+    "horn": "#1abc9c",
+    "aura": "#3498db",
+    "coat": "#2ecc71",
+    "face-markings": "#f39c12",
+    "hair": "#9b59b6",
+    "leg-markings": "#34495e",
+    "magical": "#e67e22",
+    "markings": "#16a085"
+  },
+  "beewaspCategoryAlias": {
+    "body-color-hue": "body-hue",
+    "body-color-saturation": "body-saturation",
+    "body-color-intensity": "body-intensity",
+    "wing-color-hue": "wing-hue",
+    "wing-color-saturation": "wing-saturation",
+    "wing-color-intensity": "wing-intensity"
+  }
+}

--- a/src/lib/theme/gene-colors.generated.css
+++ b/src/lib/theme/gene-colors.generated.css
@@ -1,7 +1,7 @@
 /*
  * AUTO-GENERATED — do not edit.
  * Source: src/lib/theme/gene-colors-data.json
- * Regenerate: pnpm gen:gene-colors-css (also runs as predev / prebuild)
+ * Regenerate: pnpm gen:gene-colors-css (also runs from pnpm dev / pnpm build)
  */
 :root {
   /* Effect colors */

--- a/src/lib/theme/gene-colors.generated.css
+++ b/src/lib/theme/gene-colors.generated.css
@@ -1,0 +1,45 @@
+/*
+ * AUTO-GENERATED — do not edit.
+ * Source: src/lib/theme/gene-colors-data.json
+ * Regenerate: pnpm gen:gene-colors-css (also runs as predev / prebuild)
+ */
+:root {
+  /* Effect colors */
+  --gene-positive: #4caf50;
+  --gene-negative: #f44336;
+  --gene-neutral: #95a5a6;
+  --gene-potential-positive: #3498db;
+  --gene-potential-negative: #9b59b6;
+
+  /* BeeWasp appearance colors */
+  --gene-body-hue: #ff9800;
+  --gene-body-saturation: #ff6f00;
+  --gene-body-intensity: #ffcc02;
+  --gene-wing-hue: #2196f3;
+  --gene-wing-saturation: #1976d2;
+  --gene-wing-intensity: #0d47a1;
+  --gene-body-scale: #9c27b0;
+  --gene-wing-scale: #7b1fa2;
+  --gene-head-scale: #8e24aa;
+  --gene-tail-scale: #ab47bc;
+  --gene-antenna-scale: #ba68c8;
+  --gene-leg-deformity: #e91e63;
+  --gene-antenna-deformity: #c2185b;
+  --gene-particles: #00bcd4;
+  --gene-particle-location: #0097a7;
+  --gene-glow: #8bc34a;
+  --gene-appearance-neutral: #95a5a6;
+
+  /* Horse appearance colors */
+  --gene-scale: #2980b9;
+  --gene-attributes: #e74c3c;
+  --gene-selector: #8e44ad;
+  --gene-horn: #1abc9c;
+  --gene-aura: #3498db;
+  --gene-coat: #2ecc71;
+  --gene-face-markings: #f39c12;
+  --gene-hair: #9b59b6;
+  --gene-leg-markings: #34495e;
+  --gene-magical: #e67e22;
+  --gene-markings: #16a085;
+}

--- a/src/lib/theme/gene-colors.ts
+++ b/src/lib/theme/gene-colors.ts
@@ -1,70 +1,19 @@
 /**
- * Canonical TypeScript definitions for gene colors, mirrored in src/app.css.
- * Used by the stats table (via configService) and tooltip logic (via EFFECT_COLORS).
- * The gene grid reads CSS custom properties defined in :root in src/app.css.
- *
- * To change a color: update it here AND in src/app.css to keep both in sync.
+ * Canonical TypeScript exports for gene colors. The actual values live in
+ * `gene-colors-data.json` (single source of truth) and are mirrored into
+ * CSS custom properties at build time by `scripts/gen-gene-colors-css.mjs`,
+ * which writes `gene-colors.generated.css`. The runtime app reads the same
+ * JSON via these named exports — there is no second hand-maintained list
+ * of colors anywhere.
  */
 
-export const EFFECT_COLORS = {
-  positive: '#4caf50',
-  negative: '#f44336',
-  neutral: '#95a5a6',
-  'potential-positive': '#3498db',
-  'potential-negative': '#9b59b6',
-} as const;
+import data from './gene-colors-data.json';
 
-/**
- * BeeWasp appearance colors.
- * Keys use the short CSS var names (--gene-{key}).
- * The configService maps these to the full appearance category names.
- */
-export const BEEWASP_APPEARANCE_COLORS: Record<string, string> = {
-  'body-hue': '#ff9800',
-  'body-saturation': '#ff6f00',
-  'body-intensity': '#ffcc02',
-  'wing-hue': '#2196f3',
-  'wing-saturation': '#1976d2',
-  'wing-intensity': '#0d47a1',
-  'body-scale': '#9c27b0',
-  'wing-scale': '#7b1fa2',
-  'head-scale': '#8e24aa',
-  'tail-scale': '#ab47bc',
-  'antenna-scale': '#ba68c8',
-  'leg-deformity': '#e91e63',
-  'antenna-deformity': '#c2185b',
-  particles: '#00bcd4',
-  'particle-location': '#0097a7',
-  glow: '#8bc34a',
-  'appearance-neutral': '#95a5a6',
-};
+export const EFFECT_COLORS = data.effects as Record<string, string>;
+export const BEEWASP_APPEARANCE_COLORS: Record<string, string> = data.beewaspAppearance;
+export const HORSE_APPEARANCE_COLORS: Record<string, string> = data.horseAppearance;
 
-export const HORSE_APPEARANCE_COLORS: Record<string, string> = {
-  scale: '#2980b9',
-  attributes: '#e74c3c',
-  selector: '#8e44ad',
-  horn: '#1abc9c',
-  aura: '#3498db',
-  coat: '#2ecc71',
-  'face-markings': '#f39c12',
-  hair: '#9b59b6',
-  'leg-markings': '#34495e',
-  magical: '#e67e22',
-  markings: '#16a085',
-};
-
-/**
- * Mapping from appearance config category names to CSS var keys.
- * Only needed where the names differ (BeeWasp color categories).
- */
-const BEEWASP_CATEGORY_TO_CSS: Record<string, string> = {
-  'body-color-hue': 'body-hue',
-  'body-color-saturation': 'body-saturation',
-  'body-color-intensity': 'body-intensity',
-  'wing-color-hue': 'wing-hue',
-  'wing-color-saturation': 'wing-saturation',
-  'wing-color-intensity': 'wing-intensity',
-};
+const BEEWASP_CATEGORY_TO_CSS: Record<string, string> = data.beewaspCategoryAlias;
 
 /** Look up the color for a BeeWasp appearance category. */
 export function getBeewaspAppearanceColor(category: string): string {

--- a/src/lib/theme/gene-colors.ts
+++ b/src/lib/theme/gene-colors.ts
@@ -9,7 +9,12 @@
 
 import data from './gene-colors-data.json';
 
-export const EFFECT_COLORS = data.effects as Record<string, string>;
+// Keep the narrow key union TypeScript infers from the JSON for EFFECT_COLORS
+// — consumers access it by literal key (e.g. EFFECT_COLORS.positive), so
+// widening to Record<string, string> would lose compile-time validation.
+export const EFFECT_COLORS = data.effects;
+// Appearance maps are accessed via dynamic string keys inside the lookup
+// helpers below, so they're typed as the wider Record shape on purpose.
 export const BEEWASP_APPEARANCE_COLORS: Record<string, string> = data.beewaspAppearance;
 export const HORSE_APPEARANCE_COLORS: Record<string, string> = data.horseAppearance;
 


### PR DESCRIPTION
## Summary

The same colour values were hand-maintained in **two** places:

- \`src/lib/theme/gene-colors.ts\` — TS exports, used by the gene visualizer (\`EFFECT_COLORS\`) and \`configService\` (appearance-badge \`color_indicator\`).
- \`src/app.css\` — \`:root { --gene-*: …; }\` block, used by the gene grid for direct CSS class styling.

The CSS file's own comment said *"These must stay in sync. The TS module is the source of truth."* — exactly the build-time win the audit flagged.

## What changed

Single source of truth → \`src/lib/theme/gene-colors-data.json\`.

| File | Role |
|---|---|
| \`gene-colors-data.json\` | Canonical colour values + BeeWasp category aliases. |
| \`gene-colors.ts\` | Imports the JSON, re-exports the same typed shapes the runtime already uses. **No public-API change.** |
| \`scripts/gen-gene-colors-css.mjs\` | Reads the JSON, writes \`gene-colors.generated.css\`. Idempotent (skips writes when content matches). |
| \`gene-colors.generated.css\` | Committed (so cold checkouts build), clearly marked AUTO-GENERATED. |
| \`app.css\` | \`@import\`s the generated file. Dark-theme override of \`--gene-neutral\` / \`--gene-appearance-neutral\` stays — it's a theme tweak, not part of the canonical palette. |
| \`package.json\` | \`pnpm dev\` and \`pnpm build\` now run the gen script first. \`pnpm gen:gene-colors-css\` is also exposed. |

Closes #168 and the audit's *"Build-time wins"* section.

## Test plan
- [x] \`pnpm test\` — 318 unit tests pass.
- [x] \`pnpm test:e2e\` — 117 tests pass.
- [x] \`pnpm run build\` — generates the CSS, builds clean.
- [x] \`pnpm run lint:ci\`.
- [x] To change a colour: edit \`gene-colors-data.json\`, run \`pnpm gen:gene-colors-css\` (or any \`pnpm dev\` / \`pnpm build\`); both the TS module and the CSS file pick up the new value automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)