### PR TITLE
chore(firebase): wire real public web config for `gorgonetics` project

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "gorgonetics-share"
+    "default": "gorgonetics"
   }
 }

--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -9,9 +9,13 @@ See `docs/design/public-pet-sharing-v1.md` for the design rationale.
 
 ## One-time project creation
 
-1. Visit <https://console.firebase.google.com> and create a new project
-   named **`gorgonetics`**. Stay on the default **Spark** plan
-   (no card required).
+1. Visit <https://console.firebase.google.com> and create a new project.
+   The **project ID** must be **`gorgonetics`** (not just the display
+   name) — `.firebaserc` and the SDK config both pin that exact ID, so a
+   mismatched ID leaves the CLI target and config out of sync. Firebase
+   may suffix the ID if `gorgonetics` is taken; if so, use the resulting
+   ID consistently in `.firebaserc` and `src/lib/firebase.ts`. Stay on
+   the default **Spark** plan (no card required).
 2. In the project, open **Build → Firestore Database → Create database**.
    - Mode: **Production** (rules deny by default).
    - Location: any region close to the user base — e.g. `eur3` for

--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -10,7 +10,7 @@ See `docs/design/public-pet-sharing-v1.md` for the design rationale.
 ## One-time project creation
 
 1. Visit <https://console.firebase.google.com> and create a new project
-   named **`gorgonetics-share`**. Stay on the default **Spark** plan
+   named **`gorgonetics`**. Stay on the default **Spark** plan
    (no card required).
 2. In the project, open **Build → Firestore Database → Create database**.
    - Mode: **Production** (rules deny by default).
@@ -29,8 +29,11 @@ values from step 4 above:
 ```ts
 const firebaseConfig = {
   apiKey: '…',
-  authDomain: 'gorgonetics-share.firebaseapp.com',
-  projectId: 'gorgonetics-share',
+  authDomain: 'gorgonetics.firebaseapp.com',
+  projectId: 'gorgonetics',
+  storageBucket: 'gorgonetics.firebasestorage.app',
+  messagingSenderId: '…',
+  appId: '…',
 };
 ```
 
@@ -46,7 +49,7 @@ it globally with `npm i -g firebase-tools` if you prefer).
 
 ```bash
 pnpm exec firebase login
-pnpm exec firebase use gorgonetics-share
+pnpm exec firebase use gorgonetics
 pnpm exec firebase deploy --only firestore:rules
 pnpm exec firebase deploy --only firestore:indexes   # empty in v1
 ```
@@ -54,7 +57,7 @@ pnpm exec firebase deploy --only firestore:indexes   # empty in v1
 Both files are checked in at the repo root:
 
 - `firebase.json` — points the CLI at `firestore.rules` + indexes.
-- `.firebaserc` — pins the `default` project alias to `gorgonetics-share`.
+- `.firebaserc` — pins the `default` project alias to `gorgonetics`.
 - `firestore.rules` — the entire backend (see design §4).
 - `firestore.indexes.json` — empty for v1; populated when filtering lands.
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -5,10 +5,9 @@
  * is not a secret. Security comes from `firestore.rules`, not from hiding
  * these values.
  *
- * Before this module can talk to a real project, replace the placeholder
- * values with the config printed by `firebase apps:sdkconfig web` after
- * creating the `gorgonetics-share` Firebase project on the Spark plan.
- * See docs/firebase-setup.md for the full procedure.
+ * The config below is the real public config for the `gorgonetics` Firebase
+ * project (Spark plan), printed by `firebase apps:sdkconfig web`. See
+ * docs/firebase-setup.md for the full procedure.
  */
 
 import { getApp, getApps, initializeApp } from 'firebase/app';
@@ -17,9 +16,12 @@ import { getFirestore } from 'firebase/firestore';
 const PLACEHOLDER_API_KEY = 'PLACEHOLDER_REPLACE_AFTER_PROJECT_CREATION';
 
 const firebaseConfig = {
-  apiKey: PLACEHOLDER_API_KEY,
-  authDomain: 'gorgonetics-share.firebaseapp.com',
-  projectId: 'gorgonetics-share',
+  apiKey: 'AIzaSyC4dMgz9Ocu1-KOp-DGxZOOwdm4zS1VRC0',
+  authDomain: 'gorgonetics.firebaseapp.com',
+  projectId: 'gorgonetics',
+  storageBucket: 'gorgonetics.firebasestorage.app',
+  messagingSenderId: '12621482059',
+  appId: '1:12621482059:web:dd9960e2d6d1a7a592a5ce',
 };
 
 export const isPlaceholderConfig = firebaseConfig.apiKey === PLACEHOLDER_API_KEY;
