### PR TITLE
feat(breeding): Mendelian genetics utility (PR 1/5)

### DIFF
--- a/docs/design/breeding-assistant-v1.md
+++ b/docs/design/breeding-assistant-v1.md
@@ -1,0 +1,213 @@
+# Breeding Assistant — v1 Implementation Plan
+
+**Status:** Design — not yet implemented
+**Scope source:** `Project: Gorgonetics` Logseq page, section `2026-05-03: Breeding Assistant v1 — Scope`
+**Target:** A new **Breeding** tab that ranks all eligible parent pairs (M × F, same species, both stabled) by expected offspring quality, with two complementary objectives: maximise positive-effect attribute genes; minimise mixed (`x`) genes.
+
+---
+
+## 1. Genetics model (reference)
+
+| P1 × P2 | P(D) | P(x) | P(R) |
+|---|---|---|---|
+| D × D | 1 | 0 | 0 |
+| D × R | 0 | 1 | 0 |
+| D × x | ½ | ½ | 0 |
+| R × R | 0 | 0 | 1 |
+| R × x | 0 | ½ | ½ |
+| x × x | ¼ | ½ | ¼ |
+
+If either parent's allele at a locus is `?`, the offspring's allele at that locus is `?` (contributes 0 to EV[positive] and EV[mixed]; counted in EV[unknown]).
+
+Expression follows the existing `getPetGeneStats` rule: `R` expresses recessive effect; `D` and `x` express dominant effect.
+
+## 2. Per-pair output
+
+```ts
+interface BreedingPairResult {
+  male: Pet;
+  female: Pet;
+  // Pure predictability — counted across every locus the parents share
+  // (attribute + appearance + selector). Range [0, totalLoci].
+  evMixed: number;
+  // Expected positive-effect attribute genes broken down per attribute
+  // (intelligence, toughness, ruggedness, enthusiasm, friendliness,
+  // virility, plus species-specific temperament/ferocity).
+  evPositiveByAttribute: Record<string, number>;
+  // Convenience sum over attributes (sortable single column).
+  evPositiveTotal: number;
+  // Loci where either parent's gene type is `?`.
+  evUnknown: number;
+  // Loci compared (excludes breed-locked-to-other-breed for horse).
+  totalLoci: number;
+}
+```
+
+## 3. Data sources reused
+
+- `pet_genes` projection (one row per gene) — already populated for every pet via the existing backfill. No genome JSON parsing on the hot path.
+- `getParsedGenesCached(species)` — `gene_id → { dominantAttribute, dominantSign, recessiveAttribute, recessiveSign, breed }`.
+- `isHorseBreedFiltered(species, offspringBreed, geneBreed)` — already in `geneService.ts`. Re-used to skip breed-locked horse genes when scoring against the player-selected offspring breed.
+- `getAllAttributeNames(species)` — for per-attribute EV table columns.
+
+## 4. New module surface
+
+### `src/lib/utils/breedingGenetics.ts` (pure math, no I/O)
+```ts
+export interface AlleleDistribution { D: number; x: number; R: number; unknown: number; }
+
+/** Combine parent gene types into the offspring allele distribution. */
+export function offspringDistribution(p1: GeneType, p2: GeneType): AlleleDistribution;
+
+/** P(offspring expresses a positive effect at this locus), given the gene record. */
+export function positiveExpressionProbability(
+  dist: AlleleDistribution,
+  gene: ParsedGeneRecord,
+): number;
+```
+
+### `src/lib/services/breedingService.ts` (DB-aware)
+```ts
+export async function rankBreedingPairs(opts: {
+  species: string;
+  offspringBreed?: string;
+  pets: Pet[];          // pre-filtered: same species, stabled
+}): Promise<BreedingPairResult[]>;
+```
+- Loads `pet_genes` for the union of input pets in one query.
+- Loads `getParsedGenesCached(species)` once.
+- For each (M, F) pair, walks the union of gene_ids, applies `offspringDistribution`, and accumulates the three EVs.
+
+### `src/lib/stores/breeding.svelte.ts`
+- `offspringBreed` (state)
+- `eligiblePets` (derived from `pets` store: same species, stabled, filter by gender)
+- `pairResults` (async derived)
+- `sortColumn`, `sortDir`
+
+### Components (`src/lib/components/breeding/`)
+- `BreedingTab.svelte` — top-level layout with breed selector + results table.
+- `BreedingBreedSelector.svelte` — global offspring-breed dropdown (horse only; hidden for beewasp).
+- `BreedingPairTable.svelte` — sortable rows: male, female, EV[mixed], EV[positive] per attribute, EV[unknown].
+- `BreedingPairRow.svelte` — one row, links into `selectPet` for either parent.
+
+### TopBar / routing
+- Add `'breeding'` to the `Tab` union in `src/lib/stores/pets.ts`.
+- Add tab button in `TopBar.svelte` (between Stable and Compare, e.g. `🧬 Breed`).
+- Mount `BreedingTab` in `MasterPanel.svelte` / `+page.svelte` when `activeTab === 'breeding'`.
+
+## 5. Refactor opportunity (shared with Pet Comparison)
+
+Both features need: "iterate the union of two pets' loci, with their gene types side-by-side". Today `comparisonService.diffGenomes` parses genome JSON; breeding will read `pet_genes`. Plan:
+
+- Extract `loadPetLoci(petId): Promise<Map<gene_id, GeneType>>` from `pet_genes` (cheap, indexed read).
+- Extract `walkPairLoci(a, b, fn)` helper that yields `(geneId, typeA, typeB)` for the union.
+
+The comparison service can migrate onto this projection in a follow-up — not blocking for v1.
+
+## 6. Tests
+
+### Unit
+- `tests/unit/breedingGenetics.test.js` — exhaustive coverage of the 6 (×2 symmetry) Mendelian combinations; unknown handling on either side; positive-expression probability for each attribute-sign combination.
+- `tests/unit/breedingService.test.js` — seed in-memory DB with known gene effects + 2 male + 2 female pets; verify EVs against hand-computed expected values; verify breed-locked filtering.
+
+### Performance
+- `tests/unit/breedingService.perf.test.js` (PR 2) — synthesise the worst-case input (15 male + 15 female horses, ~1500 loci each = 225 pairs × ~1500 loci ≈ 340 k locus-comparisons) and assert `rankBreedingPairs` completes under a generous budget (e.g. 500 ms in CI). Goal is a **regression alarm**, not a tight bound — if a future change blows past it, we know to investigate. If the v1 implementation already fails this budget, that's the signal to apply gene pruning, bit-array encoding of the genome, or pre-aggregation; do **not** pre-optimise before measuring.
+
+### E2E
+- `tests/e2e/breeding.spec.js` — open Breeding tab, change offspring breed, sort by Toughness column, click into a parent.
+
+## 7. Out of scope (v1 → v2)
+
+- "Find best partner for selected pet" (one-sided ranking).
+- Bottleneck hint per pair (chromosome/gene that drags score down).
+- Multi-generation planning.
+- Persisting suggested pairs / favourites.
+- Pareto-front display / weighted composite score.
+- Breed-feasibility warnings (depends on selector-gene mechanics).
+- Selector-gene modelling (folded into future "genetic studies" feature).
+
+---
+
+## 8. PR breakdown
+
+Five PRs, each independently reviewable and mergeable. Earlier PRs are pure or hidden behind a feature path that does not yet appear in the UI, so they cannot break user flows on their own.
+
+### PR 1 — Pure genetics utility + types
+**Files**
+- `src/lib/types/index.ts` — add `AlleleDistribution`, `BreedingPairResult`.
+- `src/lib/utils/breedingGenetics.ts` — `offspringDistribution`, `positiveExpressionProbability`.
+- `tests/unit/breedingGenetics.test.js`.
+
+**Reviewer focus:** correctness of the Mendelian table; symmetry; unknown handling; sign/expression rules match `getPetGeneStats`.
+
+**Size:** ~200 LOC + tests. No UI.
+
+---
+
+### PR 2 — Breeding service layer
+**Files**
+- `src/lib/services/breedingService.ts` — `rankBreedingPairs`.
+- `tests/unit/breedingService.test.js` — seed gene effects + pets in in-memory DB, hand-verify EVs.
+
+**Depends on:** PR 1.
+
+**Reviewer focus:** correct use of `pet_genes` projection (no genome JSON parse); breed-locked filtering via `isHorseBreedFiltered`; n×m loop is O(pairs × loci) and stays well under the 225-pair worst case.
+
+**Size:** ~250 LOC + tests. Still no UI.
+
+---
+
+### PR 3 — Tab scaffold + store (no scoring UI yet)
+**Files**
+- `src/lib/stores/pets.ts` — extend `Tab` union with `'breeding'`.
+- `src/lib/stores/breeding.svelte.ts` — new store.
+- `src/lib/components/layout/TopBar.svelte` — new tab button.
+- `src/lib/components/breeding/BreedingTab.svelte` — minimal placeholder ("Breeding assistant — N eligible pets").
+- Routing wiring in `MasterPanel.svelte` / `+page.svelte`.
+- Test: `tests/e2e/breeding.spec.js` — clicking the tab activates the placeholder.
+
+**Depends on:** none functionally (PR 2 not strictly required for the placeholder), but ordering after PR 2 keeps the tab from landing empty in `main`.
+
+**Reviewer focus:** tab plumbing matches existing tabs (Stable/Compare); store does not load anything heavy on mount; layout doesn't regress other tabs.
+
+**Size:** ~150 LOC. Tiny.
+
+---
+
+### PR 4 — Breeding ranking UI
+**Files**
+- `src/lib/components/breeding/BreedingBreedSelector.svelte`.
+- `src/lib/components/breeding/BreedingPairTable.svelte`.
+- `src/lib/components/breeding/BreedingPairRow.svelte`.
+- `BreedingTab.svelte` — wire selector + table to the store and `rankBreedingPairs`.
+- E2E: extend `tests/e2e/breeding.spec.js` to cover sorting by a column and changing the offspring breed.
+
+**Depends on:** PR 1, 2, 3.
+
+**Reviewer focus:** sort interaction; breed selector hidden for non-horse species; empty/single-gender states; performance on the 15×15 worst case (should be instant).
+
+**Size:** ~400 LOC + tests. The biggest PR — most of the user-visible surface.
+
+---
+
+### PR 5 — (Optional) Shared two-pet locus walker
+**Files**
+- `src/lib/utils/petLoci.ts` — `loadPetLoci`, `walkPairLoci`.
+- Migrate `breedingService.ts` and `comparisonService.diffGenomes` onto it.
+- Update existing comparison tests + add tests for the new utility.
+
+**Depends on:** PR 1–4 merged. Pure refactor, no behavioural change.
+
+**Reviewer focus:** the comparison test suite still passes unchanged; no perf regression on the comparison hot path.
+
+**Size:** ~200 LOC net (mostly code movement).
+
+**Decision point:** can be skipped if the duplication is judged trivial after PR 4 lands. Listed last so v1 ships without it.
+
+---
+
+## 9. Open questions deferred to implementation time
+
+- Whether PR 5 is worth doing standalone, or rolled into PR 2 ("build it shared from the start"). Lean toward standalone — keeps PR 2 focused on breeding semantics; comparison-side migration can land separately.
+- Whether the offspring-breed selector should default to "Mixed" or to the most common breed in the eligible pet set. (Lean: "Mixed", as it has no breed-locked filtering and surfaces the most pairs.)
+- Whether pairs with `evUnknown == totalLoci` should be hidden by default. (Lean: no — surface them with the count visible; let the player filter.)

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -234,6 +234,37 @@ export interface PetGenomeVisualization {
   chromosomes: Record<string, VisualizationGene[]>;
 }
 
