### PR TITLE
Release v0.6.3 — sync bundled gene assets with the canonical copy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,23 +1,13 @@
-# v0.6.2
+# v0.6.3
 
-A small but important patch. v0.6.1 shipped corrected horse gene effects, but the app's gene catalog only seeded itself on the very first launch — so anyone who already had Gorgonetics installed kept seeing the old, wrong effects after upgrading. This release fixes the upgrade path so future template fixes propagate automatically.
+Hotfix release. v0.6.1 shipped corrected horse gene effects and v0.6.2 shipped the auto-refresh that should have propagated them — but neither actually reached the bundled application because Tauri bundles assets from `src-tauri/resources/assets/`, not from the top-level `assets/` directory where the corrections were applied. The two directories had been silently drifting since the project's Tauri migration.
 
-## Auto-refreshing gene templates
+This release re-syncs the bundled asset directory from the canonical source. After upgrading, v0.6.2's auto-refresh will pick up the corrected templates on first launch and the gene editor (and every downstream view) will finally show the right effects.
 
-The app now hashes the bundled gene template files on each launch and re-syncs the gene catalog whenever the bundle's hash differs from what was last applied. After upgrading to v0.6.2, your catalog will pick up the v0.6.1 corrections (and any future ones) automatically — no need to wipe the database or re-import anything.
+If you've been running v0.6.2 with the wrong effects, simply install v0.6.3 — no manual intervention needed. The hash-gated refresh in v0.6.2 will detect the new bundle and re-sync your local catalog automatically; your gene notes are preserved across the refresh, and pet `Total +` counts are recomputed in the background to reflect the corrected effects.
 
-What's preserved across the refresh:
+## What's actually fixed
 
-- Any **notes** you've written on individual genes via the Gene Editor — the user-authored field is the explicit carve-out and is read back from your database before each upsert.
-- Pet stats — the `Total +` count on each pet is recomputed from the new effects in the background after launch, so the Stable view will update to reflect the corrected catalog automatically.
+The 58 horse + beewasp template JSONs in `src-tauri/resources/assets/` now match the corrected versions in `assets/`. Concretely, all the gene-effect corrections from #214 (chr15, chr16, chr20, chr22, chr24, chr42) and the field-order normalization from #215 are now in the bundle.
 
