### PR TITLE
feat(nav): add back navigation between tabs

### DIFF
--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -1,13 +1,34 @@
 <script>
+import { ArrowLeft } from '@lucide/svelte';
 import logoImg from '$lib/assets/logo.png';
-import { activeTab, appState } from '$lib/stores/pets.js';
+import { activeTab, appState, canGoBack } from '$lib/stores/pets.js';
 import DataMenu from './DataMenu.svelte';
 import SettingsModal from './SettingsModal.svelte';
 
 function switchTab(tab) {
   appState.switchTab(tab);
 }
+
+function handleWindowKeydown(e) {
+  // Alt+Left → previous tab. Don't hijack it while the user is typing.
+  if (!(e.altKey && e.key === 'ArrowLeft')) return;
+  const t = e.target;
+  if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return;
+  e.preventDefault();
+  appState.goBack();
+}
+
+function handleMouseUp(e) {
+  // Mouse "back" button (button 3) → previous tab. goBack is a no-op
+  // when there's no history, so an unconditional call is safe.
+  if (e.button === 3) {
+    e.preventDefault();
+    appState.goBack();
+  }
+}
 </script>
+
+<svelte:window onkeydown={handleWindowKeydown} onmouseup={handleMouseUp} />
 
 <header class="top-bar">
     <div class="top-bar-left">
@@ -15,6 +36,15 @@ function switchTab(tab) {
         <span class="app-name">Gorgonetics</span>
     </div>
     <div class="top-bar-right">
+    <button
+        class="back-btn"
+        onclick={() => appState.goBack()}
+        disabled={!$canGoBack}
+        title="Back to previous tab (Alt+←)"
+        aria-label="Back to previous tab"
+    >
+        <ArrowLeft size={16} />
+    </button>
     <nav aria-label="Main navigation" class="top-bar-tabs">
         <button
             class="tab-btn"
@@ -100,6 +130,30 @@ function switchTab(tab) {
         display: flex;
         align-items: center;
         gap: 12px;
+    }
+
+    .back-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 30px;
+        height: 30px;
+        border: none;
+        border-radius: 6px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .back-btn:hover:not(:disabled) {
+        color: var(--text-primary);
+        background: var(--border-primary);
+    }
+
+    .back-btn:disabled {
+        opacity: 0.35;
+        cursor: default;
     }
 
     .top-bar-tabs {

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -13,6 +13,14 @@ export const error: Writable<string | null> = writable(null);
 export const geneEditingView: Writable<unknown> = writable(null);
 export const activeTab: Writable<Tab> = writable('pets');
 
+// Bounded back-stack of previously-active tabs (oldest first, newest last),
+// driving the TopBar "back" control (#276). Capped so long sessions of tab
+// hopping don't grow it without bound.
+const MAX_TAB_HISTORY = 50;
+const tabHistory: Writable<Tab[]> = writable([]);
+/** True when `appState.goBack()` has a previous tab to return to. */
+export const canGoBack = derived(tabHistory, (h) => h.length > 0);
+
 /** All unique tags across all pets, sorted. Shared by PetEditor and PetList. */
 export const allTags = derived(pets, ($pets) => [...new Set($pets.flatMap((p) => p.tags ?? []))].sort());
 
@@ -146,8 +154,31 @@ export const appState = {
   },
 
   switchTab(tab: Tab) {
+    const current = getCurrentValue(activeTab);
+    // Record the tab we're leaving so `goBack` can return to it. Re-selecting
+    // the already-active tab still re-runs its state reset (existing
+    // behaviour) but must not stack a duplicate history entry.
+    if (current !== undefined && current !== tab) {
+      tabHistory.update((h) => {
+        const next = [...h, current];
+        return next.length > MAX_TAB_HISTORY ? next.slice(next.length - MAX_TAB_HISTORY) : next;
+      });
+    }
     activeTab.set(tab);
     TAB_STATE_RESETS[tab]();
+  },
+
+  /** Return to the previously-active tab. No-op when there's no history. */
+  goBack() {
+    let target: Tab | undefined;
+    tabHistory.update((h) => {
+      if (h.length === 0) return h;
+      target = h[h.length - 1];
+      return h.slice(0, -1);
+    });
+    if (target === undefined) return;
+    activeTab.set(target);
+    TAB_STATE_RESETS[target]();
   },
 
   clearError() {

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -194,5 +194,8 @@ export const appState = {
     geneEditingView.set(null);
     error.set(null);
     loading.set(false);
+    // Drop the back-stack too — its entries point into the pre-reset
+    // session and shouldn't survive a full reset (#276 review).
+    tabHistory.set([]);
   },
 };

--- a/tests/unit/tabNavigation.test.js
+++ b/tests/unit/tabNavigation.test.js
@@ -70,4 +70,12 @@ describe('tab navigation history', () => {
     expect(get(activeTab)).toBe('editor');
     expect(get(selectedPet)).toBeNull();
   });
+
+  it('clears the back-stack on reset', () => {
+    appState.switchTab('stable');
+    expect(get(canGoBack)).toBe(true);
+
+    appState.reset();
+    expect(get(canGoBack)).toBe(false);
+  });
 });