+// --- Breeding types ---
+
+/**
+ * Probability distribution over the four possible offspring gene types
+ * at a single locus. `D + x + R + unknown == 1` for any non-degenerate
+ * distribution. `unknown` carries the mass when at least one parent's
+ * allele is `?` — see `offspringDistribution` in `utils/breedingGenetics`.
+ */
+export interface AlleleDistribution {
+  D: number;
+  x: number;
+  R: number;
+  unknown: number;
+}
+
+/**
+ * Per-pair scoring output for the Breeding Assistant. `evMixed` covers
+ * every locus the parents share (attribute + appearance + selector) and
+ * is the predictability metric; `evPositiveByAttribute` is attribute-only
+ * and broken down per attribute so the breeder can sort to target one.
+ */
+export interface BreedingPairResult {
+  male: Pet;
+  female: Pet;
+  evMixed: number;
+  evPositiveByAttribute: Record<string, number>;
+  evPositiveTotal: number;
+  evUnknown: number;
+  totalLoci: number;
+}
+
 // --- Comparison types ---
 
 export interface AttributeComparisonResult {

--- a/src/lib/utils/breedingGenetics.ts
+++ b/src/lib/utils/breedingGenetics.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure Mendelian-genetics math for the Breeding Assistant.
+ *
+ * No I/O, no Svelte, no DB access. Each function operates on a single
+ * locus; the breeding service composes them across all loci of a pair.
+ *
+ * Allele convention (matches `GeneType` and the existing `getPetGeneStats`):
+ *   - `D` homozygous dominant — passes D
+ *   - `R` homozygous recessive — passes R
+ *   - `x` mixed (heterozygous) — passes D 50%, R 50%
+ *   - `?` unknown — offspring's allele at this locus is unknowable
+ *
+ * Expression: `D` and `x` express the dominant effect; `R` expresses the
+ * recessive effect.
+ */
+
+import type { AlleleDistribution } from '$lib/types/index.js';
+import { GeneType } from '$lib/types/index.js';
+
+/**
+ * Minimal parsed-gene shape this module needs. Defined locally to keep
+ * the genetics utility independent of the service layer; structurally
+ * compatible with `ParsedGeneRecord` from `geneService`.
+ */
+export interface GeneSignSummary {
+  dominantSign: '+' | '-' | null;
+  recessiveSign: '+' | '-' | null;
+}
+
+/**
+ * Combination table for the six known-allele parent pairs (canonical
+ * order D > x > R). Each entry is read-only; callers receive a fresh
+ * object so accumulation/mutation downstream is safe.
+ */
+const COMBINATIONS: Readonly<Record<string, AlleleDistribution>> = Object.freeze({
+  'D|D': { D: 1, x: 0, R: 0, unknown: 0 },
+  'D|x': { D: 0.5, x: 0.5, R: 0, unknown: 0 },
+  'D|R': { D: 0, x: 1, R: 0, unknown: 0 },
+  'x|x': { D: 0.25, x: 0.5, R: 0.25, unknown: 0 },
+  'x|R': { D: 0, x: 0.5, R: 0.5, unknown: 0 },
+  'R|R': { D: 0, x: 0, R: 1, unknown: 0 },
+});
+
+const RANK: Record<string, number> = {
+  [GeneType.DOMINANT]: 0,
+  [GeneType.MIXED]: 1,
+  [GeneType.RECESSIVE]: 2,
+};
+
+function canonicalKey(p1: GeneType, p2: GeneType): string {
+  return RANK[p1] <= RANK[p2] ? `${p1}|${p2}` : `${p2}|${p1}`;
+}
+
+/**
+ * Distribution of offspring gene types given two parent gene types.
+ *
+ * If either parent is `?`, the offspring's allele at this locus is
+ * unknowable — all probability mass lands in `unknown`.
+ */
+export function offspringDistribution(p1: GeneType, p2: GeneType): AlleleDistribution {
+  if (p1 === GeneType.UNKNOWN || p2 === GeneType.UNKNOWN) return { D: 0, x: 0, R: 0, unknown: 1 };
+  const entry = COMBINATIONS[canonicalKey(p1, p2)];
+  return entry ? { ...entry } : { D: 0, x: 0, R: 0, unknown: 1 };
+}
+
+/**
+ * Probability the offspring expresses a positive-effect attribute at
+ * this locus. `D` and `x` mass count toward the dominant sign; `R` mass
+ * counts toward the recessive sign. Unknown mass contributes 0 by
+ * construction. Returns 0 for genes with no positive sign or for an
+ * undefined gene record (caller has no entry for this gene_id).
+ */
+export function positiveExpressionProbability(dist: AlleleDistribution, gene: GeneSignSummary | undefined): number {
+  if (!gene) return 0;
+  let p = 0;
+  if (gene.dominantSign === '+') p += dist.D + dist.x;
+  if (gene.recessiveSign === '+') p += dist.R;
+  return p;
+}

--- a/src/lib/utils/breedingGenetics.ts
+++ b/src/lib/utils/breedingGenetics.ts
@@ -29,16 +29,18 @@ export interface GeneSignSummary {
 
 /**
  * Combination table for the six known-allele parent pairs (canonical
- * order D > x > R). Each entry is read-only; callers receive a fresh
- * object so accumulation/mutation downstream is safe.
+ * order D > x > R). Each entry is deep-frozen so a caller reaching
+ * through the table directly cannot corrupt shared state; callers of
+ * `offspringDistribution` always receive a fresh object via spread, so
+ * downstream accumulation/mutation stays safe regardless.
  */
-const COMBINATIONS: Readonly<Record<string, AlleleDistribution>> = Object.freeze({
-  'D|D': { D: 1, x: 0, R: 0, unknown: 0 },
-  'D|x': { D: 0.5, x: 0.5, R: 0, unknown: 0 },
-  'D|R': { D: 0, x: 1, R: 0, unknown: 0 },
-  'x|x': { D: 0.25, x: 0.5, R: 0.25, unknown: 0 },
-  'x|R': { D: 0, x: 0.5, R: 0.5, unknown: 0 },
-  'R|R': { D: 0, x: 0, R: 1, unknown: 0 },
+const COMBINATIONS: Readonly<Record<string, Readonly<AlleleDistribution>>> = Object.freeze({
+  'D|D': Object.freeze({ D: 1, x: 0, R: 0, unknown: 0 }),
+  'D|x': Object.freeze({ D: 0.5, x: 0.5, R: 0, unknown: 0 }),
+  'D|R': Object.freeze({ D: 0, x: 1, R: 0, unknown: 0 }),
+  'x|x': Object.freeze({ D: 0.25, x: 0.5, R: 0.25, unknown: 0 }),
+  'x|R': Object.freeze({ D: 0, x: 0.5, R: 0.5, unknown: 0 }),
+  'R|R': Object.freeze({ D: 0, x: 0, R: 1, unknown: 0 }),
 });
 
 const RANK: Record<string, number> = {

--- a/tests/unit/breedingGenetics.test.js
+++ b/tests/unit/breedingGenetics.test.js
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { offspringDistribution, positiveExpressionProbability } from '$lib/utils/breedingGenetics.js';
+
+const KNOWN_TYPES = ['D', 'R', 'x'];
+const ALL_TYPES = [...KNOWN_TYPES, '?'];
+
+describe('offspringDistribution', () => {
+  it.each([
+    ['D', 'D', { D: 1, x: 0, R: 0, unknown: 0 }],
+    ['R', 'R', { D: 0, x: 0, R: 1, unknown: 0 }],
+    ['D', 'R', { D: 0, x: 1, R: 0, unknown: 0 }],
+    ['D', 'x', { D: 0.5, x: 0.5, R: 0, unknown: 0 }],
+    ['R', 'x', { D: 0, x: 0.5, R: 0.5, unknown: 0 }],
+    ['x', 'x', { D: 0.25, x: 0.5, R: 0.25, unknown: 0 }],
+  ])('%s × %s yields the canonical Mendelian distribution', (a, b, expected) => {
+    expect(offspringDistribution(a, b)).toEqual(expected);
+  });
+
+  it('is symmetric in its parents', () => {
+    for (const a of KNOWN_TYPES) {
+      for (const b of KNOWN_TYPES) {
+        expect(offspringDistribution(a, b)).toEqual(offspringDistribution(b, a));
+      }
+    }
+  });
+
+  it('yields a full-unknown distribution whenever either parent is `?`', () => {
+    const expected = { D: 0, x: 0, R: 0, unknown: 1 };
+    for (const t of ALL_TYPES) {
+      expect(offspringDistribution('?', t)).toEqual(expected);
+      expect(offspringDistribution(t, '?')).toEqual(expected);
+    }
+  });
+
+  it('returns a fresh object on every call (mutation does not leak across calls)', () => {
+    const first = offspringDistribution('D', 'D');
+    first.D = 999;
+    const second = offspringDistribution('D', 'D');
+    expect(second.D).toBe(1);
+  });
+
+  it('always sums to 1', () => {
+    for (const a of ALL_TYPES) {
+      for (const b of ALL_TYPES) {
+        const d = offspringDistribution(a, b);
+        expect(d.D + d.x + d.R + d.unknown).toBeCloseTo(1, 10);
+      }
+    }
+  });
+});
+
+describe('positiveExpressionProbability', () => {
+  const positiveDominant = { dominantSign: '+', recessiveSign: null };
+  const positiveRecessive = { dominantSign: null, recessiveSign: '+' };
+  const negativeDominant = { dominantSign: '-', recessiveSign: null };
+  const bothPositive = { dominantSign: '+', recessiveSign: '+' };
+  const bothNegative = { dominantSign: '-', recessiveSign: '-' };
+
+  it('returns 0 when no gene record is provided', () => {
+    expect(positiveExpressionProbability(offspringDistribution('D', 'D'), undefined)).toBe(0);
+  });
+
+  it('returns 0 for a gene with neither sign positive', () => {
+    expect(positiveExpressionProbability(offspringDistribution('D', 'D'), bothNegative)).toBe(0);
+    expect(positiveExpressionProbability(offspringDistribution('R', 'R'), bothNegative)).toBe(0);
+    expect(positiveExpressionProbability(offspringDistribution('x', 'x'), bothNegative)).toBe(0);
+  });
+
+  it('counts D + x mass when only the dominant sign is positive', () => {
+    // DD: D=1 → P=1
+    expect(positiveExpressionProbability(offspringDistribution('D', 'D'), positiveDominant)).toBe(1);
+    // DR: x=1 → P=1
+    expect(positiveExpressionProbability(offspringDistribution('D', 'R'), positiveDominant)).toBe(1);
+    // RR: R=1 → P=0
+    expect(positiveExpressionProbability(offspringDistribution('R', 'R'), positiveDominant)).toBe(0);
+    // Dx: D=.5 x=.5 → P=1
+    expect(positiveExpressionProbability(offspringDistribution('D', 'x'), positiveDominant)).toBe(1);
+    // Rx: x=.5 R=.5 → P=.5
+    expect(positiveExpressionProbability(offspringDistribution('R', 'x'), positiveDominant)).toBe(0.5);
+    // xx: D=.25 x=.5 R=.25 → P=.75
+    expect(positiveExpressionProbability(offspringDistribution('x', 'x'), positiveDominant)).toBeCloseTo(0.75, 10);
+  });
+
+  it('counts only R mass when only the recessive sign is positive', () => {
+    expect(positiveExpressionProbability(offspringDistribution('R', 'R'), positiveRecessive)).toBe(1);
+    expect(positiveExpressionProbability(offspringDistribution('D', 'D'), positiveRecessive)).toBe(0);
+    expect(positiveExpressionProbability(offspringDistribution('D', 'R'), positiveRecessive)).toBe(0);
+    expect(positiveExpressionProbability(offspringDistribution('R', 'x'), positiveRecessive)).toBe(0.5);
+    expect(positiveExpressionProbability(offspringDistribution('x', 'x'), positiveRecessive)).toBeCloseTo(0.25, 10);
+  });
+
+  it('sums both contributions when both signs are positive', () => {
+    // Every known-allele case should give P = 1 - unknown.
+    for (const a of KNOWN_TYPES) {
+      for (const b of KNOWN_TYPES) {
+        const dist = offspringDistribution(a, b);
+        expect(positiveExpressionProbability(dist, bothPositive)).toBeCloseTo(1, 10);
+      }
+    }
+  });
+
+  it('contributes 0 when either parent is unknown, regardless of sign', () => {
+    const dist = offspringDistribution('?', 'D');
+    expect(positiveExpressionProbability(dist, positiveDominant)).toBe(0);
+    expect(positiveExpressionProbability(dist, positiveRecessive)).toBe(0);
+    expect(positiveExpressionProbability(dist, bothPositive)).toBe(0);
+  });
+
+  it('ignores negative dominant signs (they do not subtract from positive)', () => {
+    // negativeDominant has dominantSign === '-', not '+', so it returns 0.
+    expect(positiveExpressionProbability(offspringDistribution('D', 'D'), negativeDominant)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the **Breeding Assistant** feature — a pure, I/O-free per-locus utility plus the v1 design note that frames the remaining four PRs.

The full design and PR breakdown live in `docs/design/breeding-assistant-v1.md`. This PR lands:

- `src/lib/utils/breedingGenetics.ts` — `offspringDistribution(p1, p2)` (Mendelian D/R/x/? table) and `positiveExpressionProbability(dist, gene)` (D+x mass for dominant `+`, R mass for recessive `+`; unknown loci contribute 0 by construction).
- `src/lib/types/index.ts` — adds `AlleleDistribution` and `BreedingPairResult` interfaces.
- `tests/unit/breedingGenetics.test.js` — 17 tests: full 6-cell Mendelian table, parent symmetry, unknown propagation on either side, fresh-object contract, sum-to-1 invariant, all positive/negative sign combinations.

No UI surface; safe to land independently of the rest of the feature.

## Notes for the reviewer

- Genetics rules (per scoping discussion): expression follows the existing `getPetGeneStats` convention — `D` and `x` express the dominant effect, `R` expresses the recessive effect.
- `?` in either parent → `?` for offspring at that locus. Tracked separately via `AlleleDistribution.unknown`; contributes 0 to both EV[positive] and EV[mixed] in the downstream service.
- `GeneSignSummary` is defined locally rather than imported from `geneService` so the utility stays independent of the service layer (matches the `geneAnalysis.ts` convention).
- Performance concern about the horse-genome scale (~1500 loci × 225 pairs = ~340k invocations) is acknowledged. A regression test will land alongside the breeding service in PR 2; if that test reveals a real cost, the `{...entry}` spread or string-concat key are the obvious levers — not pre-optimised here.

## Follow-up PRs

| # | Surface |
|---|---|
| 2 | `breedingService.ts` (DB-aware composer) + perf-regression test |
| 3 | Tab scaffold + store (placeholder UI) |
| 4 | Ranking UI (breed selector + sortable pair table) |
| 5 | (optional) Shared two-pet locus walker, refactored from comparison |

## Test plan

- [x] `vitest run tests/unit/breedingGenetics.test.js` — 17/17 pass
- [x] full unit suite — 358/358 pass (no regressions)
- [x] `biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)