-What changes:
-
-- **effectDominant / effectRecessive / appearance / breed** track the bundled templates. If you'd previously edited any of these via the Gene Editor, those edits will be overwritten by the catalog. (See PR #219 for the rationale.)
-
-The refresh is also defensive about edge cases — an empty bundle (resource directory missing) or a malformed JSON file abort the refresh without touching the catalog or the hash sentinel, so a launch can never silently brick the gene table.
-
-## Dependency bumps
-
-- `@sveltejs/kit` 2.57.1 → 2.59.1 (#206)
-- `@tauri-apps/plugin-fs` 2.5.0 → 2.5.1 (#205)
+A follow-up issue (#222) tracks the structural fix to eliminate the duplication so future asset edits can't regress this way.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorgonetics",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Gorgon genetics breeding tool for Project Gorgon",
   "type": "module",
   "private": true,

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "gorgonetics"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gorgonetics"
-version = "0.6.2"
+version = "0.6.3"
 description = "Gorgonetics - Pet Genetics Breeding Tool"
 authors = ["Javier Lopez Pena"]
 license = "MIT"

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr01.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr01.json
@@ -4,319 +4,319 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B3",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C1",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01G1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01G2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01G3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01H1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01H3",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01H4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01I1",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01I3",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01I4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01J1",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01J2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr02.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr02.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A3",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D3",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E1",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Body Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr03.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr03.json
@@ -4,319 +4,319 @@
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A4",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G1",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J1",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Wing Color Hue",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr04.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr04.json
@@ -4,159 +4,159 @@
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Wing Color Saturation",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C3",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D2",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04E1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04E3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Color Intensity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr05.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr05.json
@@ -4,79 +4,79 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B3",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B4",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Glow",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr06.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr06.json
@@ -4,79 +4,79 @@
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A3",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B3",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Body Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr07.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr07.json
@@ -4,319 +4,319 @@
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Head Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D1",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D2",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Antenna Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H2",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Wing Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I1",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Tail Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr08.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr08.json
@@ -4,191 +4,191 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B2",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Antenna Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08F2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Deformity",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr09.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr09.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09A3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09A4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09B2",
     "effectDominant": "Ferocity-",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09B3",
     "effectDominant": "None",
     "effectRecessive": "Ferocity+",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09B4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09C2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Particle Location",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09D1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09D2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09D4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09E1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "09E4",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Particles",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/beewasp/beewasp_genes_chr10.json
+++ b/src-tauri/resources/assets/beewasp/beewasp_genes_chr10.json
@@ -4,111 +4,111 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "10D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr01.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr01.json
@@ -4,191 +4,191 @@
     "effectDominant": "Virility-",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01A4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B2",
     "effectDominant": "Toughness-",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B3",
     "effectDominant": "Temperament-",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01B4",
     "effectDominant": "Virility-",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01C4",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D1",
     "effectDominant": "Toughness-",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D2",
     "effectDominant": "Temperament-",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D3",
     "effectDominant": "Virility-",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01D4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E2",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E3",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01E4",
     "effectDominant": "Toughness-",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F1",
     "effectDominant": "Temperament-",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F2",
     "effectDominant": "Virility-",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F3",
     "effectDominant": "Friendliness-",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "01F4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr02.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr02.json
@@ -4,351 +4,351 @@
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A2",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02A4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B1",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02B4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D1",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02D4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02E4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02F2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02F3",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02G1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02G3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02G4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02H1",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02H2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02H4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02I1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02I2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02I4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02J1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02J2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02J3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02J4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02K1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02K3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "02K4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Hair",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr03.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr03.json
@@ -4,383 +4,383 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03B4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E1",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03E4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H2",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03H4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03J4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03K1",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03K3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03K4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03L1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03L2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03L3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "03L4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr04.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr04.json
@@ -4,127 +4,127 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "04D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr05.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr05.json
@@ -4,191 +4,191 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B1",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05D1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05D2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05D3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05D4",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05E2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05E3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05F2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05F3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "05F4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Face Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr06.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr06.json
@@ -4,319 +4,319 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A2",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06A4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06B4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06C4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06D1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06D3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06E1",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06E2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06E3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06F1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06F3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06F4",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06G1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06G2",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06H1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06H3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06I1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06I2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06I3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06J1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06J2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "06J4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Leg Markings",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr07.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr07.json
@@ -4,319 +4,319 @@
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07A4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07B4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07C4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07D4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07E4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Magical",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F1",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07F4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07G4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I2",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07I4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "07J4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Aura",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr08.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr08.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08A4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B1",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B2",
     "effectDominant": "None",
-    "effectRecessive": "Temperament-",
+    "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B3",
     "effectDominant": "None",
-    "effectRecessive": "None",
+    "effectRecessive": "Temperament-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   },
   {
     "gene": "08E4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": ""
+    "breed": "",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr09.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr09.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "09E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr10.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr10.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10A2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10A3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10A4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10B1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10B2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10B3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10B4",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10C1",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10C2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10C3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10C4",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10D1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10D2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10D4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10E1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10E2",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10E3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10E4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10F1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10F2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10F3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10F4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "10G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr11.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr11.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11A2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11A4",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11B4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11C2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11C4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11E1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11E3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11F4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11G1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11G4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11H2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11H4",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11I3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11J2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11J3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "11K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr12.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr12.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12A4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12B4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12C4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12D1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12D4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12E3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12F3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12G1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12H1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12H4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12I3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12J1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12J3",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   },
   {
     "gene": "12K2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Standardbred"
+    "breed": "Standardbred",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr13.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr13.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "13E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr14.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr14.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14A2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14A3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14A4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14B1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14B2",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14B3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14B4",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14C1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14C2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14C3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14D1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14D2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14D3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14D4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14E1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14E2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14E3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14E4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14F1",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14F2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14F3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14F4",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "14G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr15.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr15.json
@@ -4,335 +4,335 @@
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15A2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15A4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15B2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15B3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15B4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15C2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15D1",
-    "effectDominant": "Ruggedness+",
-    "effectRecessive": "None",
+    "effectDominant": "None",
+    "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15D2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15D3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15D4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15E1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15E3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15F1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15F2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15G1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15G3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15H1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15H3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15I1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15I4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15J3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "15K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr16.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr16.json
@@ -4,335 +4,335 @@
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16A3",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16A4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16B2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16B4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16C2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16D1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16D4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16E2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16F1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16F4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16G2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16G3",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16H3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16H4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16I1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16I3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16J2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16J4",
-    "effectDominant": "None",
+    "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16K1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   },
   {
     "gene": "16K2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Kurbone"
+    "breed": "Kurbone",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr17.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr17.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "17E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr18.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr18.json
@@ -4,223 +4,223 @@
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18A2",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18A3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18A4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18B1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18B2",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18B3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18B4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18C1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18C2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18C3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18D1",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18D2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18D3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18D4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18E1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18E2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18E3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18E4",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18F1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18F2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18F3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18F4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "18G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr19.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr19.json
@@ -4,335 +4,335 @@
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19A3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19B1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19B3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19C1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19C3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19D1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19D2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19D4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19E3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19F1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19F2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19F4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19G2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19H1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19H3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19H4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19J1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19J3",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "19K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr20.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr20.json
@@ -4,335 +4,335 @@
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20A2",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20A3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20B1",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20B3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20C1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20C2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20D1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20E1",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20E3",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20F1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20F2",
-    "effectDominant": "Intelligence+",
-    "effectRecessive": "None",
-    "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
-  },
-  {
-    "gene": "20F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
+  },
+  {
+    "gene": "20F3",
+    "effectDominant": "Intelligence+",
+    "effectRecessive": "None",
+    "appearance": "Scale",
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20G1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20G3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20H3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20H4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20I3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20J2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20J3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20J4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   },
   {
     "gene": "20K2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Ilmarian"
+    "breed": "Ilmarian",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr21.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr21.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "21E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr22.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr22.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22A2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22A3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22A4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22B1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22B2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22B3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22B4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22C1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22C2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22C3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22C4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22D1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22D2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22D4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22E1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22E2",
-    "effectDominant": "None",
-    "effectRecessive": "Virility+",
+    "effectDominant": "Virility+",
+    "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22E3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22E4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22F1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22F2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22F3",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22F4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "22G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr23.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr23.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23A2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23A4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23B2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23B3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23D1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23E1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23E3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23F2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23G2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23G4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23H3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23I1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23I3",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23I4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23J3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "23K2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr24.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr24.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24A3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24B2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24B3",
-    "effectDominant": "Toughness+",
+    "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24C3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24C4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24D1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24E1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24F2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24G1",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24G2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24G4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24H2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24I1",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24I4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24J1",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24J2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   },
   {
     "gene": "24K2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Plateau Pony"
+    "breed": "Plateau Pony",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr25.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr25.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "25E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr26.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr26.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26A2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26A3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26A4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26B1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26B2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26B3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26B4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26C1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26C2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26C3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26C4",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26D1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26D2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26D3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26D4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26E1",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26E2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26E3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26E4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26F1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26F2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26F3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26F4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "26G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr27.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr27.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27A2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27A3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27B2",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27B3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27B4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27C1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27C2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27C3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27C4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27D3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27D4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27E2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27F1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27F3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27F4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27G2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27H2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27H4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27I2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27I3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27I4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27J3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27K1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "27K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr28.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr28.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28A4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28B2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28B4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28C1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28D3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28E1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28E4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28F1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28F3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28G2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28G3",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28H2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28H3",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28I1",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28I3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28I4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28J2",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28J3",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28K1",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   },
   {
     "gene": "28K2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Satincoat"
+    "breed": "Satincoat",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr29.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr29.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "29E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr30.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr30.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30A2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30A3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30A4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30B1",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30B2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30B3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30B4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30C1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30C2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30C3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30C4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30D1",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30D2",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30D3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30D4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30E1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30E2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30E3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30E4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30F1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30F2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30F3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30F4",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "30G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr31.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr31.json
@@ -4,335 +4,335 @@
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31A3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31A4",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31B2",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31B3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31C1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31C4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31D1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31D2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31D4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31E3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31F1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31F4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31G2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31H1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31H3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31H4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31I3",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31I4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31J3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31J4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "31K2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr32.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr32.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32A2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32A3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32B1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32B4",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32C3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32C4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32D3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32D4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32E2",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32E3",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32F1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32F4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32G3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32G4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32H3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32I3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32I4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32J1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32J3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   },
   {
     "gene": "32K2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Statehelm"
+    "breed": "Statehelm",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr33.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr33.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "33E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr34.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr34.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34A2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34A3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34A4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34B1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34B2",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34B3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34B4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34C1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34C2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34C3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34C4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34D1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34D2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34D3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34D4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34E1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34E3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34E4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34F1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34F2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34F3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34F4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "34G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr35.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr35.json
@@ -4,335 +4,335 @@
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35A2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35A3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35B1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35B2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35B4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35C1",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35C3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35D1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35D2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35D3",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35D4",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35E3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35F1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35F3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35G1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35G2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35G4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35H1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35H3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35I1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35I4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35J2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35J3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35K1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "35K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr36.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr36.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36A2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36A4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36B4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36C1",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36C3",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36D1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36D3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36E1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36E3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36F1",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36F2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36F4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36G1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36G3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36G4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36H3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36H4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36I2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36I4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36J2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36K1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   },
   {
     "gene": "36K2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Blanketed"
+    "breed": "Blanketed",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr37.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr37.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "37E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr38.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr38.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38A2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38A3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38A4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38B1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38B2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38B3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38B4",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38C1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38C2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38C3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38C4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38D1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38D2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38D3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38D4",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38E1",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38E3",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38E4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38F1",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38F2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38F3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38F4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "38G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr39.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr39.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39A2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39A3",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39A4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39B2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39B3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39B4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39C2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39C3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39C4",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39D1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39D4",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39E2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39E3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39E4",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39F2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39F4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39G1",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39G3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39H1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39H3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39H4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39I2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39I3",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39J1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39J4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "39K2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr40.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr40.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40A2",
     "effectDominant": "None",
     "effectRecessive": "Virility-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40A4",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40B2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40C1",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40C2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40C4",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40D2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40D3",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40E1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40E4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40F2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40F3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40F4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40G2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40H1",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40H3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40H4",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40I2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40I3",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40I4",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40J3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40J4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   },
   {
     "gene": "40K2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Leopard"
+    "breed": "Leopard",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr41.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr41.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "41E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr42.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr42.json
@@ -4,223 +4,223 @@
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42A2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42A3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42A4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42B1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42B2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42B3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42B4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42C1",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42C2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42C3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42C4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42D1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42D2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42D4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42E1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42E2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42E3",
     "effectDominant": "None",
-    "effectRecessive": "Intelligence+",
+    "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42E4",
     "effectDominant": "None",
-    "effectRecessive": "Intelligence+",
+    "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42F1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42F2",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42F3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42F4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "42G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr43.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr43.json
@@ -4,335 +4,335 @@
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43A2",
     "effectDominant": "Toughness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43A3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43A4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43B3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43C1",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43C2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43C4",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43D2",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43D3",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43E2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43E3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43E4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43F1",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43F2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43F3",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43G2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43G3",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43H2",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43H3",
     "effectDominant": "Virility-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43H4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43I2",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43I4",
     "effectDominant": "Friendliness-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43J2",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43J4",
     "effectDominant": "None",
     "effectRecessive": "Toughness-",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43K1",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "43K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr44.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr44.json
@@ -4,335 +4,335 @@
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44A3",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44B1",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44B3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44B4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44C1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44C3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44D2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44D4",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44E2",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44E3",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44F3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness-",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44F4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44G1",
     "effectDominant": "Intelligence-",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44G2",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44G4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44H1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44H2",
     "effectDominant": "Temperament-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44H4",
     "effectDominant": "Enthusiasm-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44I1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44I3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44I4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44J1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44J2",
     "effectDominant": "Ruggedness-",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44J3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44J4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44K1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   },
   {
     "gene": "44K2",
     "effectDominant": "None",
     "effectRecessive": "Temperament-",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Paint"
+    "breed": "Paint",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr45.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr45.json
@@ -4,159 +4,159 @@
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45A2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45A3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45A4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45B1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45B2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45B3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45C2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45D2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45E2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45E3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "45E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Selector",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr46.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr46.json
@@ -4,223 +4,223 @@
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46A2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46A3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46A4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46B1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46B2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46B3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46B4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46C1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46C2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46C3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46C4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46D1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46D2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46D3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46D4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46E1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46E2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46E3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46E4",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46F1",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46F2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46F3",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46F4",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Attributes",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46G3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "46G4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "None",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr47.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr47.json
@@ -4,335 +4,335 @@
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47A2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47A3",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47A4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47B1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47B2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47B3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47C2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47C3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47C4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47D1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47D2",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47D3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47D4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47E1",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47E2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47E3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47E4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47F1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47F3",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47F4",
     "effectDominant": "Enthusiasm+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47G1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47G2",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47G3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47G4",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Coat",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47H1",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47H2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47H4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47I1",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47I2",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47I3",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47I4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47J1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47J2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47J3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47J4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47K1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "47K2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Markings",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   }
 ]

--- a/src-tauri/resources/assets/horse/horse_genes_chr48.json
+++ b/src-tauri/resources/assets/horse/horse_genes_chr48.json
@@ -4,335 +4,335 @@
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48A2",
     "effectDominant": "Ruggedness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48A3",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48A4",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48B1",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48B2",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48B3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48B4",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48C1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48C2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48C3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48C4",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48D1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48D2",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48D3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48D4",
     "effectDominant": "None",
     "effectRecessive": "Friendliness+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48E1",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48E2",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48E3",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48E4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48F1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48F2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48F3",
     "effectDominant": "None",
     "effectRecessive": "Intelligence+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48F4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48G1",
     "effectDominant": "Toughness+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48G2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48G3",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48G4",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Scale",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48H1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48H2",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48H3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48H4",
     "effectDominant": "None",
     "effectRecessive": "Virility+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48I1",
     "effectDominant": "Temperament+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48I2",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48I3",
     "effectDominant": "None",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48I4",
     "effectDominant": "Intelligence+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48J1",
     "effectDominant": "None",
     "effectRecessive": "Ruggedness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48J2",
     "effectDominant": "None",
     "effectRecessive": "Enthusiasm+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48J3",
     "effectDominant": "Virility+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48J4",
     "effectDominant": "Friendliness+",
     "effectRecessive": "None",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48K1",
     "effectDominant": "None",
     "effectRecessive": "Toughness+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   },
   {
     "gene": "48K2",
     "effectDominant": "None",
     "effectRecessive": "Temperament+",
     "appearance": "Horn",
-    "notes": "",
-    "breed": "Calico"
+    "breed": "Calico",
+    "notes": ""
   }
 ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Gorgonetics",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "com.gorgonetics.app",
   "build": {
     "frontendDist": "../build",


### PR DESCRIPTION
## Why

Per the screenshot in the chat: a fresh v0.6.2 install still showed the *old* effects on horse 15D1 (Ruggedness+ on dominant instead of recessive). v0.6.2's auto-refresh feature was working correctly — it was refreshing the DB to match the bundled assets — but the bundled assets in `src-tauri/resources/assets/` had been silently stale since the Tauri migration. The v0.6.1 corrections (#214) and the format normalization (#215) only updated the top-level `assets/` tree, never reaching the bundle.

Issue went latent because earlier versions only seeded the catalog on first install; v0.6.2's auto-refresh is the first time the bundled state is actually applied to existing installs on every launch.

## What

Copy `assets/horse/*.json` → `src-tauri/resources/assets/horse/` and the same for beewasp. 58 files, all template content. Confirmed via `diff -q`: the `.json` files in both directories are now byte-identical (the only remaining differences are the `.omc/` artifact dir and `.DS_Store`, which we're leaving alone).

Also bumps the four version files to 0.6.3 and refreshes `RELEASE_NOTES.md`.

## How users get the fix

Install v0.6.3 → on first launch, v0.6.2's `refreshGeneTemplatesIfChanged` sees the new bundle hash, re-syncs the local catalog, preserves gene notes, queues the background backfill that recomputes per-pet `Total +` counts. No manual intervention.

## Follow-up

#222 tracks the structural fix to deduplicate the two trees — symlink, pre-build copy, or pointing `tauri.conf.json` at `../assets/` directly.

## Test plan
- [x] `diff -q assets/horse src-tauri/resources/assets/horse` — JSON files match
- [x] `pnpm run lint:ci` — clean (one pre-existing biome schema-version info, unrelated)
- [x] `pnpm test` — 395/395 pass
- [x] `pnpm test:e2e` — 121 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)