### PR TITLE
fix: don't count padded grid cells in genome diff totals

### DIFF
--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -240,8 +240,15 @@ async function loadData() {
           cellsB[block][i] = gB ? makeCell(gB) : null;
           const isDiff = (gA?.type || null) !== (gB?.type || null);
           diffs[block][i] = isDiff;
-          chrTotal++;
-          if (isDiff) chrDiffs++;
+          // Only count actual gene positions, not padded grid cells: sortedBlocks
+          // unions every block letter across all chromosomes (so chr 01 still
+          // iterates block L, which only chr 03 has) and maxLen is the largest
+          // chromosome's per-block size — counting those empty slots inflates
+          // totals (e.g. horse 1576 → 2304).
+          if (gA || gB) {
+            chrTotal++;
+            if (isDiff) chrDiffs++;
+          }
         }
       }
 

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -205,8 +205,11 @@ async function loadData() {
       return a.localeCompare(b);
     });
 
-    let totalGenes = 0;
-    let identicalGenes = 0;
+    // Total is a per-species constant — the gene catalog (loaded once and
+    // cached by `getGeneEffectsCached`) has one entry per genome position.
+    // Don't try to derive it from the display grid: `sortedBlocks` × `maxGenes`
+    // is a padded layout shape, not a gene count.
+    const totalGenes = Object.keys(effectsDB).length;
     let differentGenes = 0;
 
     chromosomeRows = chrKeys.map((chr) => {
@@ -222,7 +225,6 @@ async function loadData() {
       const cellsB = {};
       const diffs = {};
       let chrDiffs = 0;
-      let chrTotal = 0;
 
       for (const block of sortedBlocks) {
         const genesA = genesByBlockA.get(block) || [];
@@ -240,25 +242,15 @@ async function loadData() {
           cellsB[block][i] = gB ? makeCell(gB) : null;
           const isDiff = (gA?.type || null) !== (gB?.type || null);
           diffs[block][i] = isDiff;
-          // Only count actual gene positions, not padded grid cells: sortedBlocks
-          // unions every block letter across all chromosomes (so chr 01 still
-          // iterates block L, which only chr 03 has) and maxLen is the largest
-          // chromosome's per-block size — counting those empty slots inflates
-          // totals (e.g. horse 1576 → 2304).
-          if (gA || gB) {
-            chrTotal++;
-            if (isDiff) chrDiffs++;
-          }
+          if (isDiff) chrDiffs++;
         }
       }
 
-      totalGenes += chrTotal;
       differentGenes += chrDiffs;
-      identicalGenes += chrTotal - chrDiffs;
-
-      return { chr, cellsA, cellsB, diffs, chrTotal, chrDiffs, hasDiffs: chrDiffs > 0 };
+      return { chr, cellsA, cellsB, diffs, hasDiffs: chrDiffs > 0 };
     });
 
+    const identicalGenes = totalGenes - differentGenes;
     const pct = totalGenes > 0 ? Math.round((identicalGenes / totalGenes) * 100) : 0;
     summary = { totalGenes, identicalGenes, differentGenes, similarityPercent: pct };
   } catch (err) {

--- a/tests/e2e/comparison.spec.js
+++ b/tests/e2e/comparison.spec.js
@@ -86,4 +86,21 @@ test.describe('Pet Comparison', () => {
     // Compare button should show 1/2
     await expect(page.locator('.compare-now-btn')).toContainText('1/2');
   });
+
+  test('Genome Diff summary uses species gene total, not padded grid size', async ({ page }) => {
+    // Regression: the diff loop padded every chromosome to the largest
+    // chromosome's grid shape (sortedBlocks × maxGenes). For horses that
+    // padded shape was 48×48=2304 cells, which got reported as the gene
+    // total even though a horse genome only has 1576 positions.
+    await page.locator('.tab-btn').filter({ hasText: 'Compare' }).click();
+    await page.locator('.picker-pet-card').filter({ hasText: 'Sample Horse' }).click();
+    await page.locator('.picker-pet-card').filter({ hasText: 'Roach' }).click();
+
+    await page.locator('.view-tab').filter({ hasText: 'Genome Diff' }).click();
+
+    const summary = page.locator('.summary-detail');
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText('/1576 genes match');
+    await expect(summary).not.toContainText('/2304');
+  });
 });


### PR DESCRIPTION
## Summary
- Genome diff summary was reading "1487/2304 genes match" for two horses, but a horse genome only has 1576 genes.
- Root cause: `GenomeGridDiff.svelte` builds a uniform display grid by unioning every block letter across all chromosomes (`sortedBlocks`, A–L for horses since chr 03 has 12 blocks) and using the largest per-block gene count (`maxGenes`, 4 for horses). Every chromosome is padded to that grid shape for rendering — but the gene counter `chrTotal++` was firing on every grid cell, including empty padded slots. 48 chromosomes × 48 grid cells = exactly 2304.
- Fix: only count cells where at least one pet has an actual gene at that slot. Roach vs Sample Horse now reports 1576.

The simpler `GenomeDiff.svelte` view (which goes through `comparisonService.diffGenomes`) was unaffected — it iterates the flat `pet_genes` projection per chromosome with `Math.max(genesA.length, genesB.length)`, which was already correct.

## Test plan
- [ ] Open Comparison view for two horses (e.g. demo Roach vs Sample Horse), Genome Diff tab → "X/1576 genes match" (not 2304)
- [ ] Confirm percentage and `diff` count still add up: identical + diff = total
- [ ] Spot-check a non-horse species with different block layout to confirm count still matches that species' actual gene count

🤖 Generated with [Claude Code](https://claude.com/claude-code)