### PR TITLE
fix: set allowBuilds.esbuild to true in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 allowBuilds:
-  esbuild: set this to true or false
+  esbuild: true
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
The v0.6.0 release commit (#1c6563a) captured a placeholder value in `pnpm-workspace.yaml`:

\`\`\`yaml
allowBuilds:
  esbuild: set this to true or false
\`\`\`

pnpm writes that placeholder when the dev server boots without an explicit decision recorded; the release script's \`git add -A\` swept it into the release commit. Replace with the actual decision — \`esbuild: true\` — since esbuild does need its post-install build step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)