### PR TITLE
Release script: cd to repo root + fail loud on empty notes (closes #221)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,8 +42,9 @@ fi
 # Anchor at the repo root so every relative path (package.json,
 # src-tauri/Cargo.toml, RELEASE_NOTES.md, …) resolves correctly even if
 # the script was invoked from a subdirectory. v0.6.2 shipped with an
-# empty tag annotation because `cat RELEASE_NOTES.md` ran with cwd in
-# src-tauri/ — the heredoc swallowed cat's stderr and produced "".
+# empty tag annotation because `git tag -m "...$(cat RELEASE_NOTES.md)..."`
+# ran with cwd in src-tauri/; cat's stderr surfaced but the surrounding
+# command substitution still resolved to "" and the tag pushed cleanly.
 cd "$(git rev-parse --show-toplevel)"
 
 git pull --ff-only
@@ -144,11 +145,11 @@ COMPARE_LINK="**Full Changelog**: https://github.com/gorgonetics/Gorgonetics/com
 
 if [[ -f "$NOTES_FILE" ]]; then
   echo "Using release notes from $NOTES_FILE ($(wc -c <"$NOTES_FILE") bytes)"
-  BODY=$(cat "$NOTES_FILE")
-  if [[ -z "${BODY// }" ]]; then
-    echo "Error: $NOTES_FILE is empty — refusing to tag with no annotation"
+  if ! grep -q '[^[:space:]]' "$NOTES_FILE"; then
+    echo "Error: $NOTES_FILE has no non-whitespace content — refusing to tag with no annotation"
     exit 1
   fi
+  BODY=$(cat "$NOTES_FILE")
 else
   echo "No notes file at $NOTES_FILE — generating changelog from git log"
   if [[ -n "$LAST_TAG" ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,13 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
+# Anchor at the repo root so every relative path (package.json,
+# src-tauri/Cargo.toml, RELEASE_NOTES.md, …) resolves correctly even if
+# the script was invoked from a subdirectory. v0.6.2 shipped with an
+# empty tag annotation because `cat RELEASE_NOTES.md` ran with cwd in
+# src-tauri/ — the heredoc swallowed cat's stderr and produced "".
+cd "$(git rev-parse --show-toplevel)"
+
 git pull --ff-only
 
 # --- Read current version ---
@@ -136,8 +143,12 @@ LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 COMPARE_LINK="**Full Changelog**: https://github.com/gorgonetics/Gorgonetics/compare/${LAST_TAG:-initial}...v$NEW_VERSION"
 
 if [[ -f "$NOTES_FILE" ]]; then
-  echo "Using release notes from $NOTES_FILE"
+  echo "Using release notes from $NOTES_FILE ($(wc -c <"$NOTES_FILE") bytes)"
   BODY=$(cat "$NOTES_FILE")
+  if [[ -z "${BODY// }" ]]; then
+    echo "Error: $NOTES_FILE is empty — refusing to tag with no annotation"
+    exit 1
+  fi
 else
   echo "No notes file at $NOTES_FILE — generating changelog from git log"
   if [[ -n "$LAST_TAG" ]]; then


### PR DESCRIPTION
## Summary

Closes #221.

`scripts/release.sh` is full of relative paths (`package.json`, `src-tauri/Cargo.toml`, `RELEASE_NOTES.md`, …). If invoked with a non-root cwd — exactly what happened during the v0.6.2 release after an earlier `cd src-tauri && cargo check` — `cat RELEASE_NOTES.md` errored to stderr but the surrounding heredoc resolved to `""`, and the tag was pushed with an empty annotation.

- Add `cd "$(git rev-parse --show-toplevel)"` immediately after the branch + cleanliness checks. Anchors every subsequent relative path to the repo root regardless of the caller's cwd.
- Fail loudly (`exit 1`) if the resolved notes file is empty, rather than silently tagging with a blank body. Logs the byte count so the resolved size is visible before the tag command runs.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax clean
- [x] Verified `cd "$(git rev-parse --show-toplevel)"` in a subshell from `src-tauri/` resolves to the repo root
- [ ] Next real release exercises the full flow — defer end-to-end verification until v0.6.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)