### PR TITLE
Release v0.6.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,47 +1,23 @@
-# v0.6.1
+# v0.6.2
 
-A small patch release to ship hand-verified horse gene effect corrections and stabilise the gene editor export format so future fixes round-trip cleanly against the bundled asset files.
+A small but important patch. v0.6.1 shipped corrected horse gene effects, but the app's gene catalog only seeded itself on the very first launch — so anyone who already had Gorgonetics installed kept seeing the old, wrong effects after upgrading. This release fixes the upgrade path so future template fixes propagate automatically.
 
-## Horse gene effect corrections
+## Auto-refreshing gene templates
 
-Eight genes across six chromosomes had their dominant/recessive effects wrong in the bundled templates. Each correction was reviewed manually against in-game data:
+The app now hashes the bundled gene template files on each launch and re-syncs the gene catalog whenever the bundle's hash differs from what was last applied. After upgrading to v0.6.2, your catalog will pick up the v0.6.1 corrections (and any future ones) automatically — no need to wipe the database or re-import anything.
 
-- **chr15** `15D1` — Ruggedness+ moved from dominant to recessive
-- **chr16** `16J4` — dominant set to Toughness+
-- **chr20** `20F2`/`20F3` — Intelligence+ moved from F2 dominant to F3 dominant
-- **chr22** `22E2` — Virility+ moved from recessive to dominant
-- **chr24** `24B3` — cleared a stray dominant Toughness+
-- **chr42** `42E3`/`42E4` — recessive Intelligence+ corrected to Ruggedness+
+What's preserved across the refresh:
 
-If you previously imported the demo gene set, the app will pick up these corrections on next launch. (#214)
+- Any **notes** you've written on individual genes via the Gene Editor — the user-authored field is the explicit carve-out and is read back from your database before each upsert.
+- Pet stats — the `Total +` count on each pet is recomputed from the new effects in the background after launch, so the Stable view will update to reflect the corrected catalog automatically.
 
-## Gene editor export round-trip
+What changes:
 
-The chromosome export had two papercuts that produced massive cosmetic diffs whenever an exported file was used to update the bundled assets:
+- **effectDominant / effectRecessive / appearance / breed** track the bundled templates. If you'd previously edited any of these via the Gene Editor, those edits will be overwritten by the catalog. (See PR #219 for the rationale.)
 
-- The exported filename had a duplicated `chr` prefix (e.g. `horse_genes_chrchr15.json`).
-- The field order put `notes` before `breed`, while asset files used the reverse — and a cleared effect was written as `""` instead of `"None"`.
-
-Both are fixed: the editor now exports byte-identical JSON to the asset files when no edits are made. All 58 horse + beewasp asset files were also reordered to the canonical export shape (purely cosmetic — no gene effects changed by this rewrite). New tests lock in the export contract by round-tripping three real asset files through the gene editor pipeline. (#215)
-
-## New asset invariant tests
-
-Two species-specific data invariants are now enforced in CI:
-
-- **Beewasp**: dominant alleles always carry a negative or `"None"` effect; recessive alleles always positive or `"None"`. (#215)
-- **Horse**: chromosome 1 genes always carry a negative dominant *and* a positive recessive effect; genes on chr02..chr48 carry an effect on at most one allele. (#215)
-
-A future asset edit that violates either rule will fail the test suite without needing chromosome-by-chromosome manual review.
-
-## Other fixes
-
-- Genome diff totals no longer count padded grid cells, and the per-species total is now sourced from the gene catalog rather than a hardcoded constant. (#212, #213)
-- `pnpm-workspace.yaml` whitelists `esbuild` builds so fresh `pnpm install` runs no longer get blocked on the build-script approval prompt. (#203)
+The refresh is also defensive about edge cases — an empty bundle (resource directory missing) or a malformed JSON file abort the refresh without touching the catalog or the hash sentinel, so a launch can never silently brick the gene table.
 
 ## Dependency bumps
 
-- `tauri` 2.10.3 → 2.11.0 (#206)
-- `tauri-plugin-fs` 2.5.0 → 2.5.1 (#210)
-- `tauri-plugin-dialog` 2.7.0 → 2.7.1 (#211)
-- `@tauri-apps/api` 2.10.1 → 2.11.0 (#208)
-- `@tauri-apps/cli` 2.10.1 → 2.11.0 (#204)
+- `@sveltejs/kit` 2.57.1 → 2.59.1 (#206)
+- `@tauri-apps/plugin-fs` 2.5.0 → 2.5.1 (#205)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorgonetics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Gorgon genetics breeding tool for Project Gorgon",
   "type": "module",
   "private": true,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "gorgonetics"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gorgonetics"
-version = "0.6.1"
+version = "0.6.2"
 description = "Gorgonetics - Pet Genetics Breeding Tool"
 authors = ["Javier Lopez Pena"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Gorgonetics",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.gorgonetics.app",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Summary

Patch release bumping `package.json`, `tauri.conf.json`, `Cargo.toml`, and `Cargo.lock` from `0.6.1` to `0.6.2`, and updating `RELEASE_NOTES.md` with the user-facing changelog.

Headline: ships #219 (auto-refreshing gene templates) so the v0.6.1 gene corrections finally reach existing installs.

After merge, tag `v0.6.2` will be pushed to trigger the release build workflow.

## Test plan
- [x] `pnpm run lint:ci` clean
- [x] `pnpm test` — 395 unit tests pass
- [x] `pnpm test:e2e` — 122 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)