### PR TITLE
refactor(ui): consolidate text-input styles

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -301,6 +301,50 @@ textarea:focus:not(:focus-visible) {
   top: 0;
 }
 
+/* Shared text-input baseline. Use `text-input--lg` for the larger
+   variant (PetList search) and `text-input--mono` for monospace
+   (path/code-style fields). Keep custom selectors in components for
+   layout-specific tweaks (margins, etc.) but reach for these
+   modifiers for size/font/focus. */
+.text-input {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-size: 12px;
+  outline: none;
+  box-sizing: border-box;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    background 0.15s;
+}
+
+.text-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.text-input::placeholder {
+  color: var(--text-muted);
+}
+
+.text-input--lg {
+  padding: 8px 12px;
+  font-size: 13px;
+  background: var(--bg-secondary);
+}
+
+.text-input--lg:focus {
+  background: var(--bg-primary);
+}
+
+.text-input--mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
 .checkbox-row {
   display: flex;
   align-items: flex-start;

--- a/src/app.css
+++ b/src/app.css
@@ -314,8 +314,11 @@ textarea:focus:not(:focus-visible) {
   background: var(--bg-primary);
   color: var(--text-primary);
   font-size: 12px;
-  outline: none;
   box-sizing: border-box;
+  /* Outline intentionally not zeroed: the global
+     `input:focus:not(:focus-visible)` rule suppresses it for mouse
+     focus, while keyboard focus keeps the visible outline from
+     `:focus-visible` for accessibility. */
   transition:
     border-color 0.15s,
     box-shadow 0.15s,

--- a/src/lib/components/comparison/ComparisonPetPicker.svelte
+++ b/src/lib/components/comparison/ComparisonPetPicker.svelte
@@ -74,7 +74,7 @@ function handlePetClick(pet) {
     <div class="picker-search">
         <input
             type="text"
-            class="search-input"
+            class="text-input"
             placeholder="Search pets..."
             bind:value={searchQuery}
         />
@@ -238,23 +238,6 @@ function handlePetClick(pet) {
 
     .picker-search {
         padding: 0 12px;
-    }
-
-    .search-input {
-        width: 100%;
-        padding: 6px 10px;
-        border: 1px solid var(--border-primary);
-        border-radius: 6px;
-        font-size: 12px;
-        background: var(--bg-primary);
-        color: var(--text-primary);
-        outline: none;
-        box-sizing: border-box;
-    }
-
-    .search-input:focus {
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px var(--accent-soft);
     }
 
     .species-filter-hint {

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -220,7 +220,7 @@ async function installUpdate() {
 
           <div class="setting-row" style="cursor: default;">
             <input
-              class="folder-input"
+              class="text-input text-input--mono"
               type="text"
               placeholder={gameFolderPlaceholder}
               value={gameFolderValue}
@@ -555,22 +555,6 @@ async function installUpdate() {
     border-radius: 8px;
     padding: 12px;
     margin: -4px 0;
-  }
-
-  .folder-input {
-    width: 100%;
-    padding: 6px 10px;
-    border: 1px solid var(--border-secondary);
-    border-radius: 6px;
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    font-size: 12px;
-    font-family: var(--font-mono, monospace);
-    outline: none;
-  }
-
-  .folder-input:focus {
-    border-color: var(--accent);
   }
 
   .progress-bar {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -287,7 +287,7 @@ async function handleDrop(e, dropIndex) {
 <div class="pet-list">
     <div class="pet-list-header">
         <input
-            class="search-input"
+            class="text-input text-input--lg"
             type="text"
             placeholder="Search pets..."
             bind:value={searchQuery}
@@ -498,27 +498,6 @@ async function handleDrop(e, dropIndex) {
         padding: 12px 34px 12px 12px;
         border-bottom: 1px solid var(--border-primary);
         flex-shrink: 0;
-    }
-
-    .search-input {
-        width: 100%;
-        padding: 8px 12px;
-        border: 1px solid var(--border-primary);
-        border-radius: 6px;
-        font-size: 13px;
-        background: var(--bg-secondary);
-        color: var(--text-primary);
-        outline: none;
-        transition: border-color 0.15s;
-    }
-
-    .search-input:focus {
-        border-color: var(--accent);
-        background: var(--bg-primary);
-    }
-
-    .search-input::placeholder {
-        color: var(--text-muted);
     }
 
     .marker-filter {

--- a/tests/e2e/app.spec.js
+++ b/tests/e2e/app.spec.js
@@ -54,7 +54,7 @@ test.describe('Pet List', () => {
   });
 
   test('shows search input and upload button', async ({ page }) => {
-    await expect(page.locator('.search-input')).toBeVisible();
+    await expect(page.locator('.pet-list .text-input')).toBeVisible();
     await expect(page.locator('.upload-btn')).toContainText('Upload Genome');
   });
 
@@ -66,11 +66,11 @@ test.describe('Pet List', () => {
     const before = await page.locator('.pet-card').count();
     expect(before).toBeGreaterThan(0);
 
-    await page.locator('.search-input').fill('zzz-nonexistent');
+    await page.locator('.pet-list .text-input').fill('zzz-nonexistent');
     await expect(page.locator('.pet-card')).toHaveCount(0);
 
     // Clear search restores all
-    await page.locator('.search-input').fill('');
+    await page.locator('.pet-list .text-input').fill('');
     await expect(page.locator('.pet-card')).toHaveCount(before);
   });
 


### PR DESCRIPTION
## Summary

- Adds `.text-input` baseline + `.text-input--lg` / `.text-input--mono` modifiers to `app.css`.
- Replaces the three near-duplicate input styles (`.search-input` in PetList, `.search-input` in ComparisonPetPicker, `.folder-input` in SettingsModal) with the shared classes; local CSS blocks deleted.
- Net change: +50/-60 lines across 5 files.

## Variants

| Class | Size | Background | Use |
| --- | --- | --- | --- |
| `.text-input` | 12px / 6×10 padding | `--bg-primary` | Default (picker search, etc.) |
| `.text-input--lg` | 13px / 8×12 padding | `--bg-secondary`, focus → `--bg-primary` | Prominent search (pet list) |
| `.text-input--mono` | adds system monospace stack | (composes with base) | Path/code inputs (settings) |

Focus is unified: `accent` border + soft accent box-shadow.

## Test plan

- [x] `pnpm test` — 335 unit pass.
- [x] `pnpm test:e2e` — 117/117 pass. Updated `app.spec.js` to use `.pet-list .text-input` instead of the removed `.search-input` selector.
- [x] `pnpm lint:ci` clean.
- [ ] Visual: confirm pet list search, comparison picker, and settings game-folder field still look right in light + dark themes.

Closes #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)