### PR TITLE
Release v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorgonetics",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Gorgon genetics breeding tool for Project Gorgon",
   "type": "module",
   "private": true,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "gorgonetics"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gorgonetics"
-version = "0.6.0"
+version = "0.6.1"
 description = "Gorgonetics - Pet Genetics Breeding Tool"
 authors = ["Javier Lopez Pena"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Gorgonetics",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "com.gorgonetics.app",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary

Patch release bumping `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock` from `0.6.0` to `0.6.1`.

Release notes were already committed in 88598bf — see `RELEASE_NOTES.md` for the user-facing changelog (gene effect corrections, gene editor export round-trip fix, asset invariant tests).

After merge, tag `v0.6.1` will be pushed to trigger the release build workflow.

## Test plan
- [x] `pnpm run lint:ci` clean
- [x] `pnpm test:e2e` — 122 passed, 2 skipped
- [x] `pnpm test` — 388 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)