### PR TITLE
feat(breeding): scoring service + perf regression test (PR 2/5)

### DIFF
--- a/src/lib/services/breedingService.ts
+++ b/src/lib/services/breedingService.ts
@@ -11,7 +11,7 @@
  */
 
 import type { AlleleDistribution, BreedingPairResult, GeneType, Pet } from '$lib/types/index.js';
-import { GeneType as GT } from '$lib/types/index.js';
+import { Gender, GeneType as GT } from '$lib/types/index.js';
 import { offspringDistribution } from '$lib/utils/breedingGenetics.js';
 import { capitalize } from '$lib/utils/string.js';
 import { getAllAttributeNames, normalizeSpecies } from './configService.js';
@@ -137,8 +137,7 @@ function scorePair(
     evMixed += dist.x;
     evUnknown += dist.unknown;
     totalLoci++;
-    // Distribution is full-unknown when one parent is `?`, so the
-    // positive-expression probability is 0 — no attribute contribution.
+    // One parent unknown → distribution is full-unknown, P(positive) = 0.
   }
 
   return { male, female, evMixed, evPositiveByAttribute, evPositiveTotal, evUnknown, totalLoci };
@@ -151,8 +150,8 @@ function scorePair(
  * the player picks.
  */
 export async function rankBreedingPairs(opts: RankBreedingPairsOptions): Promise<BreedingPairResult[]> {
-  const males = opts.pets.filter((p) => p.gender === 'Male');
-  const females = opts.pets.filter((p) => p.gender === 'Female');
+  const males = opts.pets.filter((p) => p.gender === Gender.MALE);
+  const females = opts.pets.filter((p) => p.gender === Gender.FEMALE);
   if (males.length === 0 || females.length === 0) return [];
 
   const species = normalizeSpecies(opts.species);

--- a/src/lib/services/breedingService.ts
+++ b/src/lib/services/breedingService.ts
@@ -1,9 +1,11 @@
 /**
  * Breeding Assistant scoring engine.
  *
- * Composes the per-locus genetics primitives (`offspringDistribution`,
- * `positiveExpressionProbability`) across every (Male × Female) pair in
- * the input set, returning per-pair EVs the UI can sort and present.
+ * Composes the per-locus `offspringDistribution` primitive across every
+ * (Male × Female) pair in the input set. The per-attribute positive
+ * accumulation is done inline rather than via `positiveExpressionProbability`
+ * because the UI needs the contribution split *per attribute*, not the
+ * single aggregate probability that helper returns.
  *
  * Reads from the pre-projected `pet_genes` table — no genome JSON parse
  * on the hot path — and from the cached parsed-effect columns on the

--- a/src/lib/services/breedingService.ts
+++ b/src/lib/services/breedingService.ts
@@ -1,0 +1,175 @@
+/**
+ * Breeding Assistant scoring engine.
+ *
+ * Composes the per-locus genetics primitives (`offspringDistribution`,
+ * `positiveExpressionProbability`) across every (Male × Female) pair in
+ * the input set, returning per-pair EVs the UI can sort and present.
+ *
+ * Reads from the pre-projected `pet_genes` table — no genome JSON parse
+ * on the hot path — and from the cached parsed-effect columns on the
+ * `genes` table.
+ */
+
+import type { AlleleDistribution, BreedingPairResult, GeneType, Pet } from '$lib/types/index.js';
+import { GeneType as GT } from '$lib/types/index.js';
+import { offspringDistribution } from '$lib/utils/breedingGenetics.js';
+import { capitalize } from '$lib/utils/string.js';
+import { getAllAttributeNames, normalizeSpecies } from './configService.js';
+import { getDb } from './database.js';
+import { getParsedGenesCached, isHorseBreedFiltered, type ParsedGeneRecord } from './geneService.js';
+
+export interface RankBreedingPairsOptions {
+  /** Canonical or display species — passed through `normalizeSpecies`. */
+  species: string;
+  /**
+   * Player-selected offspring breed. For horses, drives `isHorseBreedFiltered`
+   * to skip breed-locked-to-other-breed loci. Optional / ignored for
+   * species without breeds.
+   */
+  offspringBreed?: string;
+  /**
+   * Pre-filtered candidate parents (caller is expected to pass only
+   * stabled, same-species pets). The service splits by gender and ranks
+   * every M × F pair; same-gender or empty inputs return [].
+   */
+  pets: Pet[];
+}
+
+type PetLoci = Map<string, GeneType>;
+
+/**
+ * Single bulk read of `pet_genes` for the union of input pet ids. One
+ * round-trip instead of N — at the worst-case 30 pets this is the
+ * difference between 30 selects and 1.
+ */
+async function loadAllPetLoci(petIds: number[]): Promise<Map<number, PetLoci>> {
+  const map = new Map<number, PetLoci>();
+  if (petIds.length === 0) return map;
+  const db = getDb();
+  const placeholders = petIds.map((_, i) => `$id${i}`).join(', ');
+  const params: Record<string, unknown> = {};
+  petIds.forEach((id, i) => {
+    params[`id${i}`] = id;
+  });
+  const rows = await db.select<{ pet_id: number; gene_id: string; gene_type: string }[]>(
+    `SELECT pet_id, gene_id, gene_type FROM pet_genes WHERE pet_id IN (${placeholders})`,
+    params,
+  );
+  for (const row of rows) {
+    let loci = map.get(row.pet_id);
+    if (!loci) {
+      loci = new Map();
+      map.set(row.pet_id, loci);
+    }
+    loci.set(row.gene_id, row.gene_type as GeneType);
+  }
+  return map;
+}
+
+/**
+ * Add this locus's contribution to the per-attribute positive-expression
+ * tally. Returns the total positive mass added across all attributes so
+ * the caller can keep an aggregate without re-summing the record.
+ */
+function accumulatePositive(dist: AlleleDistribution, gd: ParsedGeneRecord, into: Record<string, number>): number {
+  let total = 0;
+  if (gd.dominantSign === '+' && gd.dominantAttribute) {
+    const p = dist.D + dist.x;
+    if (p > 0) {
+      const key = capitalize(gd.dominantAttribute);
+      into[key] = (into[key] ?? 0) + p;
+      total += p;
+    }
+  }
+  if (gd.recessiveSign === '+' && gd.recessiveAttribute) {
+    const p = dist.R;
+    if (p > 0) {
+      const key = capitalize(gd.recessiveAttribute);
+      into[key] = (into[key] ?? 0) + p;
+      total += p;
+    }
+  }
+  return total;
+}
+
+function emptyAttributeBreakdown(attrNames: readonly string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const a of attrNames) out[a] = 0;
+  return out;
+}
+
+function scorePair(
+  male: Pet,
+  female: Pet,
+  mLoci: PetLoci,
+  fLoci: PetLoci,
+  parsedGenes: Record<string, ParsedGeneRecord>,
+  offspringBreed: string | undefined,
+  species: string,
+  attrNames: readonly string[],
+): BreedingPairResult {
+  const evPositiveByAttribute = emptyAttributeBreakdown(attrNames);
+  let evMixed = 0;
+  let evUnknown = 0;
+  let evPositiveTotal = 0;
+  let totalLoci = 0;
+
+  // Walk the male's loci first; the female's set-difference is handled
+  // in a second pass below. In well-formed same-species inputs both maps
+  // hold identical key sets (genome files always emit one row per
+  // position, even for unknown alleles) — the second pass is defensive
+  // for partially-imported genomes.
+  for (const [geneId, t1] of mLoci) {
+    const gd = parsedGenes[geneId];
+    if (isHorseBreedFiltered(species, offspringBreed, gd?.breed)) continue;
+    const t2 = fLoci.get(geneId) ?? GT.UNKNOWN;
+    const dist = offspringDistribution(t1, t2);
+    evMixed += dist.x;
+    evUnknown += dist.unknown;
+    totalLoci++;
+    if (gd) evPositiveTotal += accumulatePositive(dist, gd, evPositiveByAttribute);
+  }
+  for (const [geneId, t2] of fLoci) {
+    if (mLoci.has(geneId)) continue;
+    const gd = parsedGenes[geneId];
+    if (isHorseBreedFiltered(species, offspringBreed, gd?.breed)) continue;
+    const dist = offspringDistribution(GT.UNKNOWN, t2);
+    evMixed += dist.x;
+    evUnknown += dist.unknown;
+    totalLoci++;
+    // Distribution is full-unknown when one parent is `?`, so the
+    // positive-expression probability is 0 — no attribute contribution.
+  }
+
+  return { male, female, evMixed, evPositiveByAttribute, evPositiveTotal, evUnknown, totalLoci };
+}
+
+/**
+ * Rank every (Male × Female) pair in the candidate set by their expected
+ * offspring scores. Returns results in deterministic male-then-female
+ * input order; the UI is responsible for sorting by whichever column
+ * the player picks.
+ */
+export async function rankBreedingPairs(opts: RankBreedingPairsOptions): Promise<BreedingPairResult[]> {
+  const males = opts.pets.filter((p) => p.gender === 'Male');
+  const females = opts.pets.filter((p) => p.gender === 'Female');
+  if (males.length === 0 || females.length === 0) return [];
+
+  const species = normalizeSpecies(opts.species);
+  const ids = [...males.map((p) => p.id), ...females.map((p) => p.id)];
+  const [petLociMap, parsedGenes] = await Promise.all([loadAllPetLoci(ids), getParsedGenesCached(species)]);
+
+  const attrNames = getAllAttributeNames(species).map(capitalize);
+  const empty: PetLoci = new Map();
+  const results: BreedingPairResult[] = [];
+
+  for (const m of males) {
+    const mLoci = petLociMap.get(m.id) ?? empty;
+    for (const f of females) {
+      const fLoci = petLociMap.get(f.id) ?? empty;
+      results.push(scorePair(m, f, mLoci, fLoci, parsedGenes, opts.offspringBreed, species, attrNames));
+    }
+  }
+
+  return results;
+}

--- a/tests/unit/breedingService.perf.test.js
+++ b/tests/unit/breedingService.perf.test.js
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { closeDatabase, initDatabase } from '$lib/services/database.js';
+import * as geneService from '$lib/services/geneService.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+/**
+ * Worst-case Gorgonetics scale: 15 stabled males × 15 stabled females ×
+ * ~1500 horse loci = 225 pairs × 1500 locus-comparisons each.
+ *
+ * This test is a **regression alarm**, not a tight bound — if a future
+ * change makes scoring blow past the budget, that is the signal to
+ * profile (gene pruning, bit-array encoding, etc.). Do not chase
+ * micro-optimisations to bring a passing run lower.
+ */
+
+const NUM_MALES = 15;
+const NUM_FEMALES = 15;
+const NUM_CHROMOSOMES = 30;
+const ALLELES_PER_CHROMOSOME = 50; // 30 × 50 = 1500 loci per pet
+const SCORING_BUDGET_MS = 500;
+
+const ALLELE_CYCLE = ['D', 'R', 'x', 'D', 'R', 'D', 'x', 'R'];
+
+function buildAlleles(seed) {
+  let s = '';
+  for (let i = 0; i < ALLELES_PER_CHROMOSOME; i++) {
+    s += ALLELE_CYCLE[(seed + i) % ALLELE_CYCLE.length];
+  }
+  return s;
+}
+
+function buildHorseGenome(name, seed) {
+  const lines = [`[Overview]`, 'Format=1.0', 'Character=PerfTester', `Entity=${name}`, 'Genome=Horse', '', '[Genes]'];
+  for (let chr = 1; chr <= NUM_CHROMOSOMES; chr++) {
+    lines.push(`${chr}=${buildAlleles(seed + chr)}`);
+  }
+  return lines.join('\n');
+}
+
+async function seedHorseGeneTable() {
+  // Mix of attribute and neutral effects so the per-attribute breakdown
+  // exercises the accumulator without making every locus equivalent.
+  const effects = ['Toughness+', 'Friendliness+', 'Intelligence-', 'None', 'Ruggedness+'];
+  for (let chr = 1; chr <= NUM_CHROMOSOMES; chr++) {
+    for (let pos = 0; pos < ALLELES_PER_CHROMOSOME; pos++) {
+      const block = String.fromCharCode(65 + Math.floor(pos / 10));
+      const within = (pos % 10) + 1;
+      const chrStr = String(chr).padStart(2, '0');
+      const geneId = `${chrStr}${block}${within}`;
+      const effect = effects[(chr + pos) % effects.length];
+      await geneService.upsertGene('horse', chrStr, geneId, {
+        effectDominant: effect,
+        effectRecessive: 'None',
+        breed: '',
+      });
+    }
+  }
+  geneService.clearGeneEffectsCache('horse');
+}
+
+async function uploadHorse(name, gender, seed) {
+  const result = await petService.uploadPet(buildHorseGenome(name, seed), { name, gender });
+  expect(result.status).toBe('success');
+  const pet = await petService.getPet(result.pet_id);
+  expect(pet).not.toBeNull();
+  return pet;
+}
+
+describe('rankBreedingPairs — performance regression', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    await runMigrations();
+    geneService.clearGeneEffectsCache();
+  });
+
+  it(`scores 15×15 horses with ~1500 loci each in under ${SCORING_BUDGET_MS}ms`, async () => {
+    await seedHorseGeneTable();
+
+    const males = [];
+    for (let i = 0; i < NUM_MALES; i++) {
+      males.push(await uploadHorse(`M${i}`, 'Male', i * 7 + 1));
+    }
+    const females = [];
+    for (let i = 0; i < NUM_FEMALES; i++) {
+      females.push(await uploadHorse(`F${i}`, 'Female', i * 11 + 3));
+    }
+
+    const start = performance.now();
+    const results = await rankBreedingPairs({ species: 'Horse', pets: [...males, ...females] });
+    const elapsed = performance.now() - start;
+
+    expect(results).toHaveLength(NUM_MALES * NUM_FEMALES);
+    // Sanity: at least one pair scored a non-zero positive total — the
+    // loop is doing real work, not skipping every locus.
+    expect(results.some((r) => r.evPositiveTotal > 0)).toBe(true);
+    expect(results.some((r) => r.totalLoci > 0)).toBe(true);
+
+    console.log(
+      `[perf] rankBreedingPairs ${NUM_MALES}×${NUM_FEMALES} pets, ${NUM_CHROMOSOMES * ALLELES_PER_CHROMOSOME} loci/pet → ${elapsed.toFixed(1)}ms`,
+    );
+    expect(elapsed).toBeLessThan(SCORING_BUDGET_MS);
+  }, 30_000);
+});

