### PR TITLE
feat(import): auto-scan game folder for new pet gene reports

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,7 +15,8 @@
       "identifier": "fs:allow-read-text-file",
       "allow": [
         { "path": "$APPDATA/**/*" },
-        { "path": "$RESOURCE/**/*" }
+        { "path": "$RESOURCE/**/*" },
+        { "path": "$HOME/**" }
       ]
     },
     {
@@ -28,14 +29,16 @@
       "identifier": "fs:allow-exists",
       "allow": [
         { "path": "$APPDATA/**/*" },
-        { "path": "$RESOURCE/**/*" }
+        { "path": "$RESOURCE/**/*" },
+        { "path": "$HOME/**" }
       ]
     },
     {
       "identifier": "fs:allow-read-dir",
       "allow": [
         { "path": "$APPDATA/**/*" },
-        { "path": "$RESOURCE/**/*" }
+        { "path": "$RESOURCE/**/*" },
+        { "path": "$HOME/**" }
       ]
     },
     "core:path:default",
@@ -45,7 +48,9 @@
       "identifier": "fs:scope",
       "allow": [
         { "path": "$APPDATA" },
-        { "path": "$APPDATA/**/*" }
+        { "path": "$APPDATA/**/*" },
+        { "path": "$HOME" },
+        { "path": "$HOME/**" }
       ]
     },
     {

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -41,6 +41,18 @@
         { "path": "$HOME/**" }
       ]
     },
+    {
+      "identifier": "fs:allow-watch",
+      "allow": [
+        { "path": "$HOME/**" }
+      ]
+    },
+    {
+      "identifier": "fs:allow-unwatch",
+      "allow": [
+        { "path": "$HOME/**" }
+      ]
+    },
     "core:path:default",
     "updater:default",
     "process:allow-restart",

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -17,31 +17,43 @@ import { settings, settingsActions } from '$lib/stores/settings.js';
 const { children } = $props();
 let ready = $state(false);
 let liveScanRunning = false;
+let pendingRescan = false;
 
 async function runLiveScan() {
-  if (liveScanRunning) return;
+  // Drop into a queued state instead of starting a parallel scan —
+  // a file written during a long scan would otherwise be missed
+  // until the next unrelated event.
+  if (liveScanRunning) {
+    pendingRescan = true;
+    return;
+  }
   liveScanRunning = true;
   try {
-    const result = await autoScanGameFolder();
-    if (result.imported > 0) {
-      void appState.loadPets();
-    }
+    do {
+      pendingRescan = false;
+      const result = await autoScanGameFolder();
+      if (result.imported > 0) {
+        void appState.loadPets();
+      }
+    } while (pendingRescan);
   } catch (err) {
     console.warn('live game-folder scan failed:', err);
   } finally {
     liveScanRunning = false;
+    pendingRescan = false;
   }
 }
 
-// Re-arm the folder watcher whenever the configured path changes.
-// Reading $settings makes this effect track the store; we gate on
-// `ready` so the watcher only starts after settings have been loaded
-// from disk (otherwise the first read sees defaults and would arm
-// twice in quick succession).
+// Track only the configured path. Reading $settings directly inside
+// the effect would re-fire on any settings write (theme, font scale,
+// etc.) because the store spreads a new object on every update;
+// $derived memoizes on the computed value so unrelated keys don't
+// thrash the watcher.
+const gameFolderPath = $derived($settings['import.gameFolderPath'] ?? '');
+
 $effect(() => {
   if (!ready) return;
-  // Touch the store so the effect re-fires on path changes.
-  void $settings['import.gameFolderPath'];
+  void gameFolderPath;
 
   let cancelled = false;
   let activeStop = null;

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -6,6 +6,7 @@ import { backfillParsedGeneEffectsIfNeeded } from '$lib/services/geneService.js'
 import { runMigrations } from '$lib/services/migrationService.js';
 import {
   backfillGeneCountsIfNeeded,
+  backfillImportedFilesIfNeeded,
   backfillPetGenesIfNeeded,
   backfillPositiveGenesIfNeeded,
 } from '$lib/services/petService.js';
@@ -54,6 +55,12 @@ onMount(async () => {
       void appState.loadPets();
     } catch (err) {
       console.warn('gene_counts backfill aborted:', err);
+    }
+
+    try {
+      await backfillImportedFilesIfNeeded();
+    } catch (err) {
+      console.warn('imported_files backfill aborted:', err);
     }
   })();
 });

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -2,6 +2,7 @@
 import { onMount } from 'svelte';
 import { initDatabase } from '$lib/services/database.js';
 import { loadDemoPetsIfNeeded, populateGenesIfNeeded } from '$lib/services/demoService.js';