@@ -41,7 +43,7 @@ export function assertFirebaseConfigured(): void {
   if (isPlaceholderConfig) {
     throw new Error(
       'Firebase is not configured: src/lib/firebase.ts still uses the placeholder ' +
-        'apiKey. Replace it with the real public config from the gorgonetics-share ' +
+        'apiKey. Replace it with the real public config from the gorgonetics ' +
         'project (see docs/firebase-setup.md) before using the community catalogue.',
     );
   }

--- a/tests/e2e/community.spec.js
+++ b/tests/e2e/community.spec.js
@@ -1,13 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { waitForPets } from './helpers.js';
+import { blockFirestore, waitForPets } from './helpers.js';
 
 // Exercises the dialog flow: open, preview, cancel, backdrop, Escape, and the
-// disabled state when Firebase is unconfigured (which is always true in this
-// build — `src/lib/firebase.ts` ships a placeholder apiKey by design). The
-// upload round-trip is covered by tests/integration/shareService.emulator.test.js.
+// enabled Share button now that the real public Firebase config ships in the
+// bundle (PR #279 — `isPlaceholderConfig` is false). Firestore traffic is
+// aborted via `blockFirestore` so the suite stays offline and never touches
+// the live project; the upload round-trip is covered by
+// tests/integration/shareService.emulator.test.js.
 
 test.describe('Share Pet Dialog', () => {
   test.beforeEach(async ({ page }) => {
+    await blockFirestore(page);
     await page.goto('/');
     await waitForPets(page);
     await page.locator('.pet-card').first().click();
@@ -25,11 +28,14 @@ test.describe('Share Pet Dialog', () => {
     await expect(page.locator('[data-testid="share-preview"]')).toBeVisible();
   });
 
-  test('shows the not-configured banner and disables the Share button on this build', async ({ page }) => {
+  test('enables the Share button now that Firebase is configured', async ({ page }) => {
     await page.locator('[data-testid="share-pet-btn"]').click();
 
-    await expect(page.locator('[data-testid="share-not-configured"]')).toBeVisible();
-    await expect(page.locator('[data-testid="share-confirm"]')).toBeDisabled();
+    // Real config ships in the bundle, so the not-configured banner is gone
+    // and the confirm button is live. We do not click it — that would attempt
+    // a write, which `blockFirestore` aborts anyway.
+    await expect(page.locator('[data-testid="share-not-configured"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="share-confirm"]')).toBeEnabled();
   });
 
   test('Cancel closes the dialog', async ({ page }) => {
@@ -62,14 +68,18 @@ test.describe('Share Pet Dialog', () => {
 });
 
 // PR 4 — Community catalogue browser tab.
-// Firestore is unreachable in this build (placeholder apiKey), so the store
-// surfaces the "not configured" error path. We assert the tab is reachable
-// and that the empty/error state renders correctly. The real fetch +
-// pagination + import paths are covered by the unit suite (mocked SDK) and
-// the integration suite (Firestore Emulator).
+// Firebase is configured in this build (PR #279), but `blockFirestore`
+// aborts all backend traffic so the suite stays offline and never touches
+// the live project or burns Spark quota. We assert the tab renders and is
+// navigable under a blocked backend. The fetch/error/pagination/import
+// paths (including the load-error UI) are covered by the unit suite (mocked
+// SDK) and the integration suite (Firestore Emulator) — exercising the
+// network-error path here is unreliable because the Firestore SDK retries
+// the WebChannel indefinitely rather than letting `getDocs` reject.
 
 test.describe('Community Tab', () => {
   test.beforeEach(async ({ page }) => {
+    await blockFirestore(page);
     await page.goto('/');
     await waitForPets(page);
   });
@@ -77,13 +87,6 @@ test.describe('Community Tab', () => {
   test('Community tab is reachable from the TopBar', async ({ page }) => {
     await page.locator('[data-testid="tab-community"]').click();
     await expect(page.locator('[data-testid="community-tab"]')).toBeVisible();
-  });
-
-  test('surfaces the not-configured error when Firebase is not set up', async ({ page }) => {
-    await page.locator('[data-testid="tab-community"]').click();
-    const errorBox = page.locator('[data-testid="community-error"]');
-    await expect(errorBox).toBeVisible();
-    await expect(errorBox).toContainText(/not configured/i);
   });
 
   test('shows the empty-selection panel until a row is clicked', async ({ page }) => {

--- a/tests/e2e/helpers.js
+++ b/tests/e2e/helpers.js
@@ -39,3 +39,19 @@ export async function openEditor(page) {
   await page.locator('.edit-btn').first().click();
   await expect(page.locator('.modal-panel')).toBeVisible();
 }
+
+/**
+ * Abort every request to the Firestore backend so e2e never touches the
+ * live `gorgonetics` project. Since PR #279 wired the real public config
+ * into the bundle, `isPlaceholderConfig` is false in all builds — without
+ * this, the community store's `listPets` would make non-deterministic
+ * network calls against production and burn Spark read quota on each CI
+ * run. Aborting makes `getDocs` reject with `unavailable`, exercising the
+ * store's load-error path deterministically and offline.
+ *
+ * Install this BEFORE `page.goto` so the route is in place before any
+ * SDK call fires.
+ */
+export async function blockFirestore(page) {
+  await page.route('**://firestore.googleapis.com/**', (route) => route.abort());
+}


### PR DESCRIPTION
## Summary

Flips public pet sharing from disabled → live by wiring the **real public web config** into `src/lib/firebase.ts`. `isPlaceholderConfig` is now `false`, so the service layer (`uploadPet`, `listPets`, …) will talk to the live `gorgonetics` Firestore project instead of throwing `assertFirebaseConfigured()`.

These values are **public** — they identify the project, they do not authorise writes. Security comes from `firestore.rules`, not from hiding this config (see design §4).

## Changes

- `src/lib/firebase.ts` — real `apiKey`/`appId`/`storageBucket`/`messagingSenderId` from `firebase apps:sdkconfig web`; stale header comment updated.
- `.firebaserc` + `docs/firebase-setup.md` — project id `gorgonetics-share` → `gorgonetics`; doc config example expanded to the full six-field shape.

## Note on overlap with #257

This carries the same `gorgonetics-share → gorgonetics` rename that already landed on the #257 branch (commit `9dc7c49`). The rename is inseparable from wiring the real config (the apiKey is for project `gorgonetics`), and rewriting #257's history to pull it out was off the table. Whichever PR merges second reconciles to the identical value — no conflict.

## Remote project state

Done out-of-repo by the maintainer: project created, web app registered, `firebase login` + `firebase deploy --only firestore:rules` both succeeded. So once this merges, sharing is live.

## Test plan

- [x] `pnpm run lint:ci` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)