### PR TITLE
feat(breeding): ranking UI with sortable pair table (PR 4/5)

### DIFF
--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -67,9 +67,11 @@ function fmt(n) {
         <thead>
             <tr>
                 {#each columns as col (col.id)}
+                    {@const isActive = breedingView.sortCol === col.id}
                     <th
                         class:numeric={col.numeric}
-                        class:active={breedingView.sortCol === col.id}
+                        class:active={isActive}
+                        aria-sort={isActive ? (breedingView.sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
                     >
                         <button
                             type="button"
@@ -101,7 +103,9 @@ function fmt(n) {
 
 <style>
     .table-wrapper {
-        overflow-x: auto;
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
         border: 1px solid var(--border-primary);
         border-radius: 6px;
         background: var(--bg-primary);

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -1,0 +1,179 @@
+<script>
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import { appState } from '$lib/stores/pets.js';
+
+let { results, attrNames } = $props();
+
+/**
+ * Column definitions. The per-attribute columns are appended after the
+ * fixed columns; the column id matches the key in `evPositiveByAttribute`,
+ * which in turn matches `breedingView.sortCol` after a click on the
+ * header.
+ */
+const columns = $derived([
+  { id: 'male', label: '♂ Male', accessor: (r) => r.male.name, numeric: false },
+  { id: 'female', label: '♀ Female', accessor: (r) => r.female.name, numeric: false },
+  { id: 'evMixed', label: 'Mixed', accessor: (r) => r.evMixed, numeric: true },
+  { id: 'evUnknown', label: 'Unknown', accessor: (r) => r.evUnknown, numeric: true },
+  { id: 'evPositiveTotal', label: 'Total +', accessor: (r) => r.evPositiveTotal, numeric: true },
+  ...attrNames.map((name) => ({
+    id: name,
+    label: name,
+    accessor: (r) => r.evPositiveByAttribute[name] ?? 0,
+    numeric: true,
+  })),
+]);
+
+const sortedResults = $derived.by(() => {
+  const col = columns.find((c) => c.id === breedingView.sortCol) ?? columns[4];
+  const dir = breedingView.sortDir === 'asc' ? 1 : -1;
+  return [...results].sort((a, b) => {
+    const av = col.accessor(a);
+    const bv = col.accessor(b);
+    const cmp = col.numeric ? av - bv : String(av).localeCompare(String(bv));
+    return cmp * dir;
+  });
+});
+
+function setSort(colId) {
+  if (breedingView.sortCol === colId) {
+    breedingView.sortDir = breedingView.sortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    breedingView.sortCol = colId;
+    breedingView.sortDir = 'asc';
+  }
+}
+
+function sortIndicator(colId) {
+  if (colId !== breedingView.sortCol) return '';
+  return breedingView.sortDir === 'asc' ? ' ▲' : ' ▼';
+}
+
+function openPet(pet) {
+  appState.selectPet(pet);
+  appState.switchTab('pets');
+}
+
+function fmt(n) {
+  return n === 0 ? '0' : n.toFixed(1);
+}
+</script>
+
+<div class="table-wrapper" data-testid="breeding-pair-table">
+    <table>
+        <thead>
+            <tr>
+                {#each columns as col (col.id)}
+                    <th
+                        class:numeric={col.numeric}
+                        class:active={breedingView.sortCol === col.id}
+                    >
+                        <button
+                            type="button"
+                            class="sort-btn"
+                            onclick={() => setSort(col.id)}
+                        >
+                            {col.label}{sortIndicator(col.id)}
+                        </button>
+                    </th>
+                {/each}
+            </tr>
+        </thead>
+        <tbody>
+            {#each sortedResults as pair (`${pair.male.id}-${pair.female.id}`)}
+                <tr>
+                    <td><button class="parent-link" onclick={() => openPet(pair.male)}>{pair.male.name}</button></td>
+                    <td><button class="parent-link" onclick={() => openPet(pair.female)}>{pair.female.name}</button></td>
+                    <td class="numeric">{fmt(pair.evMixed)}</td>
+                    <td class="numeric">{fmt(pair.evUnknown)}</td>
+                    <td class="numeric strong">{fmt(pair.evPositiveTotal)}</td>
+                    {#each attrNames as name (name)}
+                        <td class="numeric">{fmt(pair.evPositiveByAttribute[name] ?? 0)}</td>
+                    {/each}
+                </tr>
+            {/each}
+        </tbody>
+    </table>
+</div>
+
+<style>
+    .table-wrapper {
+        overflow-x: auto;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        background: var(--bg-primary);
+    }
+
+    table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+    }
+
+    th {
+        text-align: left;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-primary);
+        font-weight: 600;
+        font-size: 12px;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+    }
+
+    th.numeric {
+        text-align: right;
+    }
+
+    th.active {
+        color: var(--accent);
+    }
+
+    .sort-btn {
+        width: 100%;
+        padding: 8px 10px;
+        background: transparent;
+        border: none;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        text-align: inherit;
+        white-space: nowrap;
+    }
+
+    .sort-btn:hover {
+        background: var(--bg-tertiary);
+    }
+
+    td {
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--border-primary);
+    }
+
+    td.numeric {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+
+    td.strong {
+        font-weight: 600;
+    }
+
+    tbody tr:hover {
+        background: var(--bg-secondary);
+    }
+
+    .parent-link {
+        background: none;
+        border: none;
+        padding: 0;
+        color: var(--accent);
+        cursor: pointer;
+        font: inherit;
+        text-decoration: none;
+    }
+
+    .parent-link:hover {
+        text-decoration: underline;
+    }
+</style>

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -25,7 +25,10 @@ const columns = $derived([
 ]);
 
 const sortedResults = $derived.by(() => {
-  const col = columns.find((c) => c.id === breedingView.sortCol) ?? columns[4];
+  // Fallback to the headline column by name (not by index) so re-ordering
+  // the column list later won't silently change the default sort.
+  const col =
+    columns.find((c) => c.id === breedingView.sortCol) ?? columns.find((c) => c.id === 'evPositiveTotal') ?? columns[0];
   const dir = breedingView.sortDir === 'asc' ? 1 : -1;
   return [...results].sort((a, b) => {
     const av = col.accessor(a);
@@ -55,7 +58,7 @@ function openPet(pet) {
 }
 
 function fmt(n) {
-  return n === 0 ? '0' : n.toFixed(1);
+  return n.toFixed(1);
 }
 </script>
 

--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -11,6 +11,7 @@ const species = getSupportedSpecies();
 
 let pairs = $state([]);
 let loading = $state(false);
+let errored = $state(false);
 let pairsSequence = 0;
 
 const eligible = $derived($pets.filter((p) => p.stabled && normalizeSpecies(p.species) === breedingView.species));
@@ -37,6 +38,7 @@ $effect(() => {
 
   const seq = ++pairsSequence;
   loading = true;
+  errored = false;
 
   rankBreedingPairs({
     species: targetSpecies,
@@ -52,8 +54,23 @@ $effect(() => {
       if (seq !== pairsSequence) return;
       console.error('rankBreedingPairs failed', err);
       pairs = [];
+      errored = true;
       loading = false;
     });
+});
+
+const VALID_FIXED_COLS = new Set(['male', 'female', 'evMixed', 'evUnknown', 'evPositiveTotal']);
+
+$effect(() => {
+  // When the active species changes, an attribute-specific sort column
+  // may no longer apply (e.g. Ferocity disappears on the horse). Reset
+  // to the headline column so the table doesn't silently fall back with
+  // a stale direction (worst case: best pairs sink to the bottom).
+  const validIds = new Set([...VALID_FIXED_COLS, ...attrNames]);
+  if (!validIds.has(breedingView.sortCol)) {
+    breedingView.sortCol = 'evPositiveTotal';
+    breedingView.sortDir = 'desc';
+  }
 });
 
 const isHorse = $derived(breedingView.species === 'horse');
@@ -70,15 +87,14 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
 
     <div class="controls">
         <div class="control-row">
-            <label class="control-label" for="breeding-species">Species</label>
-            <div class="species-toggle" role="radiogroup" id="breeding-species" aria-label="Breeding species">
+            <span class="control-label" id="breeding-species-label">Species</span>
+            <div class="species-toggle" aria-labelledby="breeding-species-label">
                 {#each species as s (s)}
                     <button
                         type="button"
                         class="species-btn"
                         class:active={breedingView.species === s}
-                        role="radio"
-                        aria-checked={breedingView.species === s}
+                        aria-pressed={breedingView.species === s}
                         onclick={() => (breedingView.species = s)}
                     >
                         {s}
@@ -106,7 +122,15 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
     </div>
 
     <section class="results">
-        {#if loading && pairs.length === 0}
+        {#if errored}
+            <div class="status-pane error" role="alert" data-testid="breeding-error">
+                <p><strong>Couldn't rank breeding pairs.</strong></p>
+                <p class="muted">
+                    Something went wrong while computing scores. Check the browser
+                    console for details, then change a control to retry.
+                </p>
+            </div>
+        {:else if loading && pairs.length === 0}
             <div class="status-pane" data-testid="breeding-loading">
                 <div class="spinner"></div>
                 <p>Computing pair scores…</p>
@@ -238,8 +262,13 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
         color: var(--text-muted);
     }
 
-    .status-pane.empty p {
+    .status-pane.empty p,
+    .status-pane.error p {
         margin: 0;
+    }
+
+    .status-pane.error {
+        color: var(--error-text, var(--text-secondary));
     }
 
     .spinner {

--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -13,13 +13,12 @@ let pairs = $state([]);
 let loading = $state(false);
 let pairsSequence = 0;
 
+const eligible = $derived($pets.filter((p) => p.stabled && normalizeSpecies(p.species) === breedingView.species));
+
 const eligibleForCurrent = $derived.by(() => {
-  const target = breedingView.species;
   let male = 0;
   let female = 0;
-  for (const p of $pets) {
-    if (!p.stabled) continue;
-    if (normalizeSpecies(p.species) !== target) continue;
+  for (const p of eligible) {
     if (p.gender === Gender.MALE) male++;
     else if (p.gender === Gender.FEMALE) female++;
   }
@@ -29,13 +28,12 @@ const eligibleForCurrent = $derived.by(() => {
 const attrNames = $derived(getAllAttributeNames(breedingView.species).map(capitalize));
 
 $effect(() => {
-  // Re-rank whenever the species, offspring breed, or pet list changes.
-  // Reads inside this effect are tracked by Svelte's reactivity; the
-  // sequence counter discards stale results when inputs change faster
-  // than the service responds.
+  // Re-rank whenever the species, offspring breed, or eligible-pets
+  // list changes. The sequence counter discards stale results when
+  // inputs change faster than the service responds.
   const targetSpecies = breedingView.species;
   const offspringBreed = breedingView.offspringBreed;
-  const eligible = $pets.filter((p) => p.stabled && normalizeSpecies(p.species) === targetSpecies);
+  const eligiblePets = eligible;
 
   const seq = ++pairsSequence;
   loading = true;
@@ -43,7 +41,7 @@ $effect(() => {
   rankBreedingPairs({
     species: targetSpecies,
     offspringBreed,
-    pets: eligible,
+    pets: eligiblePets,
   })
     .then((result) => {
       if (seq !== pairsSequence) return;
@@ -57,10 +55,6 @@ $effect(() => {
       loading = false;
     });
 });
-
-function setSpecies(s) {
-  breedingView.species = s;
-}
 
 const isHorse = $derived(breedingView.species === 'horse');
 const horseBreedOptions = Object.keys(HORSE_BREEDS);
@@ -85,7 +79,7 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
                         class:active={breedingView.species === s}
                         role="radio"
                         aria-checked={breedingView.species === s}
-                        onclick={() => setSpecies(s)}
+                        onclick={() => (breedingView.species = s)}
                     >
                         {s}
                     </button>

--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -1,23 +1,69 @@
 <script>
-import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { getAllAttributeNames, getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { breedingView } from '$lib/stores/breeding.svelte.js';
 import { pets } from '$lib/stores/pets.js';
-import { Gender } from '$lib/types/index.js';
+import { Gender, HORSE_BREEDS } from '$lib/types/index.js';
+import { capitalize } from '$lib/utils/string.js';
+import BreedingPairTable from './BreedingPairTable.svelte';
 
 const species = getSupportedSpecies();
 
-const eligibleBySpecies = $derived.by(() => {
-  const counts = {};
-  for (const s of species) counts[s] = { male: 0, female: 0 };
+let pairs = $state([]);
+let loading = $state(false);
+let pairsSequence = 0;
+
+const eligibleForCurrent = $derived.by(() => {
+  const target = breedingView.species;
+  let male = 0;
+  let female = 0;
   for (const p of $pets) {
     if (!p.stabled) continue;
-    const bucket = counts[normalizeSpecies(p.species)];
-    if (!bucket) continue;
-    if (p.gender === Gender.MALE) bucket.male++;
-    else if (p.gender === Gender.FEMALE) bucket.female++;
+    if (normalizeSpecies(p.species) !== target) continue;
+    if (p.gender === Gender.MALE) male++;
+    else if (p.gender === Gender.FEMALE) female++;
   }
-  return counts;
+  return { male, female };
 });
+
+const attrNames = $derived(getAllAttributeNames(breedingView.species).map(capitalize));
+
+$effect(() => {
+  // Re-rank whenever the species, offspring breed, or pet list changes.
+  // Reads inside this effect are tracked by Svelte's reactivity; the
+  // sequence counter discards stale results when inputs change faster
+  // than the service responds.
+  const targetSpecies = breedingView.species;
+  const offspringBreed = breedingView.offspringBreed;
+  const eligible = $pets.filter((p) => p.stabled && normalizeSpecies(p.species) === targetSpecies);
+
+  const seq = ++pairsSequence;
+  loading = true;
+
+  rankBreedingPairs({
+    species: targetSpecies,
+    offspringBreed,
+    pets: eligible,
+  })
+    .then((result) => {
+      if (seq !== pairsSequence) return;
+      pairs = result;
+      loading = false;
+    })
+    .catch((err) => {
+      if (seq !== pairsSequence) return;
+      console.error('rankBreedingPairs failed', err);
+      pairs = [];
+      loading = false;
+    });
+});
+
+function setSpecies(s) {
+  breedingView.species = s;
+}
+
+const isHorse = $derived(breedingView.species === 'horse');
+const horseBreedOptions = Object.keys(HORSE_BREEDS);
 </script>
 
 <div class="breeding-tab" data-testid="breeding-tab">
@@ -28,28 +74,68 @@ const eligibleBySpecies = $derived.by(() => {
         </p>
     </header>
 
-    <section class="status">
-        <h3>Eligible parents</h3>
-        <ul class="species-list">
-            {#each species as s (s)}
-                {@const counts = eligibleBySpecies[s] ?? { male: 0, female: 0 }}
-                <li>
-                    <strong>{s}</strong>: {counts.male} ♂ × {counts.female} ♀
-                    {#if counts.male > 0 && counts.female > 0}
-                        <span class="pair-count">→ {counts.male * counts.female} pair{counts.male * counts.female === 1 ? '' : 's'}</span>
-                    {:else}
-                        <span class="pair-count empty">→ no pairs (need at least one of each gender)</span>
-                    {/if}
-                </li>
-            {/each}
-        </ul>
-    </section>
+    <div class="controls">
+        <div class="control-row">
+            <label class="control-label" for="breeding-species">Species</label>
+            <div class="species-toggle" role="radiogroup" id="breeding-species" aria-label="Breeding species">
+                {#each species as s (s)}
+                    <button
+                        type="button"
+                        class="species-btn"
+                        class:active={breedingView.species === s}
+                        role="radio"
+                        aria-checked={breedingView.species === s}
+                        onclick={() => setSpecies(s)}
+                    >
+                        {s}
+                    </button>
+                {/each}
+            </div>
+        </div>
 
-    <section class="placeholder-note">
-        <p>
-            The ranking table and offspring-breed selector are coming in the next
-            iteration. Active species: <strong>{breedingView.species}</strong>.
-        </p>
+        {#if isHorse}
+            <div class="control-row">
+                <label class="control-label" for="offspring-breed">Offspring breed</label>
+                <select
+                    id="offspring-breed"
+                    bind:value={breedingView.offspringBreed}
+                    class="breed-select"
+                    data-testid="offspring-breed"
+                >
+                    <option value="">Mixed (no filter)</option>
+                    {#each horseBreedOptions as breed (breed)}
+                        <option value={breed}>{breed}</option>
+                    {/each}
+                </select>
+            </div>
+        {/if}
+    </div>
+
+    <section class="results">
+        {#if loading && pairs.length === 0}
+            <div class="status-pane" data-testid="breeding-loading">
+                <div class="spinner"></div>
+                <p>Computing pair scores…</p>
+            </div>
+        {:else if eligibleForCurrent.male === 0 || eligibleForCurrent.female === 0}
+            <div class="status-pane empty" data-testid="breeding-empty">
+                <p>
+                    No pairs to rank — need at least one stabled
+                    <strong>{breedingView.species}</strong> of each gender.
+                </p>
+                <p class="muted">
+                    Currently: {eligibleForCurrent.male} ♂ × {eligibleForCurrent.female} ♀
+                </p>
+            </div>
+        {:else}
+            <div class="results-meta">
+                <span>{pairs.length} pairs</span>
+                <span class="muted">
+                    {eligibleForCurrent.male} ♂ × {eligibleForCurrent.female} ♀
+                </span>
+            </div>
+            <BreedingPairTable results={pairs} {attrNames} />
+        {/if}
     </section>
 </div>
 
@@ -57,10 +143,10 @@ const eligibleBySpecies = $derived.by(() => {
     .breeding-tab {
         flex: 1;
         padding: 24px 32px;
-        overflow-y: auto;
+        overflow: hidden;
         display: flex;
         flex-direction: column;
-        gap: 24px;
+        gap: 16px;
     }
 
     .breeding-header h2 {
@@ -74,47 +160,104 @@ const eligibleBySpecies = $derived.by(() => {
         font-size: 13px;
     }
 
-    .status h3 {
-        font-size: 14px;
+    .controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px 24px;
+    }
+
+    .control-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .control-label {
+        font-size: 13px;
         font-weight: 600;
-        margin: 0 0 8px 0;
         color: var(--text-secondary);
     }
 
-    .species-list {
-        list-style: none;
-        padding: 0;
-        margin: 0;
+    .species-toggle {
+        display: flex;
+        background: var(--bg-tertiary);
+        border-radius: 6px;
+        padding: 2px;
+    }
+
+    .species-btn {
+        padding: 4px 12px;
+        background: transparent;
+        border: none;
+        color: var(--text-tertiary);
+        font-size: 13px;
+        font-weight: 600;
+        cursor: pointer;
+        border-radius: 4px;
+        text-transform: capitalize;
+    }
+
+    .species-btn:hover {
+        color: var(--text-secondary);
+    }
+
+    .species-btn.active {
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        box-shadow: var(--shadow-sm);
+    }
+
+    .breed-select {
+        padding: 4px 8px;
+        background: var(--bg-primary);
+        border: 1px solid var(--border-primary);
+        border-radius: 4px;
+        color: var(--text-primary);
+        font-size: 13px;
+    }
+
+    .results {
+        flex: 1;
         display: flex;
         flex-direction: column;
-        gap: 6px;
+        gap: 8px;
+        min-height: 0;
     }
 
-    .species-list li {
-        font-size: 14px;
+    .results-meta {
+        display: flex;
+        gap: 12px;
+        font-size: 13px;
     }
 
-    .pair-count {
-        margin-left: 8px;
+    .muted {
         color: var(--text-muted);
-        font-size: 13px;
     }
 
-    .pair-count.empty {
-        color: var(--text-tertiary);
-        font-style: italic;
+    .status-pane {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        color: var(--text-muted);
     }
 
-    .placeholder-note {
-        padding: 12px 16px;
-        background: var(--bg-secondary);
-        border: 1px dashed var(--border-primary);
-        border-radius: 6px;
-        color: var(--text-secondary);
-        font-size: 13px;
-    }
-
-    .placeholder-note p {
+    .status-pane.empty p {
         margin: 0;
+    }
+
+    .spinner {
+        width: 24px;
+        height: 24px;
+        border: 3px solid var(--border-primary);
+        border-top: 3px solid var(--accent);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+        to { transform: rotate(360deg); }
     }
 </style>

--- a/src/lib/services/demoService.ts
+++ b/src/lib/services/demoService.ts
@@ -53,6 +53,10 @@ export async function populateGenesIfNeeded(): Promise<void> {
 
 /**
  * Load demo pets from bundled sample genome files if the pets table is empty.
+ *
+ * Two horses (one of each gender) plus one beewasp give the Breeding
+ * Assistant tab at least one same-species M × F pair to rank from the
+ * first launch.
  */
 export async function loadDemoPetsIfNeeded(): Promise<void> {
   if (await hasPets()) return;
@@ -62,6 +66,7 @@ export async function loadDemoPetsIfNeeded(): Promise<void> {
   const demoFiles = [
     { path: 'resources/data/Genes_SampleFaeBee.txt', name: 'Sample Fae Bee', gender: 'Female', breed: '' },
     { path: 'resources/data/Genes_SampleHorse.txt', name: 'Sample Horse', gender: 'Male', breed: 'Standardbred' },
+    { path: 'resources/data/Genes_Roach.txt', name: 'Roach', gender: 'Female', breed: 'Standardbred' },
   ];
 
   for (const { path, name, gender, breed } of demoFiles) {

--- a/tests/e2e/backup.spec.js
+++ b/tests/e2e/backup.spec.js
@@ -109,10 +109,11 @@ test.describe('Database Backup – v2 Zip', () => {
   test('export and import (replace) round-trips correctly', async ({ page }) => {
     const zipBase64 = await createBackupZip(page);
     const before = await getPetState(page);
-    expect(before.petCount).toBe(2);
+    const initialCount = before.petCount;
+    expect(initialCount).toBeGreaterThan(1);
 
     await deleteFirstPet(page);
-    expect((await getPetState(page)).petCount).toBe(1);
+    expect((await getPetState(page)).petCount).toBe(initialCount - 1);
 
     const result = await importBackupZip(page, zipBase64, {
       mode: 'replace',
@@ -120,16 +121,18 @@ test.describe('Database Backup – v2 Zip', () => {
       includePets: true,
       includeImages: false,
     });
-    expect(result.pets).toBe(2);
+    expect(result.pets).toBe(initialCount);
     expect(result.petsSkipped).toBe(0);
 
     const after = await getPetState(page);
-    expect(after.petCount).toBe(2);
+    expect(after.petCount).toBe(initialCount);
     expect(after.petNames).toEqual(before.petNames);
   });
 
   test('export and import (merge) restores deleted pet', async ({ page }) => {
     const zipBase64 = await createBackupZip(page);
+    const initialCount = (await getPetState(page)).petCount;
+    expect(initialCount).toBeGreaterThan(1);
     await deleteFirstPet(page);
 
     const result = await importBackupZip(page, zipBase64, {
@@ -139,12 +142,13 @@ test.describe('Database Backup – v2 Zip', () => {
       includeImages: false,
     });
     expect(result.pets).toBe(1);
-    expect(result.petsSkipped).toBe(1);
-    expect((await getPetState(page)).petCount).toBe(2);
+    expect(result.petsSkipped).toBe(initialCount - 1);
+    expect((await getPetState(page)).petCount).toBe(initialCount);
   });
 
   test('merge on full database skips all existing pets', async ({ page }) => {
     const zipBase64 = await createBackupZip(page);
+    const initialCount = (await getPetState(page)).petCount;
     const result = await importBackupZip(page, zipBase64, {
       mode: 'merge',
       includeGenes: true,
@@ -152,10 +156,11 @@ test.describe('Database Backup – v2 Zip', () => {
       includeImages: false,
     });
     expect(result.pets).toBe(0);
-    expect(result.petsSkipped).toBe(2);
+    expect(result.petsSkipped).toBe(initialCount);
   });
 
   test('selective import (genes only) preserves pets', async ({ page }) => {
+    const initialCount = (await getPetState(page)).petCount;
     const zipBase64 = await createBackupZip(page, { includeGenes: true, includePets: false });
 
     const result = await importBackupZip(page, zipBase64, {
@@ -166,7 +171,7 @@ test.describe('Database Backup – v2 Zip', () => {
     });
     expect(result.genes).toBeGreaterThan(0);
     expect(result.pets).toBe(0);
-    expect((await getPetState(page)).petCount).toBe(2);
+    expect((await getPetState(page)).petCount).toBe(initialCount);
   });
 
   test('import rejects invalid zip files', async ({ page }) => {

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -12,13 +12,15 @@ async function pickSpeciesWithPairs(page) {
   // service returns at least one result.
   const speciesButtons = page.locator('.species-btn');
   const count = await speciesButtons.count();
+  const table = page.locator('[data-testid="breeding-pair-table"]');
   for (let i = 0; i < count; i++) {
     await speciesButtons.nth(i).click();
-    const table = page.locator('[data-testid="breeding-pair-table"]');
-    if (await table.isVisible().catch(() => false)) return true;
-    // Wait briefly for the empty state vs loading state to settle.
-    await page.waitForTimeout(200);
-    if (await table.isVisible().catch(() => false)) return true;
+    try {
+      await table.waitFor({ state: 'visible', timeout: 1000 });
+      return true;
+    } catch {
+      // Empty state for this species — try the next one.
+    }
   }
   return false;
 }

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -33,32 +33,45 @@ test.describe('Breeding Assistant — ranking UI (PR 4)', () => {
 
   test('renders the species toggle and ranks pairs for the active species', async ({ page }) => {
     await openBreedingTab(page);
-    await expect(page.locator('.species-btn')).toHaveCount(2);
+    // Asserted by name rather than count so adding a new species in
+    // configService doesn't break this test.
+    await expect(page.locator('.species-btn').filter({ hasText: /beewasp/i })).toHaveCount(1);
+    await expect(page.locator('.species-btn').filter({ hasText: /horse/i })).toHaveCount(1);
 
     const found = await pickSpeciesWithPairs(page);
-    if (!found) {
-      // Demo data lacks both genders for any species — verify the empty
-      // state at least surfaces the diagnostic counts so this never silently
-      // passes if the demo seeding changes.
-      await expect(page.locator('[data-testid="breeding-empty"]')).toBeVisible();
-      return;
-    }
-
+    expect(found).toBe(true);
     const rows = page.locator('[data-testid="breeding-pair-table"] tbody tr');
     await expect(rows.first()).toBeVisible();
   });
 
-  test('clicking a column header sorts the table', async ({ page }) => {
+  test('clicking a column header flips both the indicator and aria-sort', async ({ page }) => {
     await openBreedingTab(page);
     const found = await pickSpeciesWithPairs(page);
-    test.skip(!found, 'demo data has no eligible breeding pairs');
+    expect(found).toBe(true);
 
-    const totalHeader = page.locator('th button.sort-btn').filter({ hasText: 'Total +' });
-    await totalHeader.click();
-    // Asc indicator first click
-    await expect(page.locator('th.active button')).toContainText('▲');
-    await totalHeader.click();
-    await expect(page.locator('th.active button')).toContainText('▼');
+    const totalHeader = page.locator('th').filter({ hasText: 'Total +' });
+    await totalHeader.locator('button.sort-btn').click();
+    await expect(totalHeader).toHaveAttribute('aria-sort', 'ascending');
+    await expect(totalHeader.locator('button')).toContainText('▲');
+
+    await totalHeader.locator('button.sort-btn').click();
+    await expect(totalHeader).toHaveAttribute('aria-sort', 'descending');
+    await expect(totalHeader.locator('button')).toContainText('▼');
+
+    // If demo data ever grows to ≥2 pairs in one species, also verify
+    // the rows actually re-order. With a single pair this collapses to
+    // a no-op — the indicator/aria-sort assertions above still cover
+    // the user-visible behaviour, and the unit-level sort math is
+    // exercised by the breedingService tests.
+    const rows = page.locator('[data-testid="breeding-pair-table"] tbody tr');
+    const rowCount = await rows.count();
+    if (rowCount >= 2) {
+      const descTopName = await rows.first().locator('td').first().textContent();
+      await totalHeader.locator('button.sort-btn').click(); // back to ascending
+      await expect(totalHeader).toHaveAttribute('aria-sort', 'ascending');
+      const ascTopName = await rows.first().locator('td').first().textContent();
+      expect(ascTopName).not.toEqual(descTopName);
+    }
   });
 
   test('horse offspring-breed selector appears when species is horse', async ({ page }) => {
@@ -78,16 +91,16 @@ test.describe('Breeding Assistant — ranking UI (PR 4)', () => {
   test('clicking a parent name navigates to the Pets tab with that pet selected', async ({ page }) => {
     await openBreedingTab(page);
     const found = await pickSpeciesWithPairs(page);
-    test.skip(!found, 'demo data has no eligible breeding pairs');
+    expect(found).toBe(true);
 
     const firstParent = page.locator('[data-testid="breeding-pair-table"] .parent-link').first();
     const name = (await firstParent.textContent())?.trim();
     await firstParent.click();
 
     await expect(page.locator('.tab-btn').filter({ hasText: 'Pets' })).toHaveClass(/active/);
-    // Detail pane should show the selected pet's name somewhere — leaning
-    // on visibility of the pet header rather than locking to a specific
-    // class, since PetVisualization's structure is owned by another team.
-    await expect(page.getByText(name, { exact: false }).first()).toBeVisible();
+    // Scope the name check to the detail pane — `getByText` against the
+    // whole page would also match the pet card in the master list and
+    // pass even if no pet were actually selected.
+    await expect(page.locator('.detail-content').getByText(name, { exact: false }).first()).toBeVisible();
   });
 });

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -1,43 +1,91 @@
 import { expect, test } from '@playwright/test';
 import { waitForPets } from './helpers.js';
 
-test.describe('Breeding Assistant — tab scaffold (PR 3)', () => {
+async function openBreedingTab(page) {
+  await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
+  await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+}
+
+async function pickSpeciesWithPairs(page) {
+  // Try each species until we land on one that has at least one M × F
+  // pair from the demo data; the breeding table only renders when the
+  // service returns at least one result.
+  const speciesButtons = page.locator('.species-btn');
+  const count = await speciesButtons.count();
+  for (let i = 0; i < count; i++) {
+    await speciesButtons.nth(i).click();
+    const table = page.locator('[data-testid="breeding-pair-table"]');
+    if (await table.isVisible().catch(() => false)) return true;
+    // Wait briefly for the empty state vs loading state to settle.
+    await page.waitForTimeout(200);
+    if (await table.isVisible().catch(() => false)) return true;
+  }
+  return false;
+}
+
+test.describe('Breeding Assistant — ranking UI (PR 4)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
     await waitForPets(page);
   });
 
-  test('shows the Breed tab in the top bar', async ({ page }) => {
-    await expect(page.locator('.tab-btn').filter({ hasText: 'Breed' })).toBeVisible();
+  test('renders the species toggle and ranks pairs for the active species', async ({ page }) => {
+    await openBreedingTab(page);
+    await expect(page.locator('.species-btn')).toHaveCount(2);
+
+    const found = await pickSpeciesWithPairs(page);
+    if (!found) {
+      // Demo data lacks both genders for any species — verify the empty
+      // state at least surfaces the diagnostic counts so this never silently
+      // passes if the demo seeding changes.
+      await expect(page.locator('[data-testid="breeding-empty"]')).toBeVisible();
+      return;
+    }
+
+    const rows = page.locator('[data-testid="breeding-pair-table"] tbody tr');
+    await expect(rows.first()).toBeVisible();
   });
 
-  test('clicking the Breed tab activates the placeholder view', async ({ page }) => {
-    const tab = page.locator('.tab-btn').filter({ hasText: 'Breed' });
-    await tab.click();
-    await expect(tab).toHaveClass(/active/);
-    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
-    await expect(page.getByRole('heading', { name: /Breeding Assistant/i })).toBeVisible();
+  test('clicking a column header sorts the table', async ({ page }) => {
+    await openBreedingTab(page);
+    const found = await pickSpeciesWithPairs(page);
+    test.skip(!found, 'demo data has no eligible breeding pairs');
+
+    const totalHeader = page.locator('th button.sort-btn').filter({ hasText: 'Total +' });
+    await totalHeader.click();
+    // Asc indicator first click
+    await expect(page.locator('th.active button')).toContainText('▲');
+    await totalHeader.click();
+    await expect(page.locator('th.active button')).toContainText('▼');
   });
 
-  test('placeholder lists eligible-parent counts per supported species', async ({ page }) => {
-    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
-    const list = page.locator('.species-list');
-    await expect(list).toBeVisible();
-    // Each currently supported species gets its own row. Asserted by name
-    // rather than exact count so adding a new species in configService
-    // doesn't break this test.
-    await expect(list.locator('li').filter({ hasText: 'beewasp' })).toHaveCount(1);
-    await expect(list.locator('li').filter({ hasText: 'horse' })).toHaveCount(1);
+  test('horse offspring-breed selector appears when species is horse', async ({ page }) => {
+    await openBreedingTab(page);
+    const horseBtn = page.locator('.species-btn').filter({ hasText: /horse/i });
+    if ((await horseBtn.count()) === 0) test.skip(true, 'no horse species supported in this build');
+    await horseBtn.click();
+    await expect(page.locator('[data-testid="offspring-breed"]')).toBeVisible();
+
+    const beewaspBtn = page.locator('.species-btn').filter({ hasText: /beewasp/i });
+    if ((await beewaspBtn.count()) > 0) {
+      await beewaspBtn.click();
+      await expect(page.locator('[data-testid="offspring-breed"]')).toHaveCount(0);
+    }
   });
 
-  test('switching away from Breed tab and back preserves placeholder', async ({ page }) => {
-    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
-    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+  test('clicking a parent name navigates to the Pets tab with that pet selected', async ({ page }) => {
+    await openBreedingTab(page);
+    const found = await pickSpeciesWithPairs(page);
+    test.skip(!found, 'demo data has no eligible breeding pairs');
 
-    await page.locator('.tab-btn').filter({ hasText: 'Pets' }).click();
-    await expect(page.locator('[data-testid="breeding-tab"]')).toHaveCount(0);
+    const firstParent = page.locator('[data-testid="breeding-pair-table"] .parent-link').first();
+    const name = (await firstParent.textContent())?.trim();
+    await firstParent.click();
 
-    await page.locator('.tab-btn').filter({ hasText: 'Breed' }).click();
-    await expect(page.locator('[data-testid="breeding-tab"]')).toBeVisible();
+    await expect(page.locator('.tab-btn').filter({ hasText: 'Pets' })).toHaveClass(/active/);
+    // Detail pane should show the selected pet's name somewhere — leaning
+    // on visibility of the pet header rather than locking to a specific
+    // class, since PetVisualization's structure is owned by another team.
+    await expect(page.getByText(name, { exact: false }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Fourth slice of the **Breeding Assistant**. Replaces the PR-3 placeholder with the full ranking surface — species toggle, offspring-breed selector, sortable pair table — wired to the service from PR 2.

Builds on #191, #192, #193.

## What's in the box

- `src/lib/components/breeding/BreedingTab.svelte` (rewrite) — orchestrates the surface. Reactively re-ranks via `$effect` whenever the species, offspring breed, or pet list changes, with a sequence counter to discard stale results when inputs change faster than the service responds.
- `src/lib/components/breeding/BreedingPairTable.svelte` (new) — sortable table with fixed columns (♂ Male, ♀ Female, Mixed, Unknown, Total +) plus one column per species attribute (Toughness, Intelligence, Friendliness, Ruggedness, Enthusiasm, Virility, Temperament/Ferocity). Click a header to sort, click again to flip direction. Default: `evPositiveTotal` desc.
- Click a parent's name → jumps to the Pets tab with that pet selected (existing `appState.selectPet` + `switchTab` flow).

## Demo data

Added `Genes_Roach.txt` to the demo loader as a Female horse (Standardbred) so the Breeding tab has at least one M × F same-species pair on first launch. Without this, the table would never render for new users — and the new E2E coverage of sort + parent-click would always skip.

The file already exists in the repo (`data/Genes_Roach.txt` and `src-tauri/resources/data/Genes_Roach.txt`) — just unused until now.

## Notes for the reviewer

- **Race safety:** the `$effect` increments a `pairsSequence` counter and only writes back results if the counter still matches when the promise resolves — protects against the user flipping species while a previous `rankBreedingPairs` is in flight.
- **Loading state:** spinner only shows when `pairs` is empty (initial load), so flipping breed or species doesn't blank the table mid-interaction.
- **Empty state:** when the active species has 0 of either gender, the diagnostic counter (`X ♂ × Y ♀`) is surfaced so the user knows what's missing.
- **Backup test update:** swapped the hard-coded `petCount === 2` assertions in `backup.spec.js` for `initialCount` reads. Future demo-data tweaks won't break those tests.

## Performance

PR 2's perf test still owns the regression alarm at the service level (~71 ms for the worst case). The UI just renders results.

## Follow-up

| # | Surface |
|---|---|
| 5 | (optional) Shared two-pet locus walker, refactored from comparison |

## Test plan

- [x] \`biome check\` — clean
- [x] \`vitest run\` — 365/365 pass
- [x] \`playwright test breeding.spec.js\` — 4/4 pass (sort, breed selector visibility, parent click-through, ranked rows)
- [x] full \`playwright test\` — 121 passed, 2 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)