+import { autoScanGameFolder, watchGameFolder } from '$lib/services/gameImport.js';
 import { backfillParsedGeneEffectsIfNeeded } from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import {
@@ -11,10 +12,61 @@ import {
   backfillPositiveGenesIfNeeded,
 } from '$lib/services/petService.js';
 import { appState } from '$lib/stores/pets.js';
-import { settingsActions } from '$lib/stores/settings.js';
+import { settings, settingsActions } from '$lib/stores/settings.js';
 
 const { children } = $props();
 let ready = $state(false);
+let liveScanRunning = false;
+
+async function runLiveScan() {
+  if (liveScanRunning) return;
+  liveScanRunning = true;
+  try {
+    const result = await autoScanGameFolder();
+    if (result.imported > 0) {
+      void appState.loadPets();
+    }
+  } catch (err) {
+    console.warn('live game-folder scan failed:', err);
+  } finally {
+    liveScanRunning = false;
+  }
+}
+
+// Re-arm the folder watcher whenever the configured path changes.
+// Reading $settings makes this effect track the store; we gate on
+// `ready` so the watcher only starts after settings have been loaded
+// from disk (otherwise the first read sees defaults and would arm
+// twice in quick succession).
+$effect(() => {
+  if (!ready) return;
+  // Touch the store so the effect re-fires on path changes.
+  void $settings['import.gameFolderPath'];
+
+  let cancelled = false;
+  let activeStop = null;
+
+  void (async () => {
+    try {
+      const stop = await watchGameFolder(runLiveScan);
+      if (cancelled) {
+        if (stop) await stop();
+        return;
+      }
+      activeStop = stop;
+    } catch (err) {
+      console.warn('failed to start game-folder watcher:', err);
+    }
+  })();
+
+  return () => {
+    cancelled = true;
+    if (activeStop) {
+      void activeStop();
+      activeStop = null;
+    }
+  };
+});
 
 onMount(async () => {
   await initDatabase();

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -1,6 +1,7 @@
 <script>
 /* global __APP_VERSION__ */
 
+import { detectPlatform, getDefaultGameFolder, isPlaceholderPath } from '$lib/services/gameImport.js';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
@@ -27,6 +28,14 @@ function toErrorMessage(err) {
 const modKey = /mac/i.test(navigator?.userAgent ?? '') ? '⌘' : 'Ctrl';
 const currentScale = $derived(_getFontScale($settings));
 const currentTheme = $derived(getThemePreference($settings));
+const platformLabel = detectPlatform();
+const gameFolderPlaceholder = getDefaultGameFolder(platformLabel);
+const gameFolderValue = $derived($settings['import.gameFolderPath'] ?? '');
+const gameFolderIsDefault = $derived(isPlaceholderPath(String(gameFolderValue || '')));
+
+function setGameFolderPath(value) {
+  settingsActions.update('import.gameFolderPath', value);
+}
 
 function setFontScale(scale) {
   settingsActions.update('display.fontScale', clampScale(scale));
@@ -197,6 +206,38 @@ async function installUpdate() {
                 aria-label="System theme"
               >💻 System</button>
             </div>
+          </div>
+        </div>
+
+        <div class="settings-section">
+          <h4>Auto-import</h4>
+
+          <div class="setting-row" style="cursor: default;">
+            <div class="setting-info">
+              <span class="setting-name">Game folder</span>
+              <span class="setting-desc">Folder where Project Gorgon writes pet gene reports. The auto-import button on the pet list scans this folder and imports any new files.</span>
+            </div>
+          </div>
+
+          <div class="setting-row" style="cursor: default;">
+            <input
+              class="folder-input"
+              type="text"
+              placeholder={gameFolderPlaceholder}
+              value={gameFolderIsDefault ? '' : gameFolderValue}
+              oninput={(e) => setGameFolderPath(e.currentTarget.value)}
+              aria-label="Game folder path"
+            />
+          </div>
+
+          <div class="setting-row" style="cursor: default;">
+            <span class="update-message muted">
+              {#if gameFolderIsDefault}
+                Detected platform: {platformLabel}. The path is not configured — the placeholder above is a TODO. Paste the real folder once known.
+              {:else}
+                Detected platform: {platformLabel}.
+              {/if}
+            </span>
           </div>
         </div>
 
@@ -519,6 +560,22 @@ async function installUpdate() {
     border-radius: 8px;
     padding: 12px;
     margin: -4px 0;
+  }
+
+  .folder-input {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border-secondary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-family: var(--font-mono, monospace);
+    outline: none;
+  }
+
+  .folder-input:focus {
+    border-color: var(--accent);
   }
 
   .progress-bar {

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -215,7 +215,7 @@ async function installUpdate() {
           <div class="setting-row" style="cursor: default;">
             <div class="setting-info">
               <span class="setting-name">Game folder</span>
-              <span class="setting-desc">Folder where Project Gorgon writes pet gene reports. The auto-import button on the pet list scans this folder and imports any new files.</span>
+              <span class="setting-desc">Folder where Project Gorgon writes pet gene reports. New files appear automatically as the game writes them; the 🔄 button on the pet list runs a manual scan on demand.</span>
             </div>
           </div>
 

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -1,7 +1,7 @@
 <script>
 /* global __APP_VERSION__ */
 
-import { detectPlatform, getDefaultGameFolder, isPlaceholderPath } from '$lib/services/gameImport.js';
+import { detectPlatform, getDefaultGameFolder } from '$lib/services/gameImport.js';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
@@ -31,7 +31,6 @@ const currentTheme = $derived(getThemePreference($settings));
 const platformLabel = detectPlatform();
 const gameFolderPlaceholder = getDefaultGameFolder(platformLabel);
 const gameFolderValue = $derived($settings['import.gameFolderPath'] ?? '');
-const gameFolderIsDefault = $derived(isPlaceholderPath(String(gameFolderValue || '')));
 
 function setGameFolderPath(value) {
   settingsActions.update('import.gameFolderPath', value);
@@ -224,7 +223,7 @@ async function installUpdate() {
               class="folder-input"
               type="text"
               placeholder={gameFolderPlaceholder}
-              value={gameFolderIsDefault ? '' : gameFolderValue}
+              value={gameFolderValue}
               oninput={(e) => setGameFolderPath(e.currentTarget.value)}
               aria-label="Game folder path"
             />
@@ -232,11 +231,7 @@ async function installUpdate() {
 
           <div class="setting-row" style="cursor: default;">
             <span class="update-message muted">
-              {#if gameFolderIsDefault}
-                Detected platform: {platformLabel}. The path is not configured — the placeholder above is a TODO. Paste the real folder once known.
-              {:else}
-                Detected platform: {platformLabel}.
-              {/if}
+              Detected platform: {platformLabel}. Leave blank to use the default shown above.
             </span>
           </div>
         </div>

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -415,6 +415,7 @@ async function handleDrop(e, dropIndex) {
                 onclick={handleAutoScan}
                 disabled={uploading || autoScanning}
                 title="Auto-import new genome files from the game folder"
+                aria-label="Auto-import new genome files from the game folder"
             >
                 {#if autoScanProgress}
                     🔄 ({autoScanProgress.current}/{autoScanProgress.total})

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -1,6 +1,7 @@
 <script>
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
+import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
 import { createDragState } from '$lib/utils/dragReorder.svelte.js';
@@ -45,6 +46,8 @@ let starredOnly = $state(false);
 let stabledOnly = $state(true);
 let uploading = $state(false);
 let uploadProgress = $state(null);
+let autoScanning = $state(false);
+let autoScanProgress = $state(null);
 let showEditor = $state(false);
 let editingPet = $state(null);
 let deletingPet = $state(null);
@@ -134,13 +137,55 @@ async function handleUpload() {
 
     if (failures.length > 0) {
       const succeeded = total - failures.length;
-      error.set(`${succeeded}/${total} uploaded. ${failures.length} failed: ${failures.join('; ')}`);
+      error.set(`${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`);
     }
   } catch (err) {
     error.set(`Upload failed: ${err.message}`);
   } finally {
     uploading = false;
     uploadProgress = null;
+  }
+}
+
+async function handleAutoScan() {
+  try {
+    autoScanning = true;
+    error.set(null);
+    const result = await autoScanGameFolder({
+      onProgress: (current, total) => {
+        autoScanProgress = { current, total };
+      },
+    });
+
+    if (result.status === 'not_configured') {
+      error.set('Auto-import folder is not configured. Set the path in Settings → Auto-import.');
+      return;
+    }
+    if (result.status === 'folder_missing') {
+      error.set(result.message ?? 'Configured game folder was not found.');
+      return;
+    }
+    if (result.status === 'error') {
+      error.set(result.message ?? 'Auto-import failed.');
+      return;
+    }
+
+    if (result.imported > 0) {
+      await appState.loadPets();
+    }
+
+    const summary = `Auto-import: ${result.imported} new, ${result.skipped} already imported (of ${result.scanned} files).`;
+    if (result.failures.length > 0) {
+      const lines = result.failures.map((f) => `${f.file}: ${f.reason}`);
+      error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);
+    } else if (result.imported > 0) {
+      error.set(summary);
+    }
+  } catch (err) {
+    error.set(`Auto-import failed: ${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    autoScanning = false;
+    autoScanProgress = null;
   }
 }
 
@@ -357,12 +402,24 @@ async function handleDrop(e, dropIndex) {
             <button
                 class="upload-btn"
                 onclick={handleUpload}
-                disabled={uploading}
+                disabled={uploading || autoScanning}
             >
                 {#if uploadProgress}
                     Uploading... ({uploadProgress.current}/{uploadProgress.total})
                 {:else}
                     + Upload Genome
+                {/if}
+            </button>
+            <button
+                class="auto-scan-btn"
+                onclick={handleAutoScan}
+                disabled={uploading || autoScanning}
+                title="Auto-import new genome files from the game folder"
+            >
+                {#if autoScanProgress}
+                    🔄 ({autoScanProgress.current}/{autoScanProgress.total})
+                {:else}
+                    🔄
                 {/if}
             </button>
             <button
@@ -651,6 +708,27 @@ async function handleDrop(e, dropIndex) {
 
     .compare-checkbox:disabled {
         opacity: 0.3;
+        cursor: not-allowed;
+    }
+
+    .auto-scan-btn {
+        padding: 8px 10px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        font-size: 13px;
+        cursor: pointer;
+        transition: all 0.15s ease;
+        flex-shrink: 0;
+    }
+
+    .auto-scan-btn:hover:not(:disabled) {
+        background: var(--bg-selected);
+        border-color: var(--accent);
+    }
+
+    .auto-scan-btn:disabled {
+        opacity: 0.5;
         cursor: not-allowed;
     }
 

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -1,0 +1,157 @@
+/**
+ * Auto-import service for Project Gorgon gene-report files.
+ *
+ * Scans a configured folder, computes a content hash for each .txt file,
+ * and ingests files whose hash isn't already in the `imported_files` ledger.
+ * The ledger is maintained by `petService.recordImportedFile`, which keeps
+ * skip-state across pet deletions — a pet the user deleted on purpose
+ * doesn't come back on the next scan.
+ */
+
+import { isTauri } from '$lib/utils/environment.js';
+import { hasImportedFile, recordImportedFile, uploadPet } from './petService.js';
+import { getSetting, setSetting } from './settingsService.js';
+
+export type Platform = 'windows' | 'mac' | 'linux' | 'unknown';
+
+const GAME_FOLDER_SETTING_KEY = 'import.gameFolderPath';
+
+/**
+ * Placeholder paths for the game's gene-report folder. These are not
+ * authoritative — the actual paths must be filled in by the user once
+ * verified on a machine that has Project Gorgon installed.
+ *
+ * The auto-scanner treats any value matching `<TODO:` as "not configured".
+ */
+const GAME_FOLDER_PLACEHOLDERS: Record<Platform, string> = {
+  windows: '<TODO: Windows path to Project Gorgon gene reports folder>',
+  mac: '<TODO: macOS path to Project Gorgon gene reports folder>',
+  linux: '<TODO: Linux path to Project Gorgon gene reports folder>',
+  unknown: '',
+};
+
+/**
+ * Detect host platform from the webview's userAgent. Tauri runs in the
+ * system webview, so the UA reflects the host OS.
+ */
+export function detectPlatform(): Platform {
+  if (typeof navigator === 'undefined') return 'unknown';
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('win')) return 'windows';
+  if (ua.includes('mac')) return 'mac';
+  if (ua.includes('linux') || ua.includes('x11')) return 'linux';
+  return 'unknown';
+}
+
+/** Per-platform placeholder, or '' if unknown. */
+export function getDefaultGameFolder(platform: Platform = detectPlatform()): string {
+  return GAME_FOLDER_PLACEHOLDERS[platform] ?? '';
+}
+
+/** True if the path is one of our placeholder strings (not real config). */
+export function isPlaceholderPath(path: string): boolean {
+  return !path.trim() || path.startsWith('<TODO:');
+}
+
+/** Read user-configured folder, or platform default if unset. */
+export async function getConfiguredGameFolder(): Promise<string> {
+  const stored = (await getSetting<string>(GAME_FOLDER_SETTING_KEY)) ?? '';
+  return stored.trim() ? stored : getDefaultGameFolder();
+}
+
+export function setConfiguredGameFolder(path: string): Promise<void> {
+  return setSetting(GAME_FOLDER_SETTING_KEY, path);
+}
+
+/**
+ * SHA-256 of a string — matches the hash that `uploadPet` uses internally
+ * so the dedup check is against the same key space.
+ */
+async function sha256(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export interface AutoScanResult {
+  status: 'ok' | 'not_configured' | 'folder_missing' | 'error';
+  message?: string;
+  scanned: number;
+  skipped: number;
+  imported: number;
+  failures: Array<{ file: string; reason: string }>;
+}
+
+function emptyResult(status: AutoScanResult['status'], message?: string): AutoScanResult {
+  return { status, message, scanned: 0, skipped: 0, imported: 0, failures: [] };
+}
+
+/**
+ * Scan the configured game folder and import any genome files we haven't
+ * seen before. Reports per-file failures rather than aborting on the
+ * first one — a single broken export shouldn't block the rest.
+ */
+export async function autoScanGameFolder(options?: {
+  onProgress?: (current: number, total: number) => void;
+}): Promise<AutoScanResult> {
+  if (!isTauri()) return emptyResult('error', 'Auto-import is only available in the desktop app');
+
+  const folder = await getConfiguredGameFolder();
+  if (isPlaceholderPath(folder)) return emptyResult('not_configured');
+
+  const { readDir, readTextFile, exists } = await import('@tauri-apps/plugin-fs');
+
+  if (!(await exists(folder))) {
+    return emptyResult('folder_missing', `Game folder not found: ${folder}`);
+  }
+
+  const entries = await readDir(folder);
+  const txtFiles = entries.filter((e) => e.isFile && e.name.toLowerCase().endsWith('.txt')).map((e) => e.name);
+
+  const result: AutoScanResult = {
+    status: 'ok',
+    scanned: 0,
+    skipped: 0,
+    imported: 0,
+    failures: [],
+  };
+
+  for (let i = 0; i < txtFiles.length; i++) {
+    const fileName = txtFiles[i];
+    options?.onProgress?.(i + 1, txtFiles.length);
+    result.scanned++;
+    // Path joining via plain concat is acceptable here — Tauri's fs
+    // plugin normalizes both `/` and `\` separators on all platforms.
+    const fullPath = `${folder}/${fileName}`;
+    try {
+      const content = await readTextFile(fullPath);
+      const hash = await sha256(content);
+      if (await hasImportedFile(hash)) {
+        // Record the source path even on skip, so a folder move is
+        // visible in the ledger if the user inspects it later.
+        await recordImportedFile(hash, fullPath);
+        result.skipped++;
+        continue;
+      }
+      const upload = await uploadPet(content, '', 'Male', undefined, fullPath);
+      if (upload.status === 'success') {
+        result.imported++;
+      } else {
+        // Fall-through duplicate: pets.content_hash matched but
+        // imported_files was missing the row (e.g. pre-feature legacy).
+        // Record now so future scans skip it.
+        await recordImportedFile(hash, fullPath);
+        result.failures.push({ file: fileName, reason: upload.message });
+      }
+    } catch (err) {
+      result.failures.push({
+        file: fileName,
+        reason: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -35,12 +35,16 @@ const DEFAULT_GAME_FOLDERS: Record<Platform, string> = {
 /**
  * Detect host platform from the webview's userAgent. Tauri runs in the
  * system webview, so the UA reflects the host OS.
+ *
+ * Mac is checked before Windows because the substring "win" appears
+ * inside "darwin" — a naive `ua.includes('win')` misclassifies Mac
+ * tooling/embedder UAs as Windows.
  */
 export function detectPlatform(): Platform {
   if (typeof navigator === 'undefined') return 'unknown';
   const ua = navigator.userAgent.toLowerCase();
-  if (ua.includes('win')) return 'windows';
-  if (ua.includes('mac')) return 'mac';
+  if (ua.includes('mac') || ua.includes('darwin')) return 'mac';
+  if (ua.includes('windows nt') || ua.includes('win32') || ua.includes('win64')) return 'windows';
   if (ua.includes('linux') || ua.includes('x11')) return 'linux';
   return 'unknown';
 }
@@ -163,7 +167,11 @@ export async function autoScanGameFolder(options?: {
         result.skipped++;
         continue;
       }
-      const upload = await uploadPet(item.content, '', '', undefined, item.fullPath);
+      // Gender '' would override the column default; uploadPet only
+      // pulls gender from the genome when the name is *structured*
+      // (e.g., "Kb F 60 70 …"), so unnamed/unstructured pets need a
+      // fallback. Match the manual upload path's 'Male' default.
+      const upload = await uploadPet(item.content, '', 'Male', undefined, item.fullPath);
       if (upload.status === 'success') {
         result.imported++;
       } else {

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -50,13 +50,15 @@ export function getDefaultGameFolder(platform: Platform = detectPlatform()): str
 
 /** True if the path is one of our placeholder strings (not real config). */
 export function isPlaceholderPath(path: string): boolean {
-  return !path.trim() || path.startsWith('<TODO:');
+  const trimmed = path.trim();
+  return !trimmed || trimmed.startsWith('<TODO:');
 }
 
 /** Read user-configured folder, or platform default if unset. */
 export async function getConfiguredGameFolder(): Promise<string> {
   const stored = (await getSetting<string>(GAME_FOLDER_SETTING_KEY)) ?? '';
-  return stored.trim() ? stored : getDefaultGameFolder();
+  const trimmed = stored.trim();
+  return trimmed || getDefaultGameFolder();
 }
 
 export function setConfiguredGameFolder(path: string): Promise<void> {
@@ -129,9 +131,8 @@ export async function autoScanGameFolder(options?: {
       const content = await readTextFile(fullPath);
       const hash = await sha256(content);
       if (await hasImportedFile(hash)) {
-        // Record the source path even on skip, so a folder move is
-        // visible in the ledger if the user inspects it later.
-        await recordImportedFile(hash, fullPath);
+        // Already in the ledger — first-seen source_path is intentionally
+        // immutable, so don't rewrite it on skip.
         result.skipped++;
         continue;
       }
@@ -139,9 +140,9 @@ export async function autoScanGameFolder(options?: {
       if (upload.status === 'success') {
         result.imported++;
       } else {
-        // Fall-through duplicate: pets.content_hash matched but
-        // imported_files was missing the row (e.g. pre-feature legacy).
-        // Record now so future scans skip it.
+        // pets.content_hash matched but imported_files was missing the
+        // row (e.g. pre-feature legacy that the backfill hasn't reached
+        // yet). Record now so future scans skip it.
         await recordImportedFile(hash, fullPath);
         result.failures.push({ file: fileName, reason: upload.message });
       }

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -175,3 +175,51 @@ export async function autoScanGameFolder(options?: {
 
   return result;
 }
+
+/**
+ * Watch the configured game folder for changes and invoke `onChange`
+ * when a `.txt` event fires (debounced). Returns a stop function, or
+ * `null` if there's nothing to watch (non-Tauri host, unconfigured
+ * placeholder, missing folder). The caller is expected to call the
+ * returned stop function when the watcher should be torn down.
+ *
+ * Debounce protects against editors that "save = write twice" — Unity
+ * builds aren't editors, but we still want a quiet window so we don't
+ * scan a half-written file.
+ */
+export async function watchGameFolder(
+  onChange: () => void,
+  options?: { debounceMs?: number },
+): Promise<(() => Promise<void>) | null> {
+  if (!isTauri()) return null;
+
+  const configured = await getConfiguredGameFolder();
+  if (isPlaceholderPath(configured)) return null;
+
+  const folder = await expandHomePath(configured);
+  const { exists, watch } = await import('@tauri-apps/plugin-fs');
+  if (!(await exists(folder))) return null;
+
+  const debounceMs = options?.debounceMs ?? 500;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const unwatch = await watch(
+    folder,
+    () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        onChange();
+      }, debounceMs);
+    },
+    { recursive: false },
+  );
+
+  return async () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    await unwatch();
+  };
+}

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -9,6 +9,7 @@
  */
 
 import { isTauri } from '$lib/utils/environment.js';
+import { sha256Hex } from '$lib/utils/hash.js';
 import { hasImportedFile, recordImportedFile, uploadPet } from './petService.js';
 import { getSetting, setSetting } from './settingsService.js';
 
@@ -44,55 +45,39 @@ export function detectPlatform(): Platform {
   return 'unknown';
 }
 
-/** Per-platform default, or '' if unknown. May be a `<TODO:` placeholder. */
+/** Per-platform default, or '' if the host platform is unknown. */
 export function getDefaultGameFolder(platform: Platform = detectPlatform()): string {
   return DEFAULT_GAME_FOLDERS[platform] ?? '';
 }
 
-/** True if the path is one of our placeholder strings (not real config). */
+/** True if the path is unset (only check that survives now that all platforms have real defaults). */
 export function isPlaceholderPath(path: string): boolean {
-  const trimmed = path.trim();
-  return !trimmed || trimmed.startsWith('<TODO:');
+  return !path.trim();
 }
 
 /** Read user-configured folder, or platform default if unset. */
 export async function getConfiguredGameFolder(): Promise<string> {
   const stored = (await getSetting<string>(GAME_FOLDER_SETTING_KEY)) ?? '';
-  const trimmed = stored.trim();
-  return trimmed || getDefaultGameFolder();
+  return stored.trim() || getDefaultGameFolder();
 }
 
 export function setConfiguredGameFolder(path: string): Promise<void> {
   return setSetting(GAME_FOLDER_SETTING_KEY, path);
 }
 
-/**
- * Expand a `~/` or `$HOME/` prefix to the real home directory. The Tauri
- * fs plugin doesn't substitute these — capability scope variables resolve
- * server-side, but the path passed into readDir/readTextFile is taken
- * literally — so the expansion has to happen here before the call.
- */
-async function expandHomePath(path: string): Promise<string> {
-  if (!path.startsWith('~/') && !path.startsWith('$HOME/') && path !== '~' && path !== '$HOME') {
-    return path;
-  }
-  const { homeDir } = await import('@tauri-apps/api/path');
-  const home = (await homeDir()).replace(/\/$/, '');
-  if (path === '~' || path === '$HOME') return home;
-  if (path.startsWith('~/')) return `${home}${path.slice(1)}`;
-  return `${home}${path.slice('$HOME'.length)}`;
-}
+const HOME_PREFIX = /^(~|\$HOME)(?=$|\/)/;
 
 /**
- * SHA-256 of a string — matches the hash that `uploadPet` uses internally
- * so the dedup check is against the same key space.
+ * Expand a leading `~` or `$HOME` to the real home directory. Tauri's
+ * fs plugin only resolves these as capability scope variables — the
+ * path passed to readDir/readTextFile is taken literally — so the
+ * expansion has to happen here before the call.
  */
-async function sha256(content: string): Promise<string> {
-  const data = new TextEncoder().encode(content);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
+async function expandHomePath(path: string): Promise<string> {
+  if (!HOME_PREFIX.test(path)) return path;
+  const { homeDir } = await import('@tauri-apps/api/path');
+  const home = (await homeDir()).replace(/\/$/, '');
+  return path.replace(HOME_PREFIX, home);
 }
 
 export interface AutoScanResult {
@@ -122,14 +107,21 @@ export async function autoScanGameFolder(options?: {
   if (isPlaceholderPath(configured)) return emptyResult('not_configured');
 
   const folder = await expandHomePath(configured);
-  const { readDir, readTextFile, exists } = await import('@tauri-apps/plugin-fs');
+  const fs = await import('@tauri-apps/plugin-fs');
+  const { readTextFile } = fs;
 
-  if (!(await exists(folder))) {
-    return emptyResult('folder_missing', `Game folder not found: ${folder}`);
+  let entries: Awaited<ReturnType<typeof fs.readDir>>;
+  try {
+    entries = await fs.readDir(folder);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return emptyResult('folder_missing', `Game folder not readable: ${folder} (${message})`);
   }
-
-  const entries = await readDir(folder);
-  const txtFiles = entries.filter((e) => e.isFile && e.name.toLowerCase().endsWith('.txt')).map((e) => e.name);
+  // Path joining via plain concat is acceptable — Tauri's fs plugin
+  // normalizes both `/` and `\` on Windows.
+  const txtFiles = entries
+    .filter((e) => e.isFile && e.name.toLowerCase().endsWith('.txt'))
+    .map((e) => ({ name: e.name, fullPath: `${folder}/${e.name}` }));
 
   const result: AutoScanResult = {
     status: 'ok',
@@ -139,37 +131,48 @@ export async function autoScanGameFolder(options?: {
     failures: [],
   };
 
-  for (let i = 0; i < txtFiles.length; i++) {
-    const fileName = txtFiles[i];
-    options?.onProgress?.(i + 1, txtFiles.length);
-    result.scanned++;
-    // Path joining via plain concat is acceptable here — Tauri's fs
-    // plugin normalizes both `/` and `\` separators on all platforms.
-    const fullPath = `${folder}/${fileName}`;
-    try {
-      const content = await readTextFile(fullPath);
-      const hash = await sha256(content);
-      if (await hasImportedFile(hash)) {
+  // Read+hash in parallel chunks — the slow step on cold scans is disk
+  // I/O, and SHA-256 of a small text file is negligible. SQL writes
+  // (uploadPet, recordImportedFile) stay strictly serial because
+  // uploadPet computes MAX(sort_order)+1 inside its transaction.
+  const READ_CHUNK = 8;
+  for (let i = 0; i < txtFiles.length; i += READ_CHUNK) {
+    const chunk = txtFiles.slice(i, i + READ_CHUNK);
+    const hashed = await Promise.all(
+      chunk.map(async ({ name, fullPath }) => {
+        try {
+          const content = await readTextFile(fullPath);
+          const hash = await sha256Hex(content);
+          return { name, fullPath, content, hash } as const;
+        } catch (err) {
+          return { name, fullPath, error: err instanceof Error ? err.message : String(err) } as const;
+        }
+      }),
+    );
+
+    for (const item of hashed) {
+      result.scanned++;
+      options?.onProgress?.(result.scanned, txtFiles.length);
+      if ('error' in item) {
+        result.failures.push({ file: item.name, reason: item.error });
+        continue;
+      }
+      if (await hasImportedFile(item.hash)) {
         // Already in the ledger — first-seen source_path is intentionally
         // immutable, so don't rewrite it on skip.
         result.skipped++;
         continue;
       }
-      const upload = await uploadPet(content, '', 'Male', undefined, fullPath);
+      const upload = await uploadPet(item.content, '', '', undefined, item.fullPath);
       if (upload.status === 'success') {
         result.imported++;
       } else {
         // pets.content_hash matched but imported_files was missing the
-        // row (e.g. pre-feature legacy that the backfill hasn't reached
-        // yet). Record now so future scans skip it.
-        await recordImportedFile(hash, fullPath);
-        result.failures.push({ file: fileName, reason: upload.message });
+        // row (e.g. pre-feature legacy not yet reached by backfill).
+        // Record now so future scans skip it.
+        await recordImportedFile(item.hash, item.fullPath);
+        result.failures.push({ file: item.name, reason: upload.message });
       }
-    } catch (err) {
-      result.failures.push({
-        file: fileName,
-        reason: err instanceof Error ? err.message : String(err),
-      });
     }
   }
 
@@ -197,23 +200,29 @@ export async function watchGameFolder(
   if (isPlaceholderPath(configured)) return null;
 
   const folder = await expandHomePath(configured);
-  const { exists, watch } = await import('@tauri-apps/plugin-fs');
-  if (!(await exists(folder))) return null;
+  const { watch } = await import('@tauri-apps/plugin-fs');
 
   const debounceMs = options?.debounceMs ?? 500;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
-  const unwatch = await watch(
-    folder,
-    () => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        timer = null;
-        onChange();
-      }, debounceMs);
-    },
-    { recursive: false },
-  );
+  let unwatch: Awaited<ReturnType<typeof watch>>;
+  try {
+    unwatch = await watch(
+      folder,
+      () => {
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          timer = null;
+          onChange();
+        }, debounceMs);
+      },
+      { recursive: false },
+    );
+  } catch {
+    // Folder doesn't exist or isn't watchable — caller treats null as
+    // "nothing to watch right now". A later path change re-arms.
+    return null;
+  }
 
   return async () => {
     if (timer) {

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -17,15 +17,17 @@ export type Platform = 'windows' | 'mac' | 'linux' | 'unknown';
 const GAME_FOLDER_SETTING_KEY = 'import.gameFolderPath';
 
 /**
- * Placeholder paths for the game's gene-report folder. These are not
- * authoritative — the actual paths must be filled in by the user once
- * verified on a machine that has Project Gorgon installed.
+ * Per-platform default for the game's gene-report folder. Mac and
+ * Windows are the user-confirmed canonical paths; Linux is still a
+ * placeholder pending confirmation.
  *
- * The auto-scanner treats any value matching `<TODO:` as "not configured".
+ * Forward slashes only — Tauri's fs plugin normalizes them on Windows.
+ * The auto-scanner treats any `<TODO:` value as "not configured" and
+ * lets the user override the default in Settings → Auto-import.
  */
-const GAME_FOLDER_PLACEHOLDERS: Record<Platform, string> = {
-  windows: '<TODO: Windows path to Project Gorgon gene reports folder>',
-  mac: '<TODO: macOS path to Project Gorgon gene reports folder>',
+const DEFAULT_GAME_FOLDERS: Record<Platform, string> = {
+  windows: '$HOME/AppData/LocalLow/Elder Game/Project Gorgon/Reports',
+  mac: '$HOME/Library/Application Support/unity.Elder Game.Project Gorgon/Reports',
   linux: '<TODO: Linux path to Project Gorgon gene reports folder>',
   unknown: '',
 };
@@ -43,9 +45,9 @@ export function detectPlatform(): Platform {
   return 'unknown';
 }
 
-/** Per-platform placeholder, or '' if unknown. */
+/** Per-platform default, or '' if unknown. May be a `<TODO:` placeholder. */
 export function getDefaultGameFolder(platform: Platform = detectPlatform()): string {
-  return GAME_FOLDER_PLACEHOLDERS[platform] ?? '';
+  return DEFAULT_GAME_FOLDERS[platform] ?? '';
 }
 
 /** True if the path is one of our placeholder strings (not real config). */
@@ -63,6 +65,23 @@ export async function getConfiguredGameFolder(): Promise<string> {
 
 export function setConfiguredGameFolder(path: string): Promise<void> {
   return setSetting(GAME_FOLDER_SETTING_KEY, path);
+}
+
+/**
+ * Expand a `~/` or `$HOME/` prefix to the real home directory. The Tauri
+ * fs plugin doesn't substitute these — capability scope variables resolve
+ * server-side, but the path passed into readDir/readTextFile is taken
+ * literally — so the expansion has to happen here before the call.
+ */
+async function expandHomePath(path: string): Promise<string> {
+  if (!path.startsWith('~/') && !path.startsWith('$HOME/') && path !== '~' && path !== '$HOME') {
+    return path;
+  }
+  const { homeDir } = await import('@tauri-apps/api/path');
+  const home = (await homeDir()).replace(/\/$/, '');
+  if (path === '~' || path === '$HOME') return home;
+  if (path.startsWith('~/')) return `${home}${path.slice(1)}`;
+  return `${home}${path.slice('$HOME'.length)}`;
 }
 
 /**
@@ -100,9 +119,10 @@ export async function autoScanGameFolder(options?: {
 }): Promise<AutoScanResult> {
   if (!isTauri()) return emptyResult('error', 'Auto-import is only available in the desktop app');
 
-  const folder = await getConfiguredGameFolder();
-  if (isPlaceholderPath(folder)) return emptyResult('not_configured');
+  const configured = await getConfiguredGameFolder();
+  if (isPlaceholderPath(configured)) return emptyResult('not_configured');
 
+  const folder = await expandHomePath(configured);
   const { readDir, readTextFile, exists } = await import('@tauri-apps/plugin-fs');
 
   if (!(await exists(folder))) {

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -17,18 +17,17 @@ export type Platform = 'windows' | 'mac' | 'linux' | 'unknown';
 const GAME_FOLDER_SETTING_KEY = 'import.gameFolderPath';
 
 /**
- * Per-platform default for the game's gene-report folder. Mac and
- * Windows are the user-confirmed canonical paths; Linux is still a
- * placeholder pending confirmation.
- *
- * Forward slashes only — Tauri's fs plugin normalizes them on Windows.
- * The auto-scanner treats any `<TODO:` value as "not configured" and
- * lets the user override the default in Settings → Auto-import.
+ * Per-platform default for the game's gene-report folder, all
+ * user-confirmed. Forward slashes only — Tauri's fs plugin normalizes
+ * them on Windows. The auto-scanner still falls back through
+ * `isPlaceholderPath` so the unknown-platform branch (empty string)
+ * surfaces a "not configured" result instead of attempting a scan.
+ * Users can override any default in Settings → Auto-import.
  */
 const DEFAULT_GAME_FOLDERS: Record<Platform, string> = {
   windows: '$HOME/AppData/LocalLow/Elder Game/Project Gorgon/Reports',
   mac: '$HOME/Library/Application Support/unity.Elder Game.Project Gorgon/Reports',
-  linux: '<TODO: Linux path to Project Gorgon gene reports folder>',
+  linux: '$HOME/.config/unity3d/Elder Game/Project Gorgon/Reports',
   unknown: '',
 };
 

--- a/src/lib/services/migrationService.ts
+++ b/src/lib/services/migrationService.ts
@@ -178,6 +178,23 @@ const MIGRATIONS: Migration[] = [
       await db.execute('ALTER TABLE pets ADD COLUMN unknown_genes INTEGER NOT NULL DEFAULT 0');
     },
   },
+  {
+    version: 12,
+    description: 'Add imported_files table to skip already-seen files on auto-scan',
+    up: async () => {
+      const db = getDb();
+      // Tracks every genome file ever ingested by content_hash. Survives
+      // pet deletion so the auto-scanner doesn't re-import a file the
+      // user already chose to discard.
+      await db.execute(`
+        CREATE TABLE IF NOT EXISTS imported_files (
+          content_hash TEXT PRIMARY KEY,
+          source_path TEXT,
+          imported_at TEXT NOT NULL
+        )
+      `);
+    },
+  },
 ];
 
 /** Derived from the last migration — no manual bookkeeping needed. */

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -5,6 +5,7 @@
 import type { GeneStatsEntry, Genome, Pet } from '$lib/types/index.js';
 import { GENOME_FILE_MARKERS } from '$lib/types/index.js';
 import { fromGeneId, type ParsedChromosome, type ParsedGene, toGeneId } from '$lib/utils/geneAnalysis.js';
+import { sha256Hex } from '$lib/utils/hash.js';
 import { capitalize } from '$lib/utils/string.js';
 import { now } from '$lib/utils/timestamp.js';
 import { runBatchBackfill } from './backfill.js';
@@ -14,17 +15,6 @@ import { getParsedGenesCached, isHorseBreedFiltered } from './geneService.js';
 import { compareBlockLetters, genomeToGeneStrings, isValidGenomeFile, parseGenome } from './genomeParser.js';
 import { parseStructuredPetName } from './nameParser.js';
 import { getSetting, setSetting } from './settingsService.js';
-
-/**
- * Compute SHA-256 hash of a string.
- */
-async function sha256(content: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(content);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-}
 
 type GeneCountSummary = { total: number; known: number; unknown: number };
 
@@ -371,11 +361,11 @@ export async function recordImportedFile(contentHash: string, sourcePath?: strin
  * have been deleted).
  */
 export async function hasImportedFile(contentHash: string): Promise<boolean> {
-  const rows = await getDb().select<{ cnt: number }[]>(
-    'SELECT COUNT(*) as cnt FROM imported_files WHERE content_hash = $hash',
+  const rows = await getDb().select<{ one: number }[]>(
+    'SELECT 1 AS one FROM imported_files WHERE content_hash = $hash LIMIT 1',
     { hash: contentHash },
   );
-  return rows[0].cnt > 0;
+  return rows.length > 0;
 }
 
 /**
@@ -402,7 +392,7 @@ export async function uploadPet(
   }
 
   // Compute hash for duplicate detection
-  const contentHash = await sha256(content);
+  const contentHash = await sha256Hex(content);
 
   // Check for duplicate
   const existing = await findPetByHash(contentHash);
@@ -871,7 +861,7 @@ export async function backfillImportedFilesIfNeeded(): Promise<void> {
     batchSize: 64,
     guard: async () => (await getSetting<boolean>(IMPORTED_FILES_BACKFILL_KEY)) ?? false,
     loadWorkSet: () => db.select<Row[]>('SELECT content_hash FROM pets WHERE content_hash IS NOT NULL'),
-    computeUpdate: (row) => (row.content_hash ? { hash: row.content_hash } : null),
+    computeUpdate: (row) => ({ hash: row.content_hash }),
     applyBatch: async (updates) => {
       const ts = now();
       await withTransaction(async () => {

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -355,6 +355,30 @@ export async function getPet(petId: number): Promise<Pet | null> {
 }
 
 /**
+ * Record a content hash in imported_files so the auto-scanner won't
+ * re-import the same file later (even if the pet is deleted). No-op
+ * if the hash is already present.
+ */
+export async function recordImportedFile(contentHash: string, sourcePath?: string): Promise<void> {
+  await getDb().execute(
+    'INSERT OR IGNORE INTO imported_files (content_hash, source_path, imported_at) VALUES ($hash, $path, $ts)',
+    { hash: contentHash, path: sourcePath ?? null, ts: now() },
+  );
+}
+
+/**
+ * True if this content_hash was imported before (the pet may since
+ * have been deleted).
+ */
+export async function hasImportedFile(contentHash: string): Promise<boolean> {
+  const rows = await getDb().select<{ cnt: number }[]>(
+    'SELECT COUNT(*) as cnt FROM imported_files WHERE content_hash = $hash',
+    { hash: contentHash },
+  );
+  return rows[0].cnt > 0;
+}
+
+/**
  * Upload and create a new pet from genome file content.
  */
 export async function uploadPet(
@@ -362,6 +386,7 @@ export async function uploadPet(
   name: string,
   gender: string,
   notes?: string,
+  sourcePath?: string,
 ): Promise<{ status: string; message: string; pet_id?: number; name?: string }> {
   // Validate content
   if (!content.trim()) {
@@ -460,6 +485,12 @@ export async function uploadPet(
     }
     return res;
   });
+
+  // Recorded outside the upload tx — failure here mustn't roll back the
+  // pet, and the table is only an auto-scanner skip-list. INSERT OR
+  // IGNORE keeps it idempotent if the user manually re-imports a deleted
+  // pet, then later runs an auto-scan.
+  await recordImportedFile(contentHash, sourcePath);
 
   return {
     status: 'success',
@@ -813,6 +844,41 @@ export async function backfillPositiveGenesIfNeeded(): Promise<void> {
       return updates.length;
     },
     markDone: () => setSetting(POSITIVE_GENES_BACKFILL_KEY, true),
+  });
+}
+
+const IMPORTED_FILES_BACKFILL_KEY = 'pets.imported_files_backfilled';
+
+/**
+ * One-shot backfill: every existing pet's content_hash gets a row in
+ * `imported_files` so the auto-scanner skips files that were already
+ * imported manually before this feature existed. Without it, the very
+ * first auto-scan after upgrade would treat all current pets as new
+ * candidates and only spare them via the upload-time duplicate check.
+ */
+export async function backfillImportedFilesIfNeeded(): Promise<void> {
+  const db = getDb();
+  type Row = { content_hash: string };
+  type Update = { hash: string };
+  await runBatchBackfill<Row, Update>({
+    label: 'imported_files backfill',
+    batchSize: 64,
+    guard: async () => (await getSetting<boolean>(IMPORTED_FILES_BACKFILL_KEY)) ?? false,
+    loadWorkSet: () => db.select<Row[]>('SELECT content_hash FROM pets WHERE content_hash IS NOT NULL'),
+    computeUpdate: (row) => (row.content_hash ? { hash: row.content_hash } : null),
+    applyBatch: async (updates) => {
+      const ts = now();
+      await withTransaction(async () => {
+        for (const u of updates) {
+          await db.execute(
+            'INSERT OR IGNORE INTO imported_files (content_hash, source_path, imported_at) VALUES ($hash, $path, $ts)',
+            { hash: u.hash, path: null, ts },
+          );
+        }
+      });
+      return updates.length;
+    },
+    markDone: () => setSetting(IMPORTED_FILES_BACKFILL_KEY, true),
   });
 }
 

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -487,10 +487,16 @@ export async function uploadPet(
   });
 
   // Recorded outside the upload tx — failure here mustn't roll back the
-  // pet, and the table is only an auto-scanner skip-list. INSERT OR
-  // IGNORE keeps it idempotent if the user manually re-imports a deleted
-  // pet, then later runs an auto-scan.
-  await recordImportedFile(contentHash, sourcePath);
+  // pet, and the table is only an auto-scanner skip-list. The try/catch
+  // is load-bearing: an `await` here would propagate the ledger error to
+  // the caller as a failed upload, even though the pet was already
+  // committed. Worst case for a swallowed error is the next auto-scan
+  // re-imports the file once and dedups via pets.content_hash.
+  try {
+    await recordImportedFile(contentHash, sourcePath);
+  } catch (err) {
+    console.warn('imported_files: failed to record after successful upload', err);
+  }
 
   return {
     status: 'success',

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -11,6 +11,7 @@ const SETTING_DEFAULTS: Record<string, unknown> = {
   'horse.autoSelectBreedFilter': true,
   'display.fontScale': 100,
   'display.theme': 'system',
+  'import.gameFolderPath': '',
 };
 
 export function getDefaultSettings(): Record<string, unknown> {

--- a/src/lib/utils/hash.ts
+++ b/src/lib/utils/hash.ts
@@ -1,0 +1,8 @@
+/** SHA-256 of a UTF-8 string, as a lowercase hex digest. */
+export async function sha256Hex(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,8 +14,8 @@ onMount(async () => {
 <div class="detail-content">
 	{#if $error}
 		<div class="error-banner" role="alert">
-			<span>⚠️ {$error}</span>
-			<button class="error-close" onclick={() => appState.clearError()}>×</button>
+			<div class="error-message">⚠️ {$error}</div>
+			<button class="error-close" onclick={() => appState.clearError()} aria-label="Dismiss error">×</button>
 		</div>
 	{/if}
 
@@ -54,17 +54,27 @@ onMount(async () => {
 
 	.error-banner {
 		display: flex;
-		align-items: center;
-		justify-content: space-between;
+		align-items: flex-start;
+		gap: 8px;
 		padding: 8px 16px;
 		background: var(--error-bg);
 		border-bottom: 1px solid var(--error-border);
 		color: var(--error-text);
 		font-size: 13px;
 		flex-shrink: 0;
+		max-height: 35vh;
+	}
+
+	.error-message {
+		flex: 1;
+		overflow-y: auto;
+		max-height: calc(35vh - 16px);
+		white-space: pre-wrap;
+		word-break: break-word;
 	}
 
 	.error-close {
+		flex-shrink: 0;
 		background: none;
 		border: none;
 		font-size: 16px;

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import * as gameImport from '$lib/services/gameImport.js';
 import { runMigrations } from '$lib/services/migrationService.js';
@@ -17,9 +17,41 @@ describe('gameImport service', () => {
   });
 
   describe('detectPlatform', () => {
-    it('returns one of the supported platform tags', () => {
-      const platform = gameImport.detectPlatform();
-      expect(['windows', 'mac', 'linux', 'unknown']).toContain(platform);
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    function stubUA(ua) {
+      vi.stubGlobal('navigator', { userAgent: ua });
+    }
+
+    it('classifies macOS WebKit UA as mac', () => {
+      stubUA('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15');
+      expect(gameImport.detectPlatform()).toBe('mac');
+    });
+
+    it('classifies a UA containing "darwin" as mac (not windows)', () => {
+      // Guard: 'darwin'.includes('win') is true, so a naive Windows
+      // check would misclassify Darwin-flavored UAs.
+      stubUA('SomeEmbedder/1.0 (Darwin 23.0)');
+      expect(gameImport.detectPlatform()).toBe('mac');
+    });
+
+    it('classifies Windows 10/11 WebView2 UA as windows', () => {
+      stubUA(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      );
+      expect(gameImport.detectPlatform()).toBe('windows');
+    });
+
+    it('classifies Linux WebKitGTK UA as linux', () => {
+      stubUA('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15');
+      expect(gameImport.detectPlatform()).toBe('linux');
+    });
+
+    it('returns unknown for an unrecognized UA', () => {
+      stubUA('CompletelyUnknown/1.0');
+      expect(gameImport.detectPlatform()).toBe('unknown');
     });
   });
 

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -43,8 +43,8 @@ describe('gameImport service', () => {
       );
     });
 
-    it('still uses a placeholder for Linux until confirmed', () => {
-      expect(gameImport.getDefaultGameFolder('linux')).toContain('TODO');
+    it('returns the verified Linux path under $HOME/.config/unity3d', () => {
+      expect(gameImport.getDefaultGameFolder('linux')).toBe('$HOME/.config/unity3d/Elder Game/Project Gorgon/Reports');
     });
 
     it('returns empty string for unknown platform', () => {

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -74,6 +74,13 @@ describe('gameImport service', () => {
     });
   });
 
+  describe('watchGameFolder', () => {
+    it('returns null outside Tauri', async () => {
+      const stop = await gameImport.watchGameFolder(() => {});
+      expect(stop).toBeNull();
+    });
+  });
+
   describe('imported_files ledger', () => {
     it('records hash on successful upload', async () => {
       const hash = await sha256(SAMPLE_BEEWASP);

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, initDatabase } from '$lib/services/database.js';
+import * as gameImport from '$lib/services/gameImport.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
+
+async function sha256(content) {
+  const data = new TextEncoder().encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('gameImport service', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+  });
+
+  describe('detectPlatform', () => {
+    it('returns one of the supported platform tags', () => {
+      const platform = gameImport.detectPlatform();
+      expect(['windows', 'mac', 'linux', 'unknown']).toContain(platform);
+    });
+  });
+
+  describe('getDefaultGameFolder', () => {
+    it('returns a placeholder string for each platform', () => {
+      expect(gameImport.getDefaultGameFolder('windows')).toContain('TODO');
+      expect(gameImport.getDefaultGameFolder('mac')).toContain('TODO');
+      expect(gameImport.getDefaultGameFolder('linux')).toContain('TODO');
+    });
+
+    it('returns empty string for unknown platform', () => {
+      expect(gameImport.getDefaultGameFolder('unknown')).toBe('');
+    });
+  });
+
+  describe('isPlaceholderPath', () => {
+    it('treats empty/whitespace as placeholder', () => {
+      expect(gameImport.isPlaceholderPath('')).toBe(true);
+      expect(gameImport.isPlaceholderPath('   ')).toBe(true);
+    });
+    it('treats <TODO: ...> as placeholder', () => {
+      expect(gameImport.isPlaceholderPath('<TODO: fill me in>')).toBe(true);
+    });
+    it('treats real paths as not-placeholder', () => {
+      expect(gameImport.isPlaceholderPath('/Users/me/game')).toBe(false);
+      expect(gameImport.isPlaceholderPath('C:/Games/Project Gorgon')).toBe(false);
+    });
+  });
+
+  describe('autoScanGameFolder', () => {
+    it('returns error status outside Tauri', async () => {
+      const result = await gameImport.autoScanGameFolder();
+      expect(result.status).toBe('error');
+      expect(result.message).toMatch(/desktop app/i);
+    });
+  });
+
+  describe('imported_files ledger', () => {
+    it('records hash on successful upload', async () => {
+      const hash = await sha256(SAMPLE_BEEWASP);
+      expect(await petService.hasImportedFile(hash)).toBe(false);
+
+      const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      expect(result.status).toBe('success');
+      expect(await petService.hasImportedFile(hash)).toBe(true);
+    });
+
+    it('keeps the hash recorded after pet deletion', async () => {
+      const hash = await sha256(SAMPLE_BEEWASP);
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      expect(upload.status).toBe('success');
+
+      await petService.deletePet(upload.pet_id);
+      expect(await petService.hasImportedFile(hash)).toBe(true);
+    });
+
+    it('recordImportedFile is idempotent for the same hash', async () => {
+      await petService.recordImportedFile('abc123', '/path/one');
+      await petService.recordImportedFile('abc123', '/path/two');
+      expect(await petService.hasImportedFile('abc123')).toBe(true);
+    });
+
+    it('backfillImportedFilesIfNeeded populates ledger from existing pets', async () => {
+      // Upload a pet, then wipe the ledger to simulate a pre-feature
+      // database, and verify the backfill reseeds it.
+      const hash = await sha256(SAMPLE_BEEWASP);
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      expect(upload.status).toBe('success');
+
+      const { getDb } = await import('$lib/services/database.js');
+      await getDb().execute('DELETE FROM imported_files');
+      // Reset the guard flag so the backfill actually runs.
+      await getDb().execute("DELETE FROM settings WHERE key = 'pets.imported_files_backfilled'");
+      expect(await petService.hasImportedFile(hash)).toBe(false);
+
+      await petService.backfillImportedFilesIfNeeded();
+      expect(await petService.hasImportedFile(hash)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -5,16 +5,9 @@ import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import * as gameImport from '$lib/services/gameImport.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
+import { sha256Hex } from '$lib/utils/hash.js';
 
 const SAMPLE_BEEWASP = readFileSync(resolve('data/Genes_SampleFaeBee.txt'), 'utf-8');
-
-async function sha256(content) {
-  const data = new TextEncoder().encode(content);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  return Array.from(new Uint8Array(hashBuffer))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
 
 describe('gameImport service', () => {
   beforeEach(async () => {
@@ -57,9 +50,6 @@ describe('gameImport service', () => {
       expect(gameImport.isPlaceholderPath('')).toBe(true);
       expect(gameImport.isPlaceholderPath('   ')).toBe(true);
     });
-    it('treats <TODO: ...> as placeholder', () => {
-      expect(gameImport.isPlaceholderPath('<TODO: fill me in>')).toBe(true);
-    });
     it('treats real paths as not-placeholder', () => {
       expect(gameImport.isPlaceholderPath('/Users/me/game')).toBe(false);
       expect(gameImport.isPlaceholderPath('C:/Games/Project Gorgon')).toBe(false);
@@ -83,7 +73,7 @@ describe('gameImport service', () => {
 
   describe('imported_files ledger', () => {
     it('records hash on successful upload', async () => {
-      const hash = await sha256(SAMPLE_BEEWASP);
+      const hash = await sha256Hex(SAMPLE_BEEWASP);
       expect(await petService.hasImportedFile(hash)).toBe(false);
 
       const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
@@ -92,7 +82,7 @@ describe('gameImport service', () => {
     });
 
     it('keeps the hash recorded after pet deletion', async () => {
-      const hash = await sha256(SAMPLE_BEEWASP);
+      const hash = await sha256Hex(SAMPLE_BEEWASP);
       const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
       expect(upload.status).toBe('success');
 
@@ -109,7 +99,7 @@ describe('gameImport service', () => {
     it('backfillImportedFilesIfNeeded populates ledger from existing pets', async () => {
       // Upload a pet, then wipe the ledger to simulate a pre-feature
       // database, and verify the backfill reseeds it.
-      const hash = await sha256(SAMPLE_BEEWASP);
+      const hash = await sha256Hex(SAMPLE_BEEWASP);
       const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
       expect(upload.status).toBe('success');
 

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -31,9 +31,19 @@ describe('gameImport service', () => {
   });
 
   describe('getDefaultGameFolder', () => {
-    it('returns a placeholder string for each platform', () => {
-      expect(gameImport.getDefaultGameFolder('windows')).toContain('TODO');
-      expect(gameImport.getDefaultGameFolder('mac')).toContain('TODO');
+    it('returns the verified Mac path under $HOME', () => {
+      expect(gameImport.getDefaultGameFolder('mac')).toBe(
+        '$HOME/Library/Application Support/unity.Elder Game.Project Gorgon/Reports',
+      );
+    });
+
+    it('returns the verified Windows path under $HOME/AppData/LocalLow', () => {
+      expect(gameImport.getDefaultGameFolder('windows')).toBe(
+        '$HOME/AppData/LocalLow/Elder Game/Project Gorgon/Reports',
+      );
+    });
+
+    it('still uses a placeholder for Linux until confirmed', () => {
       expect(gameImport.getDefaultGameFolder('linux')).toContain('TODO');
     });
 


### PR DESCRIPTION
## Summary

- **Auto-import** with both manual and live triggers: a 🔄 button on the pet list runs an on-demand scan, and `AuthWrapper` arms a debounced fs watcher (`@tauri-apps/plugin-fs`) that re-scans the configured folder whenever a file is created/modified there. New files are imported automatically as the game writes them.
- **Per-platform game-folder defaults** (all user-confirmed):
  - macOS: `$HOME/Library/Application Support/unity.Elder Game.Project Gorgon/Reports`
  - Windows: `$HOME/AppData/LocalLow/Elder Game/Project Gorgon/Reports`
  - Linux: `$HOME/.config/unity3d/Elder Game/Project Gorgon/Reports`
  Users can override the default in Settings → Auto-import. `expandHomePath` resolves the `$HOME` prefix at runtime via Tauri's `homeDir()`.
- **Persistent skip ledger**: a new `imported_files (content_hash, source_path, imported_at)` table (migration v12) records every hash ever ingested. The ledger survives pet deletion, so a pet the user discards stays discarded across future scans.
- **Toast fix**: the error banner is no longer unclosable when bulk uploads produce a wall of failures. It now caps at 35vh, the message body scrolls inside, and the × stays pinned regardless of message length. Bulk-upload failures render one-per-line via `pre-wrap`.

## Implementation notes

- `petService.uploadPet` records into the ledger after every successful insert (manual or auto). The recording sits **outside** the upload transaction with a try/catch — failure to record mustn't roll back the pet, and `INSERT OR IGNORE` keeps it idempotent.
- A guarded one-shot backfill (`backfillImportedFilesIfNeeded`) seeds the ledger from existing `pets.content_hash` rows so users upgrading from a populated DB don't see all current pets show up as "new" candidates.
- Watcher arming uses `$derived(gameFolderPath)` so changes to *unrelated* settings (theme, font scale, …) don't tear it down. A `pendingRescan` flag inside `runLiveScan` queues a follow-up if a file event lands during a scan.
- Read+hash run in parallel chunks of 8; SQL writes stay serial because `uploadPet` computes `MAX(sort_order)+1` inside its tx.
- Tauri capabilities widened to allow read/watch under `$HOME/**`. This is intentionally permissive — narrowing to platform-specific subdirs is tracked in #185.

## Follow-up issues

- #184 — Refactor `uploadPet` to use an options object (5 positional args is over the inflection point).
- #185 — Use `BaseDirectory.Home` + narrow fs scope instead of `$HOME` path expansion.
- #186 — Consolidate text-input styles (`search-input`, `folder-input`, …).

## Test plan

- [x] `pnpm test` — 335 unit tests pass.
- [x] `pnpm test:e2e` — 117/117 pass.
- [x] `pnpm lint:ci` clean, `cargo check` clean.
- [ ] Manual on a machine with Project Gorgon installed: drop a new gene-report `.txt` into the game folder, confirm it appears in the pet list within ~1s; delete the pet, regenerate the file, confirm it's *not* re-imported (ledger working).
- [ ] Manual: verify the toast cap by triggering a bulk import with many pre-existing pets — the × must remain reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)