--- a/tests/unit/breedingService.perf.test.js
+++ b/tests/unit/breedingService.perf.test.js
@@ -1,14 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { rankBreedingPairs } from '$lib/services/breedingService.js';
 import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import * as geneService from '$lib/services/geneService.js';
+import { parseGenome } from '$lib/services/genomeParser.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
 import { Gender } from '$lib/types/index.js';
+import { toGeneId } from '$lib/utils/geneAnalysis.js';
 
 /**
- * Worst-case Gorgonetics scale: 15 stabled males × 15 stabled females ×
- * ~1500 horse loci = 225 pairs × 1500 locus-comparisons each.
+ * Worst-case Gorgonetics scale, sized against the real game data:
+ * 15 stabled males × 15 stabled females × ~1500 horse loci. Genome
+ * structure (48 chromosomes, 4-char blocks, variable per-chromosome
+ * length) is taken straight from `data/Genes_SampleHorse.txt` so the
+ * loop walks loci in the same shape the production parser produces.
  *
  * This test is a **regression alarm**, not a tight bound — if a future
  * change makes scoring blow past the budget, that is the signal to
@@ -16,55 +23,43 @@ import { Gender } from '$lib/types/index.js';
  * micro-optimisations to bring a passing run lower.
  */
 
+const SAMPLE_HORSE = readFileSync(resolve('data/Genes_SampleHorse.txt'), 'utf-8');
+const SAMPLE_GENOME = parseGenome(SAMPLE_HORSE);
+
 const NUM_MALES = 15;
 const NUM_FEMALES = 15;
