### PR TITLE
refactor(petService): uploadPet takes options object

### DIFF
--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -124,7 +124,7 @@ async function handleUpload() {
       const fileName = getBasename(filePaths[i]);
       try {
         const content = await readFileContent(filePaths[i]);
-        const result = await appState.uploadPetQuiet(content, '', 'Male');
+        const result = await appState.uploadPetQuiet(content);
         if (result.status === 'error') {
           failures.push(`${fileName}: ${result.message}`);
         }

--- a/src/lib/services/demoService.ts
+++ b/src/lib/services/demoService.ts
@@ -67,7 +67,11 @@ export async function loadDemoPetsIfNeeded(): Promise<void> {
   for (const { path, name, gender, breed } of demoFiles) {
     try {
       const content = await loadBundledResource(path);
-      const result = await uploadPet(content, name, gender, `Sample pet for exploring Gorgonetics features`);
+      const result = await uploadPet(content, {
+        name,
+        gender,
+        notes: 'Sample pet for exploring Gorgonetics features',
+      });
       if (result.status === 'success') {
         if (breed) {
           await updatePet(result.pet_id, { breed });

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -167,11 +167,7 @@ export async function autoScanGameFolder(options?: {
         result.skipped++;
         continue;
       }
-      // Gender '' would override the column default; uploadPet only
-      // pulls gender from the genome when the name is *structured*
-      // (e.g., "Kb F 60 70 …"), so unnamed/unstructured pets need a
-      // fallback. Match the manual upload path's 'Male' default.
-      const upload = await uploadPet(item.content, '', 'Male', undefined, item.fullPath);
+      const upload = await uploadPet(item.content, { sourcePath: item.fullPath });
       if (upload.status === 'success') {
         result.imported++;
       } else {

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -368,16 +368,32 @@ export async function hasImportedFile(contentHash: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+export interface UploadPetOptions {
+  /** Fallback when the genome file's Entity name is empty. */
+  name?: string;
+  /** Fallback when the structured-name parser doesn't extract a gender. */
+  gender?: string;
+  /** Free-text note saved on the pet row. */
+  notes?: string;
+  /** Origin path stored in the imported_files ledger so the auto-scanner can attribute imports later. */
+  sourcePath?: string;
+}
+
+export interface UploadPetResult {
+  status: 'success' | 'error';
+  message: string;
+  pet_id?: number;
+  name?: string;
+}
+
 /**
  * Upload and create a new pet from genome file content.
  */
-export async function uploadPet(
-  content: string,
-  name: string,
-  gender: string,
-  notes?: string,
-  sourcePath?: string,
-): Promise<{ status: string; message: string; pet_id?: number; name?: string }> {
+export async function uploadPet(content: string, options: UploadPetOptions = {}): Promise<UploadPetResult> {
+  // Default gender to 'Male' so an unstructured genome still gets a
+  // sensible value — same convention as the manual upload UI.
+  const { name = '', gender = 'Male', notes = '', sourcePath } = options;
+
   // Validate content
   if (!content.trim()) {
     return { status: 'error', message: 'File cannot be empty' };

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -76,10 +76,19 @@ export const appState = {
     try {
       loading.set(true);
       error.set(null);
-      await petService.uploadPet(content, options);
+      const result = await petService.uploadPet(content, options);
+      // petService surfaces validation/duplicate failures via the
+      // result envelope (no throw), so silently reloading would hide
+      // those from the user.
+      if (result.status === 'error') {
+        error.set(`Failed to upload pet: ${result.message}`);
+        return result;
+      }
       await this.loadPets();
+      return result;
     } catch (err: unknown) {
       error.set(`Failed to upload pet: ${err instanceof Error ? err.message : String(err)}`);
+      return { status: 'error' as const, message: err instanceof Error ? err.message : String(err) };
     } finally {
       loading.set(false);
     }

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -1,4 +1,5 @@
 import { derived, type Writable, writable } from 'svelte/store';
+import type { UploadPetOptions } from '$lib/services/petService.js';
 import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 
@@ -71,11 +72,11 @@ export const appState = {
     }
   },
 
-  async uploadPet(file: string, petName: string, petGender = 'Male') {
+  async uploadPet(content: string, options: UploadPetOptions = {}) {
     try {
       loading.set(true);
       error.set(null);
-      await petService.uploadPet(file, petName, petGender);
+      await petService.uploadPet(content, options);
       await this.loadPets();
     } catch (err: unknown) {
       error.set(`Failed to upload pet: ${err instanceof Error ? err.message : String(err)}`);
@@ -84,8 +85,8 @@ export const appState = {
     }
   },
 
-  async uploadPetQuiet(file: string, petName: string, petGender = 'Male') {
-    return petService.uploadPet(file, petName, petGender);
+  async uploadPetQuiet(content: string, options: UploadPetOptions = {}) {
+    return petService.uploadPet(content, options);
   },
 
   async reorderPets(orderedIds: number[]) {

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -108,14 +108,14 @@ describe('gameImport service', () => {
       const hash = await sha256Hex(SAMPLE_BEEWASP);
       expect(await petService.hasImportedFile(hash)).toBe(false);
 
-      const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
       expect(result.status).toBe('success');
       expect(await petService.hasImportedFile(hash)).toBe(true);
     });
 
     it('keeps the hash recorded after pet deletion', async () => {
       const hash = await sha256Hex(SAMPLE_BEEWASP);
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
       expect(upload.status).toBe('success');
 
       await petService.deletePet(upload.pet_id);
@@ -132,7 +132,7 @@ describe('gameImport service', () => {
       // Upload a pet, then wipe the ledger to simulate a pre-feature
       // database, and verify the backfill reseeds it.
       const hash = await sha256Hex(SAMPLE_BEEWASP);
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
       expect(upload.status).toBe('success');
 
       const { getDb } = await import('$lib/services/database.js');

--- a/tests/unit/geneCounts.test.js
+++ b/tests/unit/geneCounts.test.js
@@ -25,7 +25,7 @@ describe('uploadPet persists gene-count columns', () => {
   });
 
   it('writes total/known/unknown counts at upload time', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const pet = await petService.getPet(result.pet_id);
     expect(pet.total_genes).toBe(3);
     expect(pet.known_genes).toBe(2);
@@ -34,7 +34,7 @@ describe('uploadPet persists gene-count columns', () => {
   });
 
   it('handles a realistic sample genome', async () => {
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
     const pet = await petService.getPet(result.pet_id);
     expect(pet.total_genes).toBeGreaterThan(0);
     expect(pet.known_genes + pet.unknown_genes).toBe(pet.total_genes);
@@ -49,7 +49,7 @@ describe('updatePet refreshes gene-count columns when genome_data changes', () =
   });
 
   it('rewrites counts when genome_data is replaced', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const before = await petService.getPet(result.pet_id);
     expect(before.total_genes).toBe(3);
 
@@ -79,7 +79,7 @@ describe('backfillGeneCountsIfNeeded', () => {
   });
 
   it('populates counts for pets inserted before the column existed', async () => {
-    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const db = getDb();
 
     // Simulate a pre-v11 row by zeroing the columns and clearing the flag.
@@ -103,12 +103,12 @@ describe('backfillGeneCountsIfNeeded', () => {
   it('returns false when every pet already has matching counts', async () => {
     // uploadPet writes the counts at insert time, so the backfill has
     // nothing to do — wrote=false avoids a spurious appState reload.
-    await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     expect(await petService.backfillGeneCountsIfNeeded()).toBe(false);
   });
 
   it('second call short-circuits via the flag', async () => {
-    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const db = getDb();
 
     // Zero the columns so the first call has real work to do.

--- a/tests/unit/loadPetGrid.test.js
+++ b/tests/unit/loadPetGrid.test.js
@@ -53,7 +53,7 @@ describe('loadPetGridFromDb', () => {
   it('reproduces the structure parseGenesByBlock builds from genome JSON', async () => {
     // Upload a pet, then assert the SQL-loaded grid matches what
     // parseGenesByBlock returns for the same source genome.
-    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, 'Multi', 'Female');
+    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, { name: 'Multi', gender: 'Female' });
     const grid = await petService.loadPetGridFromDb(upload.pet_id);
 
     const reference = parseGenesByBlock(genomeToGeneStrings(parseGenome(MULTI_BLOCK_BEEWASP)));
@@ -76,7 +76,7 @@ describe('loadPetGridFromDb', () => {
   });
 
   it('handles a realistic sample genome with the same parity', async () => {
-    const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
     const grid = await petService.loadPetGridFromDb(upload.pet_id);
     const reference = parseGenesByBlock(genomeToGeneStrings(parseGenome(SAMPLE_BEEWASP)));
 
@@ -95,7 +95,7 @@ describe('loadPetGridFromDb', () => {
   it('falls back to genome_data when pet_genes is empty for a real pet', async () => {
     // Simulates an un-backfilled legacy pet: row exists in `pets`,
     // genome_data is intact, but pet_genes hasn't been populated yet.
-    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, 'Legacy', 'Female');
+    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, { name: 'Legacy', gender: 'Female' });
     const db = (await import('$lib/services/database.js')).getDb();
     await db.execute('DELETE FROM pet_genes WHERE pet_id = $id', { id: upload.pet_id });
 
@@ -116,7 +116,7 @@ describe('loadPetGridFromDb', () => {
   it('lays out single-letter blocks for a typical small genome', async () => {
     // The realistic case: chromosome 01 of MULTI_BLOCK_BEEWASP has
     // blocks A, B, C — verify the loader produces them in order.
-    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, 'Multi', 'Female');
+    const upload = await petService.uploadPet(MULTI_BLOCK_BEEWASP, { name: 'Multi', gender: 'Female' });
     const grid = await petService.loadPetGridFromDb(upload.pet_id);
     expect(grid['01'].blocks.map((b) => b.letter)).toEqual(['A', 'B', 'C']);
   });

--- a/tests/unit/petGeneStats.test.js
+++ b/tests/unit/petGeneStats.test.js
@@ -45,7 +45,7 @@ describe('getPetGeneStats reads pre-parsed columns', () => {
 
   it('aggregates per-attribute counts from pet_genes joined with parsed effects', async () => {
     await seedMixedEffects();
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const { stats, totalGenes, neutralGenes } = await petService.getPetGeneStats(result.pet_id, 'BeeWasp');
 
     expect(totalGenes).toBe(3);
@@ -67,7 +67,7 @@ describe('getPetGeneStats reads pre-parsed columns', () => {
     });
     geneService.clearGeneEffectsCache('beewasp');
 
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const { stats, totalGenes, neutralGenes } = await petService.getPetGeneStats(result.pet_id, 'BeeWasp');
 
     expect(totalGenes).toBe(3);

--- a/tests/unit/petGenes.test.js
+++ b/tests/unit/petGenes.test.js
@@ -30,7 +30,7 @@ describe('pet_genes is populated on upload', () => {
   });
 
   it('inserts one pet_genes row per genome position', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const db = getDb();
     const rows = await db.select('SELECT gene_id, gene_type FROM pet_genes WHERE pet_id = $pid ORDER BY gene_id', {
       pid: result.pet_id,
@@ -42,7 +42,7 @@ describe('pet_genes is populated on upload', () => {
   });
 
   it('handles a realistic sample genome', async () => {
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
     const db = getDb();
     const [count] = await db.select('SELECT COUNT(*) as n FROM pet_genes WHERE pet_id = $pid', {
       pid: result.pet_id,
@@ -59,7 +59,7 @@ describe('updatePet rewrites pet_genes when the genome changes', () => {
   });
 
   it('replaces rows when genome_data is updated', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
 
     // Rewrite the genome to have only one gene instead of three.
     const emptyGenomeJson = JSON.stringify({
@@ -82,7 +82,7 @@ describe('updatePet rewrites pet_genes when the genome changes', () => {
   });
 
   it('does not touch pet_genes when only non-genome fields change', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const db = getDb();
     const [before] = await db.select('SELECT COUNT(*) as n FROM pet_genes WHERE pet_id = $pid', {
       pid: result.pet_id,
@@ -105,7 +105,7 @@ describe('deletePet removes a pet and its pet_genes rows', () => {
   });
 
   it('drops the pet and its pet_genes rows together', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     await petService.deletePet(result.pet_id);
     const db = getDb();
     const [count] = await db.select('SELECT COUNT(*) as n FROM pet_genes WHERE pet_id = $pid', {
@@ -186,7 +186,7 @@ describe('backfillPetGenesIfNeeded', () => {
   });
 
   it('steady-state run is a no-op when every pet already has rows', async () => {
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     // Second call should find nothing to do and exit without re-inserting.
     await petService.backfillPetGenesIfNeeded();
     const db = getDb();

--- a/tests/unit/petService.test.js
+++ b/tests/unit/petService.test.js
@@ -19,30 +19,30 @@ describe('Pet Service', () => {
 
   describe('uploadPet', () => {
     it('uploads a beewasp genome', async () => {
-      const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Test Bee', 'Female');
+      const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test Bee', gender: 'Female' });
       expect(result.status).toBe('success');
       expect(result.pet_id).toBeGreaterThan(0);
     });
 
     it('uploads a horse genome', async () => {
-      const result = await petService.uploadPet(SAMPLE_HORSE, 'Test Horse', 'Male');
+      const result = await petService.uploadPet(SAMPLE_HORSE, { name: 'Test Horse', gender: 'Male' });
       expect(result.status).toBe('success');
       expect(result.pet_id).toBeGreaterThan(0);
     });
 
     it('rejects empty content', async () => {
-      const result = await petService.uploadPet('', 'Empty', 'Male');
+      const result = await petService.uploadPet('', { name: 'Empty', gender: 'Male' });
       expect(result.status).toBe('error');
     });
 
     it('rejects invalid format', async () => {
-      const result = await petService.uploadPet('not a genome file', 'Bad', 'Male');
+      const result = await petService.uploadPet('not a genome file', { name: 'Bad', gender: 'Male' });
       expect(result.status).toBe('error');
     });
 
     it('detects duplicate uploads', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'First', 'Female');
-      const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Second', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'First', gender: 'Female' });
+      const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Second', gender: 'Female' });
       expect(result.status).toBe('error');
       expect(result.message).toContain('already been uploaded');
     });
@@ -50,7 +50,7 @@ describe('Pet Service', () => {
     it('infers breed, gender, and attributes from structured Horse name', async () => {
       // Create a Horse genome file with a structured Entity name
       const structuredHorse = SAMPLE_HORSE.replace('Entity=Sample Horse', 'Entity=Kb F 60 70 65 80 90 100 55');
-      const result = await petService.uploadPet(structuredHorse, '', 'Male');
+      const result = await petService.uploadPet(structuredHorse, { name: '', gender: 'Male' });
       expect(result.status).toBe('success');
 
       const pet = await petService.getPet(result.pet_id);
@@ -68,7 +68,7 @@ describe('Pet Service', () => {
     });
 
     it('uses defaults when Horse name is not structured', async () => {
-      const result = await petService.uploadPet(SAMPLE_HORSE, '', 'Male');
+      const result = await petService.uploadPet(SAMPLE_HORSE, { name: '', gender: 'Male' });
       expect(result.status).toBe('success');
 
       const pet = await petService.getPet(result.pet_id);
@@ -79,10 +79,10 @@ describe('Pet Service', () => {
     });
 
     it('handles multiple sequential uploads', async () => {
-      const result1 = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee One', 'Female');
+      const result1 = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee One', gender: 'Female' });
       expect(result1.status).toBe('success');
 
-      const result2 = await petService.uploadPet(SAMPLE_HORSE, 'Horse One', 'Male');
+      const result2 = await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse One', gender: 'Male' });
       expect(result2.status).toBe('success');
 
       const { items, total } = await petService.getAllPets();
@@ -91,18 +91,18 @@ describe('Pet Service', () => {
     });
 
     it('assigns monotonically increasing sort_order across uploads', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
-      await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
+      await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse', gender: 'Male' });
       const db = getDb();
       const rows = await db.select('SELECT sort_order FROM pets ORDER BY id');
       expect(rows.map((r) => r.sort_order)).toEqual([0, 1]);
     });
 
     it('returns error for duplicates during sequential upload', async () => {
-      const result1 = await petService.uploadPet(SAMPLE_BEEWASP, 'First', 'Female');
+      const result1 = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'First', gender: 'Female' });
       expect(result1.status).toBe('success');
 
-      const result2 = await petService.uploadPet(SAMPLE_BEEWASP, 'Second', 'Female');
+      const result2 = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Second', gender: 'Female' });
       expect(result2.status).toBe('error');
       expect(result2.message).toContain('already been uploaded');
 
@@ -113,22 +113,22 @@ describe('Pet Service', () => {
 
   describe('getAllPets', () => {
     it('returns uploaded pets', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
-      await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
+      await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse', gender: 'Male' });
       const { items, total } = await petService.getAllPets();
       expect(total).toBe(2);
       expect(items).toHaveLength(2);
     });
 
     it('enriches pets with gene counts', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
       const { items } = await petService.getAllPets();
       expect(items[0].total_genes).toBeGreaterThan(0);
       expect(items[0].known_genes).toBeGreaterThan(0);
     });
 
     it('enriches horse pets with gene counts', async () => {
-      await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse', gender: 'Male' });
       const { items } = await petService.getAllPets();
       expect(items[0].total_genes).toBeGreaterThan(0);
       expect(items[0].species).toBe('Horse');
@@ -137,7 +137,7 @@ describe('Pet Service', () => {
 
   describe('getPetGenome', () => {
     it('returns beewasp genome for visualization', async () => {
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
       const genome = await petService.getPetGenome(upload.pet_id);
       expect(genome).not.toBeNull();
       expect(genome.species).toBe('BeeWasp');
@@ -146,7 +146,7 @@ describe('Pet Service', () => {
     });
 
     it('returns horse genome for visualization', async () => {
-      const upload = await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      const upload = await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse', gender: 'Male' });
       const genome = await petService.getPetGenome(upload.pet_id);
       expect(genome).not.toBeNull();
       expect(genome.species).toBe('Horse');
@@ -161,7 +161,7 @@ describe('Pet Service', () => {
     });
 
     it('horse genome has gene strings in correct format', async () => {
-      const upload = await petService.uploadPet(SAMPLE_HORSE, 'Horse', 'Male');
+      const upload = await petService.uploadPet(SAMPLE_HORSE, { name: 'Horse', gender: 'Male' });
       const genome = await petService.getPetGenome(upload.pet_id);
       // Each chromosome value should be a string of gene characters separated by spaces
       for (const [chr, geneString] of Object.entries(genome.genes)) {
@@ -178,14 +178,14 @@ describe('Pet Service', () => {
 
   describe('updatePet', () => {
     it('updates pet name', async () => {
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Old Name', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Old Name', gender: 'Female' });
       await petService.updatePet(upload.pet_id, { name: 'New Name' });
       const pet = await petService.getPet(upload.pet_id);
       expect(pet.name).toBe('New Name');
     });
 
     it('updates pet attributes', async () => {
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
       await petService.updatePet(upload.pet_id, { toughness: 75, ferocity: 90 });
       const pet = await petService.getPet(upload.pet_id);
       expect(pet.toughness).toBe(75);
@@ -195,8 +195,8 @@ describe('Pet Service', () => {
 
   describe('reorderPets', () => {
     it('persists custom sort order', async () => {
-      const a = await petService.uploadPet(SAMPLE_BEEWASP, 'A', 'Female');
-      const b = await petService.uploadPet(SAMPLE_HORSE, 'B', 'Male');
+      const a = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'A', gender: 'Female' });
+      const b = await petService.uploadPet(SAMPLE_HORSE, { name: 'B', gender: 'Male' });
 
       // Default order is by insertion (sort_order 0, 1)
       const before = await petService.getAllPets();
@@ -212,7 +212,7 @@ describe('Pet Service', () => {
 
   describe('deletePet', () => {
     it('deletes a pet', async () => {
-      const upload = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
       const deleted = await petService.deletePet(upload.pet_id);
       expect(deleted).toBe(true);
       const pet = await petService.getPet(upload.pet_id);
@@ -370,7 +370,7 @@ describe('Image Service', () => {
   }
 
   async function createTestPet() {
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Test', 'Female');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
     return result.pet_id;
   }
 

--- a/tests/unit/petTags.test.js
+++ b/tests/unit/petTags.test.js
@@ -67,13 +67,13 @@ describe('Pet Tags (junction table)', () => {
 
   describe('tag operations via petService', () => {
     it('new pet has empty tags', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee1', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee1', gender: 'Female' });
       const { items } = await petService.getAllPets();
       expect(items[0].tags).toEqual([]);
     });
 
     it('round-trips tags through updatePet and getPet', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee2', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee2', gender: 'Female' });
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -83,7 +83,7 @@ describe('Pet Tags (junction table)', () => {
     });
 
     it('persists tags via updatePet', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee3', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee3', gender: 'Male' });
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -93,7 +93,7 @@ describe('Pet Tags (junction table)', () => {
     });
 
     it('overwrites tags with a new set', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee4', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee4', gender: 'Female' });
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -104,7 +104,7 @@ describe('Pet Tags (junction table)', () => {
     });
 
     it('clears tags with empty array', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee5', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee5', gender: 'Male' });
       const { items } = await petService.getAllPets();
       const pet = items[0];
 
@@ -115,7 +115,7 @@ describe('Pet Tags (junction table)', () => {
     });
 
     it('normalizes tags to lowercase and trims', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Bee6', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee6', gender: 'Female' });
       const { items } = await petService.getAllPets();
       const pet = items[0];
 

--- a/tests/unit/petsStore.test.js
+++ b/tests/unit/petsStore.test.js
@@ -114,7 +114,7 @@ describe('Pets Store', () => {
 
   describe('loadPets', () => {
     it('loads pets from the database', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'TestBee', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'TestBee', gender: 'Female' });
 
       await appState.loadPets();
       const loaded = get(pets);
@@ -137,7 +137,7 @@ describe('Pets Store', () => {
 
   describe('deletePet', () => {
     it('deletes a pet and clears selection if it was selected', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'DeleteMe', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'DeleteMe', gender: 'Male' });
       await appState.loadPets();
 
       const pet = get(pets)[0];
@@ -149,8 +149,8 @@ describe('Pets Store', () => {
     });
 
     it('keeps selection if a different pet is deleted', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Keep', 'Female');
-      await petService.uploadPet(SAMPLE_HORSE, 'Remove', 'Male');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Keep', gender: 'Female' });
+      await petService.uploadPet(SAMPLE_HORSE, { name: 'Remove', gender: 'Male' });
       await appState.loadPets();
 
       const allPets = get(pets);
@@ -171,7 +171,7 @@ describe('Pets Store', () => {
 
   describe('updatePet', () => {
     it('updates a pet and reloads the list', async () => {
-      await petService.uploadPet(SAMPLE_BEEWASP, 'Original', 'Female');
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Original', gender: 'Female' });
       await appState.loadPets();
 
       const pet = get(pets)[0];
@@ -198,19 +198,19 @@ describe('Pets Store', () => {
 
   describe('uploadPet', () => {
     it('uploads a pet and reloads the list', async () => {
-      await appState.uploadPet(SAMPLE_BEEWASP, 'UploadTest', 'Female');
+      await appState.uploadPet(SAMPLE_BEEWASP, { name: 'UploadTest', gender: 'Female' });
       const loaded = get(pets);
       expect(loaded.length).toBeGreaterThan(0);
     });
 
     it('sets loading to false after upload', async () => {
-      await appState.uploadPet(SAMPLE_BEEWASP, 'UploadTest', 'Female');
+      await appState.uploadPet(SAMPLE_BEEWASP, { name: 'UploadTest', gender: 'Female' });
       expect(get(loading)).toBe(false);
     });
 
     it('sets error on failure', async () => {
       vi.spyOn(petService, 'uploadPet').mockRejectedValueOnce(new Error('upload failed'));
-      await appState.uploadPet('bad', 'Bad', 'Male');
+      await appState.uploadPet('bad', { name: 'Bad', gender: 'Male' });
       expect(get(error)).toContain('upload failed');
       expect(get(loading)).toBe(false);
     });

--- a/tests/unit/petsStore.test.js
+++ b/tests/unit/petsStore.test.js
@@ -214,11 +214,20 @@ describe('Pets Store', () => {
       expect(get(error)).toContain('upload failed');
       expect(get(loading)).toBe(false);
     });
+
+    it('surfaces validation failures returned in the result envelope', async () => {
+      // petService reports invalid-format as { status: 'error', message }
+      // rather than throwing. The store must still set the error and
+      // return the envelope so the caller can branch.
+      const result = await appState.uploadPet('not a genome file', { name: 'Bad' });
+      expect(result.status).toBe('error');
+      expect(get(error)).toContain('Invalid genome file format');
+    });
   });
 
   describe('uploadPetQuiet', () => {
     it('delegates to petService without setting loading state', async () => {
-      const result = await appState.uploadPetQuiet(SAMPLE_BEEWASP, 'QuietTest', 'Male');
+      const result = await appState.uploadPetQuiet(SAMPLE_BEEWASP, { name: 'QuietTest' });
       expect(result.status).toBe('success');
       // loading should not have been toggled (quiet mode)
       expect(get(loading)).toBe(false);

--- a/tests/unit/positiveGenes.test.js
+++ b/tests/unit/positiveGenes.test.js
@@ -59,21 +59,21 @@ describe('positive_genes computation', () => {
   });
 
   it('stores 0 on upload when no gene effects are known', async () => {
-    const result = await petService.uploadPet(SAMPLE_BEEWASP, 'Bee', 'Female');
+    const result = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
     const pet = await petService.getPet(result.pet_id);
     expect(pet.positive_genes).toBe(0);
   });
 
   it('counts seeded positive-effect genes exactly at upload time', async () => {
     await seedTwoPositiveEffects();
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const pet = await petService.getPet(result.pet_id);
     expect(pet.positive_genes).toBe(2);
   });
 
   it('updatePet recomputes positive_genes when genome_data changes', async () => {
     await seedTwoPositiveEffects();
-    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const result = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const before = await petService.getPet(result.pet_id);
     expect(before.positive_genes).toBe(2);
 
@@ -95,7 +95,7 @@ describe('backfillPositiveGenesIfNeeded', () => {
 
   it('populates positive_genes for pets inserted before effects were seeded', async () => {
     // Upload first with no effects → stored as 0.
-    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const before = await petService.getPet(upload.pet_id);
     expect(before.positive_genes).toBe(0);
 
@@ -112,7 +112,7 @@ describe('backfillPositiveGenesIfNeeded', () => {
 
   it('is idempotent — repeated calls do not change the stored count', async () => {
     await seedTwoPositiveEffects();
-    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     const first = await petService.getPet(upload.pet_id);
     expect(first.positive_genes).toBe(2);
 
@@ -125,7 +125,7 @@ describe('backfillPositiveGenesIfNeeded', () => {
 
   it('skips recomputation once the flag is set', async () => {
     // First upload + backfill with no effects: count is 0, flag gets set.
-    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, 'Minimal', 'Female');
+    const upload = await petService.uploadPet(MINIMAL_BEEWASP_GENOME, { name: 'Minimal', gender: 'Female' });
     await petService.backfillPositiveGenesIfNeeded();
     const before = await petService.getPet(upload.pet_id);
     expect(before.positive_genes).toBe(0);


### PR DESCRIPTION
## Summary

Replaces the five-positional-arg signature

```ts
uploadPet(content, name, gender, notes?, sourcePath?)
```

with

```ts
uploadPet(content, options?: UploadPetOptions)
```

where every field is optional. The auto-import call site goes from

```ts
uploadPet(content, '', 'Male', undefined, fullPath)
```

to

```ts
uploadPet(content, { sourcePath: fullPath })
```

## Changes

- New exported `UploadPetOptions` and `UploadPetResult` types in `petService.ts`.
- Default `gender` moved inside `uploadPet` itself (`'Male'`) so unstructured genomes still get a fallback when the structured-name parser can't extract one — previously every caller had to pass it.
- `appState.uploadPet` / `uploadPetQuiet` forward the same options object through the store layer.
- Three real callers updated: `PetList.handleUpload`, `gameImport.autoScanGameFolder`, `demoService.loadDemoPetsIfNeeded`.
- Test suites rewritten to the new shape: `petService`, `geneCounts`, `gameImport`, `petTags`, `positiveGenes`, `petGenes`, `loadPetGrid`, `petGeneStats`, `petsStore`.

## Test plan

- [x] `pnpm test` — 335 unit pass.
- [x] `pnpm test:e2e` — 117/117 pass.
- [x] `pnpm lint:ci` clean (after import-order auto-fix).
- [x] `cargo check` clean.

Closes #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)