### PR TITLE
fix(pets): optimistic stable/star toggle without full reload

### DIFF
--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -106,7 +106,9 @@ function selectPet(pet) {
 async function toggleMarker(petId, key, value) {
   const pet = $pets.find((p) => p.id === petId);
   if (pet && pet[key] === value) return;
-  await appState.updatePet(petId, { [key]: value });
+  // Optimistic in-place flip — no full list reload, so the toggle is
+  // instant (#275). Errors are surfaced via the shared `error` store.
+  await appState.setPetMarker(petId, key, value).catch(() => {});
 }
 
 async function handleUpload() {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -105,7 +105,7 @@ function selectPet(pet) {
 
 async function toggleMarker(petId, key, value) {
   const pet = $pets.find((p) => p.id === petId);
-  if (pet && pet[key] === value) return;
+  if (!pet || pet[key] === value) return;
   // Optimistic in-place flip — no full list reload, so the toggle is
   // instant (#275). Errors are surfaced via the shared `error` store.
   await appState.setPetMarker(petId, key, value).catch(() => {});

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -6,6 +6,9 @@ import { errorMessage } from '$lib/utils/error.js';
 
 export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding' | 'community';
 
+/** Boolean pet flags toggled in-place via `setPetMarker` (no full reload). */
+export type MarkerKey = 'starred' | 'stabled' | 'is_pet_quality';
+
 export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
 export const loading = writable(false);
@@ -98,6 +101,42 @@ export const appState = {
       throw err;
     } finally {
       loading.set(false);
+    }
+  },
+
+  /**
+   * Flip a single boolean marker (starred/stabled/pet-quality) in place.
+   *
+   * Unlike `updatePet`, this does NOT reload the whole pet list or raise the
+   * global `loading` flag — both make a one-field toggle feel sluggish (#275).
+   * The change is applied optimistically to `pets` (and `selectedPet` if it
+   * matches), persisted in the background, and rolled back if the write fails.
+   */
+  async setPetMarker(petId: number, key: MarkerKey, value: boolean) {
+    let previous: boolean | undefined;
+    pets.update((list) =>
+      list.map((p) => {
+        if (p.id !== petId) return p;
+        previous = p[key];
+        return { ...p, [key]: value };
+      }),
+    );
+    const sel = getCurrentValue(selectedPet);
+    const selMatches = !!sel && sel.id === petId;
+    if (selMatches) selectedPet.set({ ...sel, [key]: value });
+
+    const rollback = () => {
+      pets.update((list) => list.map((p) => (p.id === petId ? { ...p, [key]: previous } : p)));
+      if (selMatches) selectedPet.set({ ...sel, [key]: previous });
+    };
+
+    try {
+      const committed = await petService.updatePet(petId, { [key]: value });
+      if (!committed) throw new Error(`pet ${petId} not found`);
+    } catch (err: unknown) {
+      rollback();
+      error.set(`Failed to update pet: ${errorMessage(err)}`);
+      throw err;
     }
   },
 

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -51,6 +51,13 @@ const TAB_STATE_RESETS: Record<Tab, () => void> = {
 // leaving the Pets/Stable tab on a stale snapshot until the next refresh.
 let loadGeneration = 0;
 
+// Tracks the latest in-flight `setPetMarker` op per `${petId}:${key}`. A
+// rapid re-toggle of the same marker supersedes the earlier op; when an
+// earlier (now-stale) write later fails, its rollback/error must be skipped
+// so it can't clobber the newer optimistic value or flash a stale error.
+let markerOpSeq = 0;
+const markerOps = new Map<string, number>();
+
 export const appState = {
   async loadPets() {
     const myGeneration = ++loadGeneration;
@@ -113,6 +120,13 @@ export const appState = {
    * matches), persisted in the background, and rolled back if the write fails.
    */
   async setPetMarker(petId: number, key: MarkerKey, value: boolean) {
+    // Claim the latest-op slot for this pet+key. A later toggle bumps this,
+    // marking us stale (see `markerOps`).
+    const opKey = `${petId}:${key}`;
+    const opId = ++markerOpSeq;
+    markerOps.set(opKey, opId);
+    const isLatest = () => markerOps.get(opKey) === opId;
+
     let previous: boolean | undefined;
     pets.update((list) =>
       list.map((p) => {
@@ -121,22 +135,29 @@ export const appState = {
         return { ...p, [key]: value };
       }),
     );
-    const sel = getCurrentValue(selectedPet);
-    const selMatches = !!sel && sel.id === petId;
-    if (selMatches) selectedPet.set({ ...sel, [key]: value });
-
-    const rollback = () => {
-      pets.update((list) => list.map((p) => (p.id === petId ? { ...p, [key]: previous } : p)));
-      if (selMatches) selectedPet.set({ ...sel, [key]: previous });
+    // Mirror onto `selectedPet` only while it still points at this pet —
+    // re-read on each write so we never overwrite a selection the user
+    // changed during the in-flight DB write.
+    const applyToSelected = (v: boolean | undefined) => {
+      const cur = getCurrentValue(selectedPet);
+      if (cur && cur.id === petId) selectedPet.set({ ...cur, [key]: v });
     };
+    applyToSelected(value);
 
     try {
       const committed = await petService.updatePet(petId, { [key]: value });
       if (!committed) throw new Error(`pet ${petId} not found`);
     } catch (err: unknown) {
-      rollback();
-      error.set(`Failed to update pet: ${errorMessage(err)}`);
+      // A newer toggle superseded us: leave its optimistic value (and any
+      // error it may raise) intact rather than reverting to our stale baseline.
+      if (isLatest()) {
+        pets.update((list) => list.map((p) => (p.id === petId ? { ...p, [key]: previous } : p)));
+        applyToSelected(previous);
+        error.set(`Failed to update pet: ${errorMessage(err)}`);
+      }
       throw err;
+    } finally {
+      if (isLatest()) markerOps.delete(opKey);
     }
   },
 

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -120,6 +120,21 @@ export const appState = {
    * matches), persisted in the background, and rolled back if the write fails.
    */
   async setPetMarker(petId: number, key: MarkerKey, value: boolean) {
+    // Optimistically flip the field, capturing the prior boolean for
+    // rollback. `found` keeps us from writing (and later restoring an
+    // `undefined`) for a pet that isn't in the current list.
+    let found = false;
+    let previous = false;
+    pets.update((list) =>
+      list.map((p) => {
+        if (p.id !== petId) return p;
+        found = true;
+        previous = p[key];
+        return { ...p, [key]: value };
+      }),
+    );
+    if (!found) return;
+
     // Claim the latest-op slot for this pet+key. A later toggle bumps this,
     // marking us stale (see `markerOps`).
     const opKey = `${petId}:${key}`;
@@ -127,18 +142,10 @@ export const appState = {
     markerOps.set(opKey, opId);
     const isLatest = () => markerOps.get(opKey) === opId;
 
-    let previous: boolean | undefined;
-    pets.update((list) =>
-      list.map((p) => {
-        if (p.id !== petId) return p;
-        previous = p[key];
-        return { ...p, [key]: value };
-      }),
-    );
     // Mirror onto `selectedPet` only while it still points at this pet —
     // re-read on each write so we never overwrite a selection the user
     // changed during the in-flight DB write.
-    const applyToSelected = (v: boolean | undefined) => {
+    const applyToSelected = (v: boolean) => {
       const cur = getCurrentValue(selectedPet);
       if (cur && cur.id === petId) selectedPet.set({ ...cur, [key]: v });
     };

--- a/tests/unit/petMarker.test.js
+++ b/tests/unit/petMarker.test.js
@@ -46,7 +46,14 @@ describe('appState.setPetMarker', () => {
     const list = get(pets);
     expect(list.find((p) => p.id === 1).stabled).toBe(true);
     expect(list.find((p) => p.id === 2).stabled).toBe(false);
-    expect(updatePet).toHaveBeenCalledExactlyOnceWith(1, { stabled: true });
+    expect(updatePet).toHaveBeenCalledTimes(1);
+    expect(updatePet).toHaveBeenCalledWith(1, { stabled: true });
+  });
+
+  it('is a no-op when the pet is not in the list', async () => {
+    await appState.setPetMarker(999, 'stabled', true);
+    expect(updatePet).not.toHaveBeenCalled();
+    expect(get(pets).map((p) => p.id)).toEqual([1, 2]);
   });
 
   it('does not raise the global loading flag', async () => {

--- a/tests/unit/petMarker.test.js
+++ b/tests/unit/petMarker.test.js
@@ -1,0 +1,92 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/services/petService.js', () => ({
+  updatePet: vi.fn(),
+  getAllPets: vi.fn(),
+  deletePet: vi.fn(),
+  reorderPets: vi.fn(),
+  uploadPet: vi.fn(),
+}));
+
+import { updatePet } from '$lib/services/petService.js';
+import { appState, error, loading, pets, selectedPet } from '$lib/stores/pets.js';
+
+function makePet(id, overrides = {}) {
+  return {
+    id,
+    name: `Pet-${id}`,
+    species: 'BeeWasp',
+    starred: false,
+    stabled: false,
+    is_pet_quality: false,
+    tags: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(updatePet).mockReset().mockResolvedValue(true);
+  pets.set([makePet(1), makePet(2)]);
+  selectedPet.set(null);
+  error.set(null);
+  loading.set(false);
+});
+
+afterEach(() => {
+  pets.set([]);
+  selectedPet.set(null);
+  error.set(null);
+});
+
+describe('appState.setPetMarker', () => {
+  it('flips the field in place without reloading or touching other pets', async () => {
+    await appState.setPetMarker(1, 'stabled', true);
+
+    const list = get(pets);
+    expect(list.find((p) => p.id === 1).stabled).toBe(true);
+    expect(list.find((p) => p.id === 2).stabled).toBe(false);
+    expect(updatePet).toHaveBeenCalledExactlyOnceWith(1, { stabled: true });
+  });
+
+  it('does not raise the global loading flag', async () => {
+    let sawLoading = false;
+    const unsub = loading.subscribe((v) => {
+      if (v) sawLoading = true;
+    });
+    await appState.setPetMarker(1, 'starred', true);
+    unsub();
+    expect(sawLoading).toBe(false);
+  });
+
+  it('mirrors the change onto selectedPet when it is the same pet', async () => {
+    selectedPet.set(makePet(1));
+    await appState.setPetMarker(1, 'starred', true);
+    expect(get(selectedPet).starred).toBe(true);
+  });
+
+  it('leaves selectedPet untouched when a different pet is toggled', async () => {
+    selectedPet.set(makePet(2));
+    await appState.setPetMarker(1, 'stabled', true);
+    expect(get(selectedPet).stabled).toBe(false);
+  });
+
+  it('rolls back the optimistic change and surfaces the error when the write throws', async () => {
+    selectedPet.set(makePet(1));
+    vi.mocked(updatePet).mockRejectedValueOnce(new Error('db down'));
+
+    await expect(appState.setPetMarker(1, 'stabled', true)).rejects.toThrow('db down');
+
+    expect(get(pets).find((p) => p.id === 1).stabled).toBe(false);
+    expect(get(selectedPet).stabled).toBe(false);
+    expect(get(error)).toMatch(/Failed to update pet/);
+  });
+
+  it('rolls back when the write reports no rows committed', async () => {
+    vi.mocked(updatePet).mockResolvedValueOnce(false);
+
+    await expect(appState.setPetMarker(1, 'starred', true)).rejects.toThrow();
+
+    expect(get(pets).find((p) => p.id === 1).starred).toBe(false);
+  });
+});

--- a/tests/unit/petMarker.test.js
+++ b/tests/unit/petMarker.test.js
@@ -89,4 +89,45 @@ describe('appState.setPetMarker', () => {
 
     expect(get(pets).find((p) => p.id === 1).starred).toBe(false);
   });
+
+  it('does not clobber a selection the user changed during the in-flight write', async () => {
+    selectedPet.set(makePet(1));
+    let reject;
+    vi.mocked(updatePet).mockReturnValueOnce(
+      new Promise((_, rej) => {
+        reject = rej;
+      }),
+    );
+
+    const pending = appState.setPetMarker(1, 'stabled', true);
+    // User navigates to a different pet while the write is in flight.
+    selectedPet.set(makePet(2));
+    reject(new Error('db down'));
+
+    await expect(pending).rejects.toThrow('db down');
+    // Rollback must leave the newer selection (pet 2) in place.
+    expect(get(selectedPet).id).toBe(2);
+  });
+
+  it('a superseded failing toggle does not revert the newer optimistic value', async () => {
+    let rejectFirst;
+    vi.mocked(updatePet)
+      .mockReturnValueOnce(
+        new Promise((_, rej) => {
+          rejectFirst = rej;
+        }),
+      )
+      .mockResolvedValueOnce(true);
+
+    const first = appState.setPetMarker(1, 'stabled', true); // in flight, will fail
+    const second = appState.setPetMarker(1, 'stabled', false); // supersedes
+    await second;
+    rejectFirst(new Error('late failure'));
+    await expect(first).rejects.toThrow('late failure');
+
+    // The newer toggle's value wins; the stale failure neither reverts it
+    // nor surfaces an error.
+    expect(get(pets).find((p) => p.id === 1).stabled).toBe(false);
+    expect(get(error)).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the noticeable pause when toggling the stable (🏠) / star (⭐) marker on a pet card in the Pets view.

The toggles routed through `appState.updatePet`, which — after persisting a single boolean — called `loadPets()`, doing a full `getAllPets()` DB round-trip, replacing the entire `pets` array, and raising the global `loading` flag. For a one-field change that's heavy and re-renders the whole list.

## Change

- Add `appState.setPetMarker(petId, key, value)` (`src/lib/stores/pets.ts`): optimistically flips the single boolean on `pets` (and `selectedPet` when it matches), persists in the background **without** the global loading flag or a list reload, and rolls back if the write fails (throw or 0-rows-committed).
- `PetList.toggleMarker` now calls `setPetMarker` instead of `updatePet`.
- The editor save path (`PetEditor.svelte`) intentionally keeps the full-reload `updatePet`, since those edits touch tags/attributes/genome and benefit from a canonical reload.

## Tests

`tests/unit/petMarker.test.js` — 6 cases: in-place flip without touching other pets, no global loading flag, `selectedPet` mirroring (same vs different pet), rollback + error on throw, rollback on 0-rows-committed.

All 476 unit tests pass; Biome clean.

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)