-const NUM_CHROMOSOMES = 30;
-const BLOCKS_PER_CHROMOSOME = 5;
-const POSITIONS_PER_BLOCK = 10;
-const ALLELES_PER_CHROMOSOME = BLOCKS_PER_CHROMOSOME * POSITIONS_PER_BLOCK; // 50
-const LOCI_PER_PET = NUM_CHROMOSOMES * ALLELES_PER_CHROMOSOME; // 1500
 const SCORING_BUDGET_MS = 500;
 
 const ALLELE_CYCLE = ['D', 'R', 'x', 'D', 'R', 'D', 'x', 'R'];
+const EFFECTS = ['Toughness+', 'Friendliness+', 'Intelligence-', 'None', 'Ruggedness+', 'Temperament+'];
 
 /**
- * Build one chromosome's allele string with whitespace between blocks
- * — `parseChromosomeGenes` splits on `\s+` to derive block letters, so
- * the per-block lengths here drive the gene IDs the parser emits, and
- * those IDs must line up with what `seedHorseGeneTable` inserts.
+ * Build a horse genome by reusing the real sample's chromosome/block
+ * structure but rewriting each allele based on `seed`. The Entity name
+ * is replaced first so the global allele substitution can't accidentally
+ * touch it (test names like `M0`/`F0` contain none of D/R/x/?, so the
+ * substitution is safe even on the whole file).
  */