--- a/tests/unit/tabNavigation.test.js
+++ b/tests/unit/tabNavigation.test.js
@@ -1,0 +1,73 @@
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/services/petService.js', () => ({
+  updatePet: vi.fn(),
+  getAllPets: vi.fn(),
+  deletePet: vi.fn(),
+  reorderPets: vi.fn(),
+  uploadPet: vi.fn(),
+}));
+
+import { activeTab, appState, canGoBack, selectedPet } from '$lib/stores/pets.js';
+
+beforeEach(() => {
+  // Drain any history left over from a previous test, then return to a
+  // known starting tab. (tabHistory is module-private by design.)
+  let guard = 0;
+  while (get(canGoBack) && guard++ < 200) appState.goBack();
+  activeTab.set('pets');
+  selectedPet.set(null);
+});
+
+describe('tab navigation history', () => {
+  it('starts with no back history', () => {
+    expect(get(canGoBack)).toBe(false);
+  });
+
+  it('records the previous tab and returns to it on goBack', () => {
+    appState.switchTab('stable');
+    expect(get(activeTab)).toBe('stable');
+    expect(get(canGoBack)).toBe(true);
+
+    appState.goBack();
+    expect(get(activeTab)).toBe('pets');
+    expect(get(canGoBack)).toBe(false);
+  });
+
+  it('walks back through multiple tabs in LIFO order', () => {
+    appState.switchTab('stable');
+    appState.switchTab('breeding');
+    appState.switchTab('community');
+
+    appState.goBack();
+    expect(get(activeTab)).toBe('breeding');
+    appState.goBack();
+    expect(get(activeTab)).toBe('stable');
+    appState.goBack();
+    expect(get(activeTab)).toBe('pets');
+    expect(get(canGoBack)).toBe(false);
+  });
+
+  it('does not push a duplicate entry when re-selecting the active tab', () => {
+    appState.switchTab('pets');
+    expect(get(canGoBack)).toBe(false);
+  });
+
+  it('goBack is a no-op when there is no history', () => {
+    appState.goBack();
+    expect(get(activeTab)).toBe('pets');
+    expect(get(canGoBack)).toBe(false);
+  });
+
+  it('runs the per-tab state reset when navigating back', () => {
+    appState.switchTab('editor'); // editor reset clears selectedPet
+    selectedPet.set({ id: 1, name: 'x' });
+    appState.switchTab('pets');
+    expect(get(selectedPet)).not.toBeNull();
+
+    appState.goBack(); // back to editor → reset clears selection again
+    expect(get(activeTab)).toBe('editor');
+    expect(get(selectedPet)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a simple way to return to the previously-viewed tab — there was no back affordance before.

## Change

- Store (`src/lib/stores/pets.ts`): a bounded (≤50) back-stack of previously-active tabs. `switchTab` records the tab being left; new `appState.goBack()` pops and returns to it; `canGoBack` (derived) drives the UI. Re-selecting the active tab still re-runs its state reset but doesn't stack a duplicate entry, and `goBack` re-applies the per-tab state reset for the target.
- `TopBar.svelte`: a back button (← icon) before the tab group, disabled when there's no history, plus **Alt+←** and the **mouse back button** as shortcuts. The keyboard handler ignores keystrokes while typing in inputs/textareas.

## Tests

`tests/unit/tabNavigation.test.js` — 6 cases: empty initial history, record + return, LIFO multi-step walk, no duplicate on same-tab reselect, no-op goBack, and per-tab reset firing on back.

All 476 unit tests pass; Biome clean; production build succeeds.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)