### PR TITLE
feat(breeding): Breed tab scaffold + placeholder (PR 3/5)

### DIFF
--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -1,0 +1,120 @@
+<script>
+import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import { Gender } from '$lib/types/index.js';
+
+const species = getSupportedSpecies();
+
+const eligibleBySpecies = $derived.by(() => {
+  const counts = {};
+  for (const s of species) counts[s] = { male: 0, female: 0 };
+  for (const p of $pets) {
+    if (!p.stabled) continue;
+    const bucket = counts[normalizeSpecies(p.species)];
+    if (!bucket) continue;
+    if (p.gender === Gender.MALE) bucket.male++;
+    else if (p.gender === Gender.FEMALE) bucket.female++;
+  }
+  return counts;
+});
+</script>
+
+<div class="breeding-tab" data-testid="breeding-tab">
+    <header class="breeding-header">
+        <h2>💞 Breeding Assistant</h2>
+        <p class="subtitle">
+            Rank stabled male × female pairs by expected offspring quality.
+        </p>
+    </header>
+
+    <section class="status">
+        <h3>Eligible parents</h3>
+        <ul class="species-list">
+            {#each species as s (s)}
+                {@const counts = eligibleBySpecies[s] ?? { male: 0, female: 0 }}
+                <li>
+                    <strong>{s}</strong>: {counts.male} ♂ × {counts.female} ♀
+                    {#if counts.male > 0 && counts.female > 0}
+                        <span class="pair-count">→ {counts.male * counts.female} pair{counts.male * counts.female === 1 ? '' : 's'}</span>
+                    {:else}
+                        <span class="pair-count empty">→ no pairs (need at least one of each gender)</span>
+                    {/if}
+                </li>
+            {/each}
+        </ul>
+    </section>
+
+    <section class="placeholder-note">
+        <p>
+            The ranking table and offspring-breed selector are coming in the next
+            iteration. Active species: <strong>{breedingView.species}</strong>.
+        </p>
+    </section>
+</div>
+
+<style>
+    .breeding-tab {
+        flex: 1;
+        padding: 24px 32px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+    }
+
+    .breeding-header h2 {
+        margin: 0 0 4px 0;
+        font-size: 20px;
+    }
+
+    .subtitle {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+
+    .status h3 {
+        font-size: 14px;
+        font-weight: 600;
+        margin: 0 0 8px 0;
+        color: var(--text-secondary);
+    }
+
+    .species-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+    }
+
+    .species-list li {
+        font-size: 14px;
+    }
+
+    .pair-count {
+        margin-left: 8px;
+        color: var(--text-muted);
+        font-size: 13px;
+    }
+
+    .pair-count.empty {
+        color: var(--text-tertiary);
+        font-style: italic;
+    }
+
+    .placeholder-note {
+        padding: 12px 16px;
+        background: var(--bg-secondary);
+        border: 1px dashed var(--border-primary);
+        border-radius: 6px;
+        color: var(--text-secondary);
+        font-size: 13px;
+    }
+
+    .placeholder-note p {
+        margin: 0;
+    }
+</style>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -39,6 +39,13 @@ function switchTab(tab) {
         </button>
         <button
             class="tab-btn"
+            class:active={$activeTab === "breeding"}
+            onclick={() => switchTab("breeding")}
+        >
+            💞 Breed
+        </button>
+        <button
+            class="tab-btn"
             class:active={$activeTab === "compare"}
             onclick={() => switchTab("compare")}
         >

--- a/src/lib/stores/breeding.svelte.ts
+++ b/src/lib/stores/breeding.svelte.ts
@@ -13,7 +13,11 @@
 
 import { getSupportedSpecies } from '$lib/services/configService.js';
 
-/** Sort columns the breeding pair table will support in PR 4. */
+/**
+ * Sort columns the breeding pair table will support in PR 4. The `| string`
+ * tail is load-bearing — per-attribute columns (Toughness, Intelligence, …)
+ * are surfaced dynamically per species, so the union can't be closed.
+ */
 export type BreedingSortColumn = 'evMixed' | 'evPositiveTotal' | 'evUnknown' | string;
 
 export const breedingView = $state({

--- a/src/lib/stores/breeding.svelte.ts
+++ b/src/lib/stores/breeding.svelte.ts
@@ -1,0 +1,28 @@
+/**
+ * Reactive state for the Breeding Assistant view.
+ *
+ * Lives at module scope so the offspring-breed pick and the sort column
+ * survive tab switches — the tab's components are unmounted when the
+ * user navigates away, but this state persists for the session.
+ *
+ * The PR-3 placeholder doesn't yet read these fields; PR 4 (the ranking
+ * UI) is where they get wired into the breed selector and sortable
+ * column headers. They are defined now so the surface is stable across
+ * the remaining PRs.
+ */
+
+import { getSupportedSpecies } from '$lib/services/configService.js';
+
+/** Sort columns the breeding pair table will support in PR 4. */
+export type BreedingSortColumn = 'evMixed' | 'evPositiveTotal' | 'evUnknown' | string;
+
+export const breedingView = $state({
+  /** Canonical species the player is breeding within (defaults to first supported). */
+  species: getSupportedSpecies()[0],
+  /** Player-selected offspring breed (horse-only; '' = no filter / mixed). */
+  offspringBreed: '' as string,
+  /** Active sort column for the pair table. */
+  sortCol: 'evPositiveTotal' as BreedingSortColumn,
+  /** Sort direction. Most useful columns are descending by default. */
+  sortDir: 'desc' as 'asc' | 'desc',
+});

--- a/src/lib/stores/breeding.svelte.ts
+++ b/src/lib/stores/breeding.svelte.ts
@@ -14,11 +14,14 @@
 import { getSupportedSpecies } from '$lib/services/configService.js';
 
 /**
- * Sort columns the breeding pair table will support in PR 4. The `| string`
- * tail is load-bearing — per-attribute columns (Toughness, Intelligence, …)
- * are surfaced dynamically per species, so the union can't be closed.
+ * Sort columns the breeding pair table will support in PR 4. The
+ * `(string & {})` tail is load-bearing — per-attribute columns
+ * (Toughness, Intelligence, …) are surfaced dynamically per species,
+ * so the union can't be closed. The branded-string trick stops TS from
+ * collapsing the literals into a bare `string` so autocomplete still
+ * surfaces the well-known column names.
  */
-export type BreedingSortColumn = 'evMixed' | 'evPositiveTotal' | 'evUnknown' | string;
+export type BreedingSortColumn = 'evMixed' | 'evPositiveTotal' | 'evUnknown' | (string & {});
 
 export const breedingView = $state({
   /** Canonical species the player is breeding within (defaults to first supported). */

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -22,6 +22,23 @@ function getCurrentValue<T>(store: Writable<T>): T | undefined {
   return value;
 }
 
+const clearSelectionAndGeneView = () => {
+  selectedPet.set(null);
+  geneEditingView.set(null);
+};
+
+/**
+ * Per-tab state-reset hook for `switchTab`. Keyed by the full `Tab`
+ * union so the compiler catches a missed branch when a new tab is added.
+ */
+const TAB_STATE_RESETS: Record<Tab, () => void> = {
+  pets: () => geneEditingView.set(null),
+  editor: () => selectedPet.set(null),
+  compare: clearSelectionAndGeneView,
+  stable: clearSelectionAndGeneView,
+  breeding: clearSelectionAndGeneView,
+};
+
 export const appState = {
   async loadPets() {
     try {
@@ -118,14 +135,7 @@ export const appState = {
 
   switchTab(tab: Tab) {
     activeTab.set(tab);
-    if (tab === 'pets') {
-      geneEditingView.set(null);
-    } else if (tab === 'editor') {
-      selectedPet.set(null);
-    } else if (tab === 'compare' || tab === 'stable' || tab === 'breeding') {
-      selectedPet.set(null);
-      geneEditingView.set(null);
-    }
+    TAB_STATE_RESETS[tab]();
   },
 
   clearError() {

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -3,7 +3,7 @@ import type { UploadPetOptions } from '$lib/services/petService.js';
 import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 
-export type Tab = 'pets' | 'editor' | 'compare' | 'stable';
+export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding';
 
 export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
@@ -122,7 +122,7 @@ export const appState = {
       geneEditingView.set(null);
     } else if (tab === 'editor') {
       selectedPet.set(null);
-    } else if (tab === 'compare' || tab === 'stable') {
+    } else if (tab === 'compare' || tab === 'stable' || tab === 'breeding') {
       selectedPet.set(null);
       geneEditingView.set(null);
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 import { onMount } from 'svelte';
+import BreedingTab from '$lib/components/breeding/BreedingTab.svelte';
 import ComparisonView from '$lib/components/comparison/ComparisonView.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
@@ -23,6 +24,8 @@ onMount(async () => {
 		<StableTable />
 	{:else if $activeTab === 'compare'}
 		<ComparisonView />
+	{:else if $activeTab === 'breeding'}
+		<BreedingTab />
 	{:else if $loading}
 		<div class="center-state">
 			<div class="spinner"></div>

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { waitForPets } from './helpers.js';
+
+test.describe('Breeding Assistant — tab scaffold (PR 3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForPets(page);
+  });
+
+  test('shows the Breed tab in the top bar', async ({ page }) => {
+    await expect(page.locator('.tab-btn').filter({ hasText: 'Breed' })).toBeVisible();
+  });
+
+  test('clicking the Breed tab activates the placeholder view', async ({ page }) => {
+    const tab = page.locator('.tab-btn').filter({ hasText: 'Breed' });
+    await tab.click();
+    await expect(tab).toHaveClass(/active/);
+    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Breeding Assistant/i })).toBeVisible();
+  });
+
+  test('placeholder lists eligible-parent counts per supported species', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
+    const list = page.locator('.species-list');
+    await expect(list).toBeVisible();
+    // Both supported species (beewasp + horse) get a row, regardless of
+    // whether the demo data has stabled pets of each.
+    await expect(list.locator('li')).toHaveCount(2);
+  });
+
+  test('switching away from Breed tab and back preserves placeholder', async ({ page }) => {
+    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
+    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+
+    await page.locator('.tab-btn').filter({ hasText: 'Pets' }).click();
+    await expect(page.locator('[data-testid="breeding-tab"]')).toHaveCount(0);
+
+    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
+    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+  });
+});

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -23,9 +23,11 @@ test.describe('Breeding Assistant — tab scaffold (PR 3)', () => {
     await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
     const list = page.locator('.species-list');
     await expect(list).toBeVisible();
-    // Both supported species (beewasp + horse) get a row, regardless of
-    // whether the demo data has stabled pets of each.
-    await expect(list.locator('li')).toHaveCount(2);
+    // Each currently supported species gets its own row. Asserted by name
+    // rather than exact count so adding a new species in configService
+    // doesn't break this test.
+    await expect(list.locator('li').filter({ hasText: 'beewasp' })).toHaveCount(1);
+    await expect(list.locator('li').filter({ hasText: 'horse' })).toHaveCount(1);
   });
 
   test('switching away from Breed tab and back preserves placeholder', async ({ page }) => {


### PR DESCRIPTION
## Summary

Third slice of the **Breeding Assistant**. Lands the tab end-to-end as a navigable surface — TopBar button, route, store, placeholder content — without the ranking UI yet (PR 4). Builds on #191 and #192.

The placeholder isn't dead-weight: it derives a live per-species count of stabled male/female pets straight from the existing `pets` store, so the user can see the eligible-pair denominator at a glance before PR 4 lands the actual table.

## What's in the box

- `src/lib/stores/pets.ts` — extends `Tab` union with `'breeding'`; `switchTab` clears `selectedPet` / `geneEditingView` on entry, same shape as the compare/stable tabs.
- `src/lib/stores/breeding.svelte.ts` — module-scoped runes state (`species`, `offspringBreed`, `sortCol`, `sortDir`) ready for PR 4 to wire into the breed selector and sortable columns. Defining the surface now means PR 4 only adds bindings, not new state.
- `src/lib/components/layout/TopBar.svelte` — 💞 Breed button between Stable and Compare.
- `src/lib/components/breeding/BreedingTab.svelte` — placeholder showing per-species eligible-parent counts (M ♂ × F ♀ → pair count) derived from the live `pets` store, plus a "coming in the next iteration" note. Uses `Gender.MALE` / `Gender.FEMALE` constants.
- `src/routes/+page.svelte` — routes `activeTab === 'breeding'` into `BreedingTab` (full-width detail pane; no master-panel content).
- `tests/e2e/breeding.spec.js` — 4 smoke tests: tab visible, click activates placeholder, species list renders, tab survives navigate-away+back.

## Notes for the reviewer

- The placeholder counts go through `normalizeSpecies`, so a pet whose `species` column is e.g. `'BeeWasp'` (display form) still slots into the canonical `'beewasp'` bucket.
- No master-panel content for this tab — the breeding view is full-width like Stable. The breed selector + table in PR 4 will live entirely in the detail pane.
- Default `sortCol = 'evPositiveTotal'`, `sortDir = 'desc'` — sensible "highest expected positive total first" default for when PR 4 wires it up.

## Follow-up

| # | Surface |
|---|---|
| 4 | Ranking UI (breed selector + sortable pair table + extended E2E) |
| 5 | (optional) Shared two-pet locus walker, refactored from comparison |

## Test plan

- [x] \`biome check\` — clean
- [x] \`vitest run\` — 365/365 unit tests pass (no regressions)
- [x] \`playwright test\` — full E2E suite: 121 passed, 2 skipped (pre-existing)
- [x] \`playwright test breeding.spec.js\` — 4/4 new E2E pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)