-function buildAlleles(seed) {
-  const blocks = [];
-  for (let b = 0; b < BLOCKS_PER_CHROMOSOME; b++) {
-    let block = '';
-    for (let i = 0; i < POSITIONS_PER_BLOCK; i++) {
-      block += ALLELE_CYCLE[(seed + b * POSITIONS_PER_BLOCK + i) % ALLELE_CYCLE.length];
-    }
-    blocks.push(block);
-  }
-  return blocks.join(' ');
-}
-
 function buildHorseGenome(name, seed) {
-  const lines = [`[Overview]`, 'Format=1.0', 'Character=PerfTester', `Entity=${name}`, 'Genome=Horse', '', '[Genes]'];
-  for (let chr = 1; chr <= NUM_CHROMOSOMES; chr++) {
-    lines.push(`${chr}=${buildAlleles(seed + chr)}`);
-  }
-  return lines.join('\n');
+  const withEntity = SAMPLE_HORSE.replace(/^Entity=.*$/m, `Entity=${name}`);
+  let counter = 0;
+  return withEntity.replace(/[DRx?]/g, () => {
+    const allele = ALLELE_CYCLE[(seed + counter) % ALLELE_CYCLE.length];
+    counter++;
+    return allele;
+  });
 }
 
 async function seedHorseGeneTable() {
-  // Mix of attribute and neutral effects so the per-attribute breakdown
-  // exercises the accumulator without making every locus equivalent.
-  const effects = ['Toughness+', 'Friendliness+', 'Intelligence-', 'None', 'Ruggedness+'];
-  for (let chr = 1; chr <= NUM_CHROMOSOMES; chr++) {
-    for (let pos = 0; pos < ALLELES_PER_CHROMOSOME; pos++) {
-      const block = String.fromCharCode(65 + Math.floor(pos / 10));
-      const within = (pos % 10) + 1;
-      const chrStr = String(chr).padStart(2, '0');
-      const geneId = `${chrStr}${block}${within}`;
-      const effect = effects[(chr + pos) % effects.length];
-      await geneService.upsertGene('horse', chrStr, geneId, {
+  // One gene record per locus the real horse genome produces, so every
+  // pet_genes row resolves to a parsed-gene record and accumulatePositive
+  // exercises the per-attribute breakdown on every iteration.
+  let i = 0;
+  for (const [chrPadded, genes] of Object.entries(SAMPLE_GENOME.genes)) {
+    for (const g of genes) {
+      const effect = EFFECTS[i % EFFECTS.length];
+      i++;
+      await geneService.upsertGene('horse', chrPadded, toGeneId(g), {
         effectDominant: effect,
         effectRecessive: 'None',
         breed: '',
@@ -90,7 +85,9 @@ describe('rankBreedingPairs — performance regression', () => {
     geneService.clearGeneEffectsCache();
   });
 
-  it(`scores 15×15 horses with ~1500 loci each in under ${SCORING_BUDGET_MS}ms`, async () => {
+  it(`scores 15×15 horses (real-genome sized) in under ${SCORING_BUDGET_MS}ms`, async () => {
+    const lociPerPet = Object.values(SAMPLE_GENOME.genes).reduce((n, arr) => n + arr.length, 0);
+
     await seedHorseGeneTable();
 
     const males = [];
@@ -107,14 +104,12 @@ describe('rankBreedingPairs — performance regression', () => {
     const elapsed = performance.now() - start;
 
     expect(results).toHaveLength(NUM_MALES * NUM_FEMALES);
-    // Sanity: at least one pair scored a non-zero positive total — the
-    // loop is doing real work, not skipping every locus.
     expect(results.some((r) => r.evPositiveTotal > 0)).toBe(true);
-    expect(results.some((r) => r.totalLoci > 0)).toBe(true);
+    expect(results.every((r) => r.totalLoci === lociPerPet)).toBe(true);
 
     if (process.env.PERF_LOG) {
       console.log(
-        `[perf] rankBreedingPairs ${NUM_MALES}×${NUM_FEMALES} pets, ${LOCI_PER_PET} loci/pet → ${elapsed.toFixed(1)}ms`,
+        `[perf] rankBreedingPairs ${NUM_MALES}×${NUM_FEMALES} pets, ${lociPerPet} loci/pet → ${elapsed.toFixed(1)}ms`,
       );
     }
     expect(elapsed).toBeLessThan(SCORING_BUDGET_MS);

--- a/tests/unit/breedingService.perf.test.js
+++ b/tests/unit/breedingService.perf.test.js
@@ -19,17 +19,30 @@ import { Gender } from '$lib/types/index.js';
 const NUM_MALES = 15;
 const NUM_FEMALES = 15;
 const NUM_CHROMOSOMES = 30;
-const ALLELES_PER_CHROMOSOME = 50; // 30 × 50 = 1500 loci per pet
+const BLOCKS_PER_CHROMOSOME = 5;
+const POSITIONS_PER_BLOCK = 10;
+const ALLELES_PER_CHROMOSOME = BLOCKS_PER_CHROMOSOME * POSITIONS_PER_BLOCK; // 50
+const LOCI_PER_PET = NUM_CHROMOSOMES * ALLELES_PER_CHROMOSOME; // 1500
 const SCORING_BUDGET_MS = 500;
 
 const ALLELE_CYCLE = ['D', 'R', 'x', 'D', 'R', 'D', 'x', 'R'];
 
+/**
+ * Build one chromosome's allele string with whitespace between blocks
+ * — `parseChromosomeGenes` splits on `\s+` to derive block letters, so
+ * the per-block lengths here drive the gene IDs the parser emits, and
+ * those IDs must line up with what `seedHorseGeneTable` inserts.
+ */
 function buildAlleles(seed) {
-  let s = '';
-  for (let i = 0; i < ALLELES_PER_CHROMOSOME; i++) {
-    s += ALLELE_CYCLE[(seed + i) % ALLELE_CYCLE.length];
+  const blocks = [];
+  for (let b = 0; b < BLOCKS_PER_CHROMOSOME; b++) {
+    let block = '';
+    for (let i = 0; i < POSITIONS_PER_BLOCK; i++) {
+      block += ALLELE_CYCLE[(seed + b * POSITIONS_PER_BLOCK + i) % ALLELE_CYCLE.length];
+    }
+    blocks.push(block);
   }
-  return s;
+  return blocks.join(' ');
 }
 
 function buildHorseGenome(name, seed) {
@@ -99,9 +112,11 @@ describe('rankBreedingPairs — performance regression', () => {
     expect(results.some((r) => r.evPositiveTotal > 0)).toBe(true);
     expect(results.some((r) => r.totalLoci > 0)).toBe(true);
 
-    console.log(
-      `[perf] rankBreedingPairs ${NUM_MALES}×${NUM_FEMALES} pets, ${NUM_CHROMOSOMES * ALLELES_PER_CHROMOSOME} loci/pet → ${elapsed.toFixed(1)}ms`,
-    );
+    if (process.env.PERF_LOG) {
+      console.log(
+        `[perf] rankBreedingPairs ${NUM_MALES}×${NUM_FEMALES} pets, ${LOCI_PER_PET} loci/pet → ${elapsed.toFixed(1)}ms`,
+      );
+    }
     expect(elapsed).toBeLessThan(SCORING_BUDGET_MS);
   }, 30_000);
 });

--- a/tests/unit/breedingService.perf.test.js
+++ b/tests/unit/breedingService.perf.test.js
@@ -4,6 +4,7 @@ import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import * as geneService from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
+import { Gender } from '$lib/types/index.js';
 
 /**
  * Worst-case Gorgonetics scale: 15 stabled males × 15 stabled females ×
@@ -81,11 +82,11 @@ describe('rankBreedingPairs — performance regression', () => {
 
     const males = [];
     for (let i = 0; i < NUM_MALES; i++) {
-      males.push(await uploadHorse(`M${i}`, 'Male', i * 7 + 1));
+      males.push(await uploadHorse(`M${i}`, Gender.MALE, i * 7 + 1));
     }
     const females = [];
     for (let i = 0; i < NUM_FEMALES; i++) {
-      females.push(await uploadHorse(`F${i}`, 'Female', i * 11 + 3));
+      females.push(await uploadHorse(`F${i}`, Gender.FEMALE, i * 11 + 3));
     }
 
     const start = performance.now();

--- a/tests/unit/breedingService.test.js
+++ b/tests/unit/breedingService.test.js
@@ -174,8 +174,12 @@ Genome=Horse
 
     const m = await petService.uploadPet(horseGenome('M', 'DD'), { name: 'M', gender: Gender.MALE });
     const f = await petService.uploadPet(horseGenome('F', 'DD'), { name: 'F', gender: Gender.FEMALE });
+    expect(m.status).toBe('success');
+    expect(f.status).toBe('success');
     const male = await petService.getPet(m.pet_id);
     const female = await petService.getPet(f.pet_id);
+    expect(male).not.toBeNull();
+    expect(female).not.toBeNull();
 
     const [withFilter] = await rankBreedingPairs({
       species: 'Horse',

--- a/tests/unit/breedingService.test.js
+++ b/tests/unit/breedingService.test.js
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { closeDatabase, initDatabase } from '$lib/services/database.js';
+import * as geneService from '$lib/services/geneService.js';
+import { runMigrations } from '$lib/services/migrationService.js';
+import * as petService from '$lib/services/petService.js';
+
+/**
+ * Three-locus beewasp genome: positions 01A1, 01A2, 01A3 — alleles
+ * controlled by the test via the third line. Same body the existing
+ * stats tests use; just parameterised on the allele triplet.
+ */
+function beewaspGenome(name, alleles) {
+  return `[Overview]
+Format=1.0
+Character=Tester
+Entity=${name}
+Genome=BeeWasp
+
+[Genes]
+1=${alleles}
+`;
+}
+
+async function uploadParent(name, gender, alleles) {
+  const result = await petService.uploadPet(beewaspGenome(name, alleles), { name, gender });
+  expect(result.status).toBe('success');
+  const pet = await petService.getPet(result.pet_id);
+  expect(pet).not.toBeNull();
+  return pet;
+}
+
+async function reset() {
+  await closeDatabase();
+  await initDatabase();
+  await runMigrations();
+  geneService.clearGeneEffectsCache();
+}
+
+describe('rankBreedingPairs — pair construction', () => {
+  beforeEach(reset);
+
+  it('returns no pairs when only one gender is present', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    geneService.clearGeneEffectsCache('beewasp');
+    const m = await uploadParent('M1', 'Male', 'D??');
+    const result = await rankBreedingPairs({ species: 'BeeWasp', pets: [m] });
+    expect(result).toEqual([]);
+  });
+
+  it('returns the cartesian product of males × females', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    geneService.clearGeneEffectsCache('beewasp');
+    const m1 = await uploadParent('M1', 'Male', 'D??');
+    const m2 = await uploadParent('M2', 'Male', 'R??');
+    const f1 = await uploadParent('F1', 'Female', 'D??');
+    const f2 = await uploadParent('F2', 'Female', 'x??');
+    const result = await rankBreedingPairs({ species: 'BeeWasp', pets: [m1, m2, f1, f2] });
+    expect(result).toHaveLength(4);
+    // Order: each male × every female, in input order.
+    expect(result.map((r) => [r.male.name, r.female.name])).toEqual([
+      ['M1', 'F1'],
+      ['M1', 'F2'],
+      ['M2', 'F1'],
+      ['M2', 'F2'],
+    ]);
+  });
+});
+
+describe('rankBreedingPairs — EV math', () => {
+  beforeEach(reset);
+
+  it('matches hand-computed values for a single pair across the Mendelian table', async () => {
+    // Three loci with three different effect signatures so the per-attribute
+    // breakdown gets exercised:
+    //   01A1: dominant=Toughness+   recessive=None
+    //   01A2: dominant=Intelligence- recessive=None    (no positive sign)
+    //   01A3: dominant=None          recessive=Friendliness+
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    await geneService.upsertGene('beewasp', '01', '01A2', { effectDominant: 'Intelligence-', effectRecessive: 'None' });
+    await geneService.upsertGene('beewasp', '01', '01A3', { effectDominant: 'None', effectRecessive: 'Friendliness+' });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    // Parents:
+    //   Male:   D x R   → at 01A1 D, 01A2 x, 01A3 R
+    //   Female: x R x
+    const male = await uploadParent('M', 'Male', 'DxR');
+    const female = await uploadParent('F', 'Female', 'xRx');
+
+    const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
+
+    // Locus 1: D × x → D=.5, x=.5, R=0, unknown=0 → mixed=.5, Toughness+=1
+    // Locus 2: x × R → D=0, x=.5, R=.5, unknown=0 → mixed=.5, no positive (sign is '-')
+    // Locus 3: R × x → D=0, x=.5, R=.5, unknown=0 → mixed=.5, Friendliness+=.5
+    expect(pair.totalLoci).toBe(3);
+    expect(pair.evMixed).toBeCloseTo(1.5, 10);
+    expect(pair.evUnknown).toBe(0);
+    expect(pair.evPositiveByAttribute.Toughness).toBeCloseTo(1, 10);
+    expect(pair.evPositiveByAttribute.Friendliness).toBeCloseTo(0.5, 10);
+    expect(pair.evPositiveByAttribute.Intelligence).toBe(0);
+    expect(pair.evPositiveTotal).toBeCloseTo(1.5, 10);
+  });
+
+  it('counts mixed-EV at every locus, not just attribute-bearing ones', async () => {
+    // Only seed an effect for locus 1; loci 2/3 have no genes-table
+    // entry and therefore no attribute, but their mixed mass must still
+    // count toward EV[mixed] (the predictability metric is gene-agnostic).
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    const male = await uploadParent('M', 'Male', 'xxx');
+    const female = await uploadParent('F', 'Female', 'xxx');
+
+    const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
+
+    // x × x at every locus → P(x) = 0.5 each, so EV[mixed] = 1.5.
+    expect(pair.totalLoci).toBe(3);
+    expect(pair.evMixed).toBeCloseTo(1.5, 10);
+    expect(pair.evUnknown).toBe(0);
+    // Only locus 1 has an attribute, contributing P(D∨x) = 0.75 to Toughness.
+    expect(pair.evPositiveByAttribute.Toughness).toBeCloseTo(0.75, 10);
+    expect(pair.evPositiveTotal).toBeCloseTo(0.75, 10);
+  });
+
+  it('routes unknown alleles to evUnknown without polluting evMixed or evPositive', async () => {
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    await geneService.upsertGene('beewasp', '01', '01A2', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    await geneService.upsertGene('beewasp', '01', '01A3', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    // Male unknown at every locus; female fully observed dominant.
+    const male = await uploadParent('M', 'Male', '???');
+    const female = await uploadParent('F', 'Female', 'DDD');
+
+    const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
+
+    expect(pair.totalLoci).toBe(3);
+    expect(pair.evUnknown).toBe(3);
+    expect(pair.evMixed).toBe(0);
+    expect(pair.evPositiveTotal).toBe(0);
+    expect(pair.evPositiveByAttribute.Toughness).toBe(0);
+  });
+});
+
+describe('rankBreedingPairs — horse breed-locked filtering', () => {
+  beforeEach(reset);
+
+  it('skips horse loci breed-locked to a different breed than the offspring breed', async () => {
+    // Two horse loci: one breed-locked to Standardbred, one universal.
+    // Offspring breed = Ilmarian → Standardbred locus is skipped from
+    // every score (totalLoci, evMixed, evPositive).
+    await geneService.upsertGene('horse', '01', '01A1', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'None',
+      breed: 'Standardbred',
+    });
+    await geneService.upsertGene('horse', '01', '01A2', {
+      effectDominant: 'Toughness+',
+      effectRecessive: 'None',
+      breed: '',
+    });
+    geneService.clearGeneEffectsCache('horse');
+
+    const horseGenome = (name, alleles) => `[Overview]
+Format=1.0
+Character=Tester
+Entity=${name}
+Genome=Horse
+
+[Genes]
+1=${alleles}
+`;
+
+    const m = await petService.uploadPet(horseGenome('M', 'DD'), { name: 'M', gender: 'Male' });
+    const f = await petService.uploadPet(horseGenome('F', 'DD'), { name: 'F', gender: 'Female' });
+    const male = await petService.getPet(m.pet_id);
+    const female = await petService.getPet(f.pet_id);
+
+    const [withFilter] = await rankBreedingPairs({
+      species: 'Horse',
+      offspringBreed: 'Ilmarian',
+      pets: [male, female],
+    });
+    expect(withFilter.totalLoci).toBe(1);
+    expect(withFilter.evPositiveByAttribute.Toughness).toBeCloseTo(1, 10);
+
+    const [withoutFilter] = await rankBreedingPairs({
+      species: 'Horse',
+      offspringBreed: 'Standardbred',
+      pets: [male, female],
+    });
+    expect(withoutFilter.totalLoci).toBe(2);
+    expect(withoutFilter.evPositiveByAttribute.Toughness).toBeCloseTo(2, 10);
+  });
+});

--- a/tests/unit/breedingService.test.js
+++ b/tests/unit/breedingService.test.js
@@ -4,6 +4,7 @@ import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import * as geneService from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
+import { Gender } from '$lib/types/index.js';
 
 /**
  * Three-locus beewasp genome: positions 01A1, 01A2, 01A3 — alleles
@@ -43,7 +44,7 @@ describe('rankBreedingPairs — pair construction', () => {
   it('returns no pairs when only one gender is present', async () => {
     await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
     geneService.clearGeneEffectsCache('beewasp');
-    const m = await uploadParent('M1', 'Male', 'D??');
+    const m = await uploadParent('M1', Gender.MALE, 'D??');
     const result = await rankBreedingPairs({ species: 'BeeWasp', pets: [m] });
     expect(result).toEqual([]);
   });
@@ -51,10 +52,10 @@ describe('rankBreedingPairs — pair construction', () => {
   it('returns the cartesian product of males × females', async () => {
     await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
     geneService.clearGeneEffectsCache('beewasp');
-    const m1 = await uploadParent('M1', 'Male', 'D??');
-    const m2 = await uploadParent('M2', 'Male', 'R??');
-    const f1 = await uploadParent('F1', 'Female', 'D??');
-    const f2 = await uploadParent('F2', 'Female', 'x??');
+    const m1 = await uploadParent('M1', Gender.MALE, 'D??');
+    const m2 = await uploadParent('M2', Gender.MALE, 'R??');
+    const f1 = await uploadParent('F1', Gender.FEMALE, 'D??');
+    const f2 = await uploadParent('F2', Gender.FEMALE, 'x??');
     const result = await rankBreedingPairs({ species: 'BeeWasp', pets: [m1, m2, f1, f2] });
     expect(result).toHaveLength(4);
     // Order: each male × every female, in input order.
@@ -84,8 +85,8 @@ describe('rankBreedingPairs — EV math', () => {
     // Parents:
     //   Male:   D x R   → at 01A1 D, 01A2 x, 01A3 R
     //   Female: x R x
-    const male = await uploadParent('M', 'Male', 'DxR');
-    const female = await uploadParent('F', 'Female', 'xRx');
+    const male = await uploadParent('M', Gender.MALE, 'DxR');
+    const female = await uploadParent('F', Gender.FEMALE, 'xRx');
 
     const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
 
@@ -108,8 +109,8 @@ describe('rankBreedingPairs — EV math', () => {
     await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
     geneService.clearGeneEffectsCache('beewasp');
 
-    const male = await uploadParent('M', 'Male', 'xxx');
-    const female = await uploadParent('F', 'Female', 'xxx');
+    const male = await uploadParent('M', Gender.MALE, 'xxx');
+    const female = await uploadParent('F', Gender.FEMALE, 'xxx');
 
     const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
 
@@ -129,8 +130,8 @@ describe('rankBreedingPairs — EV math', () => {
     geneService.clearGeneEffectsCache('beewasp');
 
     // Male unknown at every locus; female fully observed dominant.
-    const male = await uploadParent('M', 'Male', '???');
-    const female = await uploadParent('F', 'Female', 'DDD');
+    const male = await uploadParent('M', Gender.MALE, '???');
+    const female = await uploadParent('F', Gender.FEMALE, 'DDD');
 
     const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
 
@@ -171,8 +172,8 @@ Genome=Horse
 1=${alleles}
 `;
 
-    const m = await petService.uploadPet(horseGenome('M', 'DD'), { name: 'M', gender: 'Male' });
-    const f = await petService.uploadPet(horseGenome('F', 'DD'), { name: 'F', gender: 'Female' });
+    const m = await petService.uploadPet(horseGenome('M', 'DD'), { name: 'M', gender: Gender.MALE });
+    const f = await petService.uploadPet(horseGenome('F', 'DD'), { name: 'F', gender: Gender.FEMALE });
     const male = await petService.getPet(m.pet_id);
     const female = await petService.getPet(f.pet_id);
 


### PR DESCRIPTION
## Summary

Second slice of the **Breeding Assistant** feature. Composes the per-locus genetics primitives from PR 1 across every (Male × Female) pair in the candidate set and emits per-pair EVs the UI can sort.

Builds on #191 (PR 1/5) — the genetics utility — and on the existing `pet_genes` projection + `getParsedGenesCached` cache.

## What's in the box

- `src/lib/services/breedingService.ts` — `rankBreedingPairs(opts)` returning `BreedingPairResult[]`. One bulk `pet_genes` SELECT for the whole candidate set; no genome JSON parsing on the hot path. Horse breed-locked filtering reuses `isHorseBreedFiltered`.
- `tests/unit/breedingService.test.js` — pair construction (gender splits, cartesian product), hand-computed EVs across the Mendelian table, mixed-EV counts every locus including attribute-less ones, unknown-allele routing, horse breed-locked filtering toggled by offspring breed.
- `tests/unit/breedingService.perf.test.js` — worst-case 15×15 horses × ~1500 loci/pet (~340k locus-comparisons). Asserts <500 ms as a **regression alarm**, not a tight bound.

## Performance

Local run: **~62 ms** for the worst case, ~8× under the 500 ms budget. The perf test is in place so any future regression makes itself obvious; no premature optimisation needed (no gene pruning, no bit-array encoding).

## Notes for the reviewer

- `BreedingPairResult` shape (defined in PR 1): `evMixed` covers every locus the parents share (attribute + appearance + selector — the predictability metric is gene-agnostic). `evPositiveByAttribute` is attribute-only and uses `capitalize`'d attribute names for the column keys, matching the `getPetGeneStats` convention.
- Same-species genome files always emit one `pet_genes` row per genome position (even for `?` alleles), so the second loop walking the female's set-difference of loci is defensive — meant to cover partially-imported genomes, not the steady state.
- Service returns results in deterministic male-then-female input order. Sorting is a UI concern (PR 4).

## Follow-up

| # | Surface |
|---|---|
| 3 | Tab scaffold + store (placeholder UI, no scoring rendered yet) |
| 4 | Ranking UI (breed selector + sortable pair table + E2E) |
| 5 | (optional) Shared two-pet locus walker, refactored from comparison |

## Test plan

- [x] `vitest run tests/unit/breedingService.test.js` — 6/6 correctness pass
- [x] `vitest run tests/unit/breedingService.perf.test.js` — 1/1 perf pass (~62 ms vs 500 ms budget)
- [x] full unit suite — 365/365 pass (no regressions)
- [x] \`biome check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)