### PR TITLE
perf(pets): drop genome blobs from getAllPets list path (#254)

### DIFF
--- a/src/lib/components/community/CommunityPetDetail.svelte
+++ b/src/lib/components/community/CommunityPetDetail.svelte
@@ -3,6 +3,7 @@ import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { getSharedPet } from '$lib/services/shareService.js';
 import { clearSelection, communityView, importSelected, selectedSharedPet } from '$lib/stores/community.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
+import { keyedResource } from '$lib/utils/keyedResource.svelte.js';
 import { formatShortDate } from '$lib/utils/timestamp.js';
 
 const pet = $derived(selectedSharedPet());
@@ -17,55 +18,31 @@ const isImportingThis = $derived(communityView.importingHash === pet?.contentHas
 const isAnyImportInFlight = $derived(communityView.importingHash !== null);
 
 // The list view holds metadata-only SharedPets (no `genomeData`); the
-// detail pane fetches the genome on demand. Tracked locally so the store
-// doesn't need a parallel "full pet" cache layer.
-let fullPet = $state(null);
-let genomeLoading = $state(false);
-let genomeError = $state(null);
+// detail pane fetches the full pet on demand via the shared keyed resource,
+// which rejects a stale result if the user moves to another row mid-fetch.
 let importStatus = $state(null);
 
-// Non-reactive guard against duplicate fetches. We can't read `fullPet`
-// inside the effect (assigning to it during the effect body would
-// retrigger the effect before the in-flight `getSharedPet` resolves,
-// firing a second fetch for the same hash), so we track the in-flight
-// hash separately as a plain variable.
-let loadedHash = '';
+const genome = keyedResource(
+  () => pet?.contentHash,
+  (hash) => getSharedPet(hash),
+);
+const genomeLoading = $derived(genome.loading);
+// A successful fetch whose `genomeData` is missing means the blob was taken
+// down — surfaced as an error message, distinct from a genuine fetch failure.
+const fullPet = $derived(genome.value?.genomeData ? genome.value : null);
+const genomeError = $derived(
+  genome.error
+    ? errorMessage(genome.error)
+    : genome.value && !genome.value.genomeData
+      ? 'Genome data is missing for this pet — it may have been taken down.'
+      : null,
+);
 
+// Reset the transient import banner when the selection changes, so a stale
+// "Imported …" message doesn't follow the user across rows.
 $effect(() => {
-  const hash = pet?.contentHash;
-  // Reset transient state whenever the selection changes — stale
-  // "Imported …" banners would otherwise follow the user across rows.
+  void pet?.contentHash;
   importStatus = null;
-  genomeError = null;
-  if (!hash) {
-    fullPet = null;
-    genomeLoading = false;
-    loadedHash = '';
-    return;
-  }
-  if (loadedHash === hash) return;
-
-  loadedHash = hash;
-  fullPet = null;
-  genomeLoading = true;
-  getSharedPet(hash)
-    .then((p) => {
-      // The user might have moved on while the fetch was in flight; only
-      // accept the result if it still matches the current selection.
-      if (loadedHash !== hash) return;
-      if (!p?.genomeData) {
-        genomeError = 'Genome data is missing for this pet — it may have been taken down.';
-        return;
-      }
-      fullPet = p;
-    })
-    .catch((err) => {
-      if (loadedHash !== hash) return;
-      genomeError = errorMessage(err);
-    })
-    .finally(() => {
-      if (loadedHash === hash) genomeLoading = false;
-    });
 });
 
 async function handleImport() {

--- a/src/lib/components/community/SharePetDialog.svelte
+++ b/src/lib/components/community/SharePetDialog.svelte
@@ -1,6 +1,7 @@
 <script>
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { isPlaceholderConfig } from '$lib/firebase.js';
+import { getPetGenomeText } from '$lib/services/petService.js';
 import { sanitizeTags, uploadPet } from '$lib/services/shareService.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
@@ -11,22 +12,58 @@ let includeNotes = $state(false);
 let sharing = $state(false);
 let shareError = $state('');
 
+// The list path (`getAllPets`) omits `genome_text` for payload size
+// (issue #254), so `selectedPet` — and therefore the `pet` prop here —
+// usually lacks it. Lazy-load it by id. `undefined` means "still loading";
+// a string (possibly '') means resolved.
+let genomeText = $state(undefined);
+
+$effect(() => {
+  // Seed directly when the prop already carries the text (full-row fetches
+  // / the in-memory test adapter, which returns whole rows) — skip the query.
+  if (typeof pet?.genome_text === 'string') {
+    genomeText = pet.genome_text;
+    return;
+  }
+  const id = pet?.id;
+  if (typeof id !== 'number') {
+    genomeText = '';
+    return;
+  }
+  let cancelled = false;
+  getPetGenomeText(id)
+    .then((text) => {
+      if (!cancelled) genomeText = text ?? '';
+    })
+    .catch(() => {
+      if (!cancelled) genomeText = '';
+    });
+  return () => {
+    cancelled = true;
+  };
+});
+
 const previewTags = $derived(sanitizeTags(pet?.tags ?? []));
 const hasNotes = $derived(typeof pet?.notes === 'string' && pet.notes.trim().length > 0);
+const genomeLoading = $derived(genomeText === undefined);
 // Legacy pets imported before migration v13 don't have the raw genome
 // text on file, so we can't recompute the hash-matching upload payload
 // for them. They can be shared after the user re-imports the file.
-const hasRawGenome = $derived(typeof pet?.genome_text === 'string' && pet.genome_text.length > 0);
+const hasRawGenome = $derived(typeof genomeText === 'string' && genomeText.length > 0);
 
 async function handleShare() {
   // Belt-and-suspenders: the Share button is disabled when the placeholder
-  // config is still in place or the pet lacks raw genome text, so this
-  // should never fire. The early return guards programmatic re-entry.
+  // config is still in place, the genome text is still loading, or the pet
+  // lacks raw genome text, so this should never fire. The early return
+  // guards programmatic re-entry.
   if (isPlaceholderConfig || !hasRawGenome) return;
   sharing = true;
   shareError = '';
   try {
-    const petToShare = includeNotes ? pet : { ...pet, notes: '' };
+    const base = includeNotes ? pet : { ...pet, notes: '' };
+    // Attach the lazily-loaded raw text — `pet` from the list path doesn't
+    // carry it. uploadPet re-hashes this against content_hash.
+    const petToShare = { ...base, genome_text: genomeText };
     const result = await uploadPet(petToShare);
     if (result.status === 'already-shared') {
       onResult({
@@ -80,6 +117,8 @@ async function handleShare() {
           uploads are disabled. See <code>docs/firebase-setup.md</code> for how to wire up a
           Firebase project, or wait for a release with sharing enabled.
         </div>
+      {:else if genomeLoading}
+        <div class="banner" data-testid="share-genome-loading">Loading genome…</div>
       {:else if !hasRawGenome}
         <div class="banner banner-warn" data-testid="share-no-raw-genome">
           This pet was imported with an older app version that didn't store the raw
@@ -160,9 +199,9 @@ async function handleShare() {
         class="btn btn-primary"
         data-testid="share-confirm"
         onclick={handleShare}
-        disabled={sharing || isPlaceholderConfig || !hasRawGenome}
+        disabled={sharing || isPlaceholderConfig || genomeLoading || !hasRawGenome}
       >
-        {sharing ? 'Sharing…' : 'Share to community'}
+        {sharing ? 'Sharing…' : genomeLoading ? 'Loading…' : 'Share to community'}
       </button>
     </div>
   </div>

--- a/src/lib/components/community/SharePetDialog.svelte
+++ b/src/lib/components/community/SharePetDialog.svelte
@@ -15,24 +15,29 @@ let shareError = $state('');
 
 // The list path (`getAllPets`) omits `genome_text` for payload size
 // (issue #254), so `selectedPet` — and therefore the `pet` prop here —
-// lacks it. Lazy-load by id through the shared keyed resource: it handles
-// the loading flag, rejects a stale result if the dialog is re-pointed at
-// another pet, and surfaces a real fetch error (vs. a legacy empty row)
-// distinctly. `value` is the raw text ('' for legacy v13 rows, null for a
-// missing id).
+// usually lacks it. When it's already present (e.g. a full-row fetch
+// path), use it directly and skip the lazy load; otherwise lazy-load by
+// id through the shared keyed resource, which handles the loading flag,
+// rejects a stale result if the dialog is re-pointed at another pet, and
+// surfaces a real fetch error (vs. a legacy empty row) distinctly.
+// `value` is the raw text ('' for legacy v13 rows, null for a missing id).
+const propHasGenome = $derived(typeof pet?.genome_text === 'string');
 const genome = keyedResource(
-  () => pet?.id,
+  () => (propHasGenome ? undefined : pet?.id),
   (id) => getPetGenomeText(id),
 );
+// Single source of truth for the raw text: prefer the prop, fall back to
+// the lazily-loaded value.
+const genomeText = $derived(propHasGenome ? pet.genome_text : genome.value);
 
 const previewTags = $derived(sanitizeTags(pet?.tags ?? []));
 const hasNotes = $derived(typeof pet?.notes === 'string' && pet.notes.trim().length > 0);
-const genomeLoading = $derived(genome.loading);
-const genomeError = $derived(genome.error ? errorMessage(genome.error) : '');
+const genomeLoading = $derived(!propHasGenome && genome.loading);
+const genomeError = $derived(!propHasGenome && genome.error ? errorMessage(genome.error) : '');
 // Legacy pets imported before migration v13 don't have the raw genome
 // text on file, so we can't recompute the hash-matching upload payload
 // for them. They can be shared after the user re-imports the file.
-const hasRawGenome = $derived(typeof genome.value === 'string' && genome.value.length > 0);
+const hasRawGenome = $derived(typeof genomeText === 'string' && genomeText.length > 0);
 
 async function handleShare() {
   // Belt-and-suspenders: the Share button is already disabled while the
@@ -46,7 +51,7 @@ async function handleShare() {
     // Rebuild the upload payload: strip notes unless opted in, and attach the
     // lazily-loaded raw text (the list-path `pet` doesn't carry it). uploadPet
     // re-hashes genome_text against content_hash.
-    const petToShare = { ...pet, notes: includeNotes ? pet.notes : '', genome_text: genome.value };
+    const petToShare = { ...pet, notes: includeNotes ? pet.notes : '', genome_text: genomeText };
     const result = await uploadPet(petToShare);
     if (result.status === 'already-shared') {
       onResult({

--- a/src/lib/components/community/SharePetDialog.svelte
+++ b/src/lib/components/community/SharePetDialog.svelte
@@ -5,6 +5,7 @@ import { getPetGenomeText } from '$lib/services/petService.js';
 import { sanitizeTags, uploadPet } from '$lib/services/shareService.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
+import { keyedResource } from '$lib/utils/keyedResource.svelte.js';
 
 const { pet, onClose, onResult } = $props();
 
@@ -14,56 +15,38 @@ let shareError = $state('');
 
 // The list path (`getAllPets`) omits `genome_text` for payload size
 // (issue #254), so `selectedPet` — and therefore the `pet` prop here —
-// usually lacks it. Lazy-load it by id. `undefined` means "still loading";
-// a string (possibly '') means resolved.
-let genomeText = $state(undefined);
-
-$effect(() => {
-  // Seed directly when the prop already carries the text (full-row fetches
-  // / the in-memory test adapter, which returns whole rows) — skip the query.
-  if (typeof pet?.genome_text === 'string') {
-    genomeText = pet.genome_text;
-    return;
-  }
-  const id = pet?.id;
-  if (typeof id !== 'number') {
-    genomeText = '';
-    return;
-  }
-  let cancelled = false;
-  getPetGenomeText(id)
-    .then((text) => {
-      if (!cancelled) genomeText = text ?? '';
-    })
-    .catch(() => {
-      if (!cancelled) genomeText = '';
-    });
-  return () => {
-    cancelled = true;
-  };
-});
+// lacks it. Lazy-load by id through the shared keyed resource: it handles
+// the loading flag, rejects a stale result if the dialog is re-pointed at
+// another pet, and surfaces a real fetch error (vs. a legacy empty row)
+// distinctly. `value` is the raw text ('' for legacy v13 rows, null for a
+// missing id).
+const genome = keyedResource(
+  () => pet?.id,
+  (id) => getPetGenomeText(id),
+);
 
 const previewTags = $derived(sanitizeTags(pet?.tags ?? []));
 const hasNotes = $derived(typeof pet?.notes === 'string' && pet.notes.trim().length > 0);
-const genomeLoading = $derived(genomeText === undefined);
+const genomeLoading = $derived(genome.loading);
+const genomeError = $derived(genome.error ? errorMessage(genome.error) : '');
 // Legacy pets imported before migration v13 don't have the raw genome
 // text on file, so we can't recompute the hash-matching upload payload
 // for them. They can be shared after the user re-imports the file.
-const hasRawGenome = $derived(typeof genomeText === 'string' && genomeText.length > 0);
+const hasRawGenome = $derived(typeof genome.value === 'string' && genome.value.length > 0);
 
 async function handleShare() {
-  // Belt-and-suspenders: the Share button is disabled when the placeholder
-  // config is still in place, the genome text is still loading, or the pet
-  // lacks raw genome text, so this should never fire. The early return
-  // guards programmatic re-entry.
-  if (isPlaceholderConfig || !hasRawGenome) return;
+  // Belt-and-suspenders: the Share button is already disabled while the
+  // config is a placeholder, the genome text is loading or errored, or the
+  // pet lacks raw genome text (`hasRawGenome` is false in all those cases),
+  // so this should never fire. The early return guards programmatic re-entry.
+  if (isPlaceholderConfig || genomeLoading || !hasRawGenome) return;
   sharing = true;
   shareError = '';
   try {
-    const base = includeNotes ? pet : { ...pet, notes: '' };
-    // Attach the lazily-loaded raw text — `pet` from the list path doesn't
-    // carry it. uploadPet re-hashes this against content_hash.
-    const petToShare = { ...base, genome_text: genomeText };
+    // Rebuild the upload payload: strip notes unless opted in, and attach the
+    // lazily-loaded raw text (the list-path `pet` doesn't carry it). uploadPet
+    // re-hashes genome_text against content_hash.
+    const petToShare = { ...pet, notes: includeNotes ? pet.notes : '', genome_text: genome.value };
     const result = await uploadPet(petToShare);
     if (result.status === 'already-shared') {
       onResult({
@@ -119,6 +102,11 @@ async function handleShare() {
         </div>
       {:else if genomeLoading}
         <div class="banner" data-testid="share-genome-loading">Loading genome…</div>
+      {:else if genomeError}
+        <div class="banner banner-warn" data-testid="share-genome-error">
+          Couldn't read this pet's genome from the local database: {genomeError}. Close
+          and reopen this dialog to try again.
+        </div>
       {:else if !hasRawGenome}
         <div class="banner banner-warn" data-testid="share-no-raw-genome">
           This pet was imported with an older app version that didn't store the raw

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -302,23 +302,14 @@ async function loadTagsForPet(petId: number): Promise<string[]> {
 }
 
 /**
- * Columns selected by the list path (`getAllPets`). This is every `pets`
- * column EXCEPT the two heavy genome blobs (`genome_data`, `genome_text`,
- * up to 64 KiB each) — see issue #254. The list/grid UIs render only
- * metadata + attributes + the persisted gene-analysis counts; gene
- * rendering re-reads from `pet_genes` by id (`loadPetGridFromDb`) and the
- * share path lazy-fetches `genome_text` (`getPetGenomeText`), so no list
- * consumer needs the blobs.
- *
- * Maintenance: keep in sync with the `pets` schema (database.ts base table
- * + `ALTER TABLE pets ADD COLUMN` migrations). A new column added to the
- * schema but omitted here will be silently absent from list pets in
- * production — `getAllPetsSelectsMetadataOnly` in petService.test.js guards
- * the exclusion of the genome blobs, but not additions. The `tags` column
- * is intentionally omitted: it is vestigial (tags live in `pet_tags` and
- * `enrichPet` overwrites the field from the junction).
+ * Every column in the `pets` table — the base schema (database.ts) plus all
+ * `ALTER TABLE pets ADD COLUMN` migrations. Single source of truth for the
+ * projections below. The test `list SELECT covers every pets column…` in
+ * petService.test.js asserts this stays aligned with the live schema, so a
+ * future `ADD COLUMN` that isn't reflected here fails a test instead of
+ * silently vanishing from list pets in production.
  */
-const LIST_PET_COLUMNS = [
+const ALL_PET_COLUMNS = [
   'id',
   'name',
   'species',
@@ -326,7 +317,10 @@ const LIST_PET_COLUMNS = [
   'breed',
   'breeder',
   'content_hash',
+  'genome_data',
+  'genome_text',
   'notes',
+  'tags',
   'created_at',
   'updated_at',
   'intelligence',
@@ -345,7 +339,21 @@ const LIST_PET_COLUMNS = [
   'total_genes',
   'known_genes',
   'unknown_genes',
-].join(', ');
+];
+
+/**
+ * Columns the list path (`getAllPets`) does NOT select:
+ *  - `genome_data` / `genome_text`: heavy blobs (up to 64 KiB each) the
+ *    list/grid UIs never render — issue #254. Gene rendering re-reads
+ *    `pet_genes` by id (`loadPetGridFromDb`); the share path lazy-fetches
+ *    `genome_text` (`getPetGenomeText`).
+ *  - `tags`: vestigial — tags live in `pet_tags` and `enrichPet` overwrites
+ *    the field from the junction.
+ */
+const NON_LIST_PET_COLUMNS = new Set(['genome_data', 'genome_text', 'tags']);
+
+/** Explicit list-path projection: every pets column minus the heavy/vestigial ones. */
+const LIST_PET_COLUMNS = ALL_PET_COLUMNS.filter((c) => !NON_LIST_PET_COLUMNS.has(c)).join(', ');
 
 /**
  * Get all pets.
@@ -818,13 +826,24 @@ export async function findPetByHash(contentHash: string): Promise<Pet | null> {
  * scanned folder, so the cost difference is N×two-extra-queries vs
  * N×one-tiny-query.
  */
-export async function findPetGenomeTextByHash(contentHash: string): Promise<string | null> {
+/**
+ * Slim single-row `genome_text` lookup shared by the by-hash and by-id
+ * fetchers. `whereColumn` and `bindName` are hardcoded identifiers from the
+ * callers below (never user input). Defines the lookup contract once:
+ * returns `''` for a legacy v13 row whose `genome_text` is NULL/empty, or
+ * `null` when no row matches.
+ */
+async function selectGenomeText(whereColumn: string, bindName: string, value: string | number): Promise<string | null> {
   const db = getDb();
   const rows = await db.select<{ genome_text: string }[]>(
-    'SELECT genome_text FROM pets WHERE content_hash = $hash LIMIT 1',
-    { hash: contentHash },
+    `SELECT genome_text FROM pets WHERE ${whereColumn} = $${bindName} LIMIT 1`,
+    { [bindName]: value },
   );
   return rows.length > 0 ? (rows[0].genome_text ?? '') : null;
+}
+
+export async function findPetGenomeTextByHash(contentHash: string): Promise<string | null> {
+  return selectGenomeText('content_hash', 'hash', contentHash);
 }
 
 /**
@@ -835,11 +854,7 @@ export async function findPetGenomeTextByHash(contentHash: string): Promise<stri
  * never had raw text, or `null` if the id doesn't exist.
  */
 export async function getPetGenomeText(petId: number): Promise<string | null> {
-  const db = getDb();
-  const rows = await db.select<{ genome_text: string }[]>('SELECT genome_text FROM pets WHERE id = $id LIMIT 1', {
-    id: petId,
-  });
-  return rows.length > 0 ? (rows[0].genome_text ?? '') : null;
+  return selectGenomeText('id', 'id', petId);
 }
 
 /**

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -302,6 +302,52 @@ async function loadTagsForPet(petId: number): Promise<string[]> {
 }
 
 /**
+ * Columns selected by the list path (`getAllPets`). This is every `pets`
+ * column EXCEPT the two heavy genome blobs (`genome_data`, `genome_text`,
+ * up to 64 KiB each) — see issue #254. The list/grid UIs render only
+ * metadata + attributes + the persisted gene-analysis counts; gene
+ * rendering re-reads from `pet_genes` by id (`loadPetGridFromDb`) and the
+ * share path lazy-fetches `genome_text` (`getPetGenomeText`), so no list
+ * consumer needs the blobs.
+ *
+ * Maintenance: keep in sync with the `pets` schema (database.ts base table
+ * + `ALTER TABLE pets ADD COLUMN` migrations). A new column added to the
+ * schema but omitted here will be silently absent from list pets in
+ * production — `getAllPetsSelectsMetadataOnly` in petService.test.js guards
+ * the exclusion of the genome blobs, but not additions. The `tags` column
+ * is intentionally omitted: it is vestigial (tags live in `pet_tags` and
+ * `enrichPet` overwrites the field from the junction).
+ */
+const LIST_PET_COLUMNS = [
+  'id',
+  'name',
+  'species',
+  'gender',
+  'breed',
+  'breeder',
+  'content_hash',
+  'notes',
+  'created_at',
+  'updated_at',
+  'intelligence',
+  'toughness',
+  'friendliness',
+  'ruggedness',
+  'enthusiasm',
+  'virility',
+  'ferocity',
+  'temperament',
+  'sort_order',
+  'starred',
+  'stabled',
+  'is_pet_quality',
+  'positive_genes',
+  'total_genes',
+  'known_genes',
+  'unknown_genes',
+].join(', ');
+
+/**
  * Get all pets.
  */
 export async function getAllPets(options?: {
@@ -324,8 +370,9 @@ export async function getAllPets(options?: {
   const countRows = await db.select<{ cnt: number }[]>(`SELECT COUNT(*) as cnt FROM pets${where}`, bindParams);
   const total = countRows[0].cnt;
 
-  // Get paginated results
-  let query = `SELECT * FROM pets${where} ORDER BY sort_order, name`;
+  // Get paginated results. Explicit column list (no genome blobs) — see
+  // LIST_PET_COLUMNS / issue #254.
+  let query = `SELECT ${LIST_PET_COLUMNS} FROM pets${where} ORDER BY sort_order, name`;
   const selectParams = { ...bindParams };
   if (options?.limit !== undefined) {
     query += ' LIMIT $limit OFFSET $offset';
@@ -777,6 +824,21 @@ export async function findPetGenomeTextByHash(contentHash: string): Promise<stri
     'SELECT genome_text FROM pets WHERE content_hash = $hash LIMIT 1',
     { hash: contentHash },
   );
+  return rows.length > 0 ? (rows[0].genome_text ?? '') : null;
+}
+
+/**
+ * Fetch just the `genome_text` for one pet by id. The list path
+ * (`getAllPets`) omits the genome blobs (issue #254), so the share dialog
+ * lazy-loads the raw text on demand from the `selectedPet`'s id rather than
+ * paying for it on every list load. Returns `''` for legacy v13 rows that
+ * never had raw text, or `null` if the id doesn't exist.
+ */
+export async function getPetGenomeText(petId: number): Promise<string | null> {
+  const db = getDb();
+  const rows = await db.select<{ genome_text: string }[]>('SELECT genome_text FROM pets WHERE id = $id LIMIT 1', {
+    id: petId,
+  });
   return rows.length > 0 ? (rows[0].genome_text ?? '') : null;
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -80,15 +80,27 @@ export interface Pet {
   breed: string;
   breeder: string;
   content_hash: string;
-  genome_data: string;
+  /**
+   * Parsed-and-JSON-stringified genome. **Optional on the type because the
+   * hot list path omits it:** `getAllPets` SELECTs an explicit column list
+   * that excludes the heavy genome columns (issue #254), so pets flowing
+   * from the list / `selectedPet` carry `undefined` here. Full-row fetches
+   * (`getPet`, `findPetByHash`) still populate it. Gene rendering re-reads
+   * from `pet_genes` by id (`loadPetGridFromDb`), so list consumers never
+   * need this field.
+   */
+  genome_data?: string;
   /**
    * Raw `[Overview]` / `[Genes]` text of the genome file, byte-identical to
    * what was uploaded. Used by the community share path: `content_hash` is
    * the SHA-256 of this string, and `genome_data` is the parsed JSON
    * representation (which is lossy w.r.t. whitespace, so its hash would
    * not match `content_hash`). Empty for rows that predate migration v13.
+   *
+   * Optional for the same reason as `genome_data` — omitted on the list
+   * path. The share dialog lazy-fetches it by id via `getPetGenomeText`.
    */
-  genome_text: string;
+  genome_text?: string;
   notes: string;
   tags: string[];
   created_at: string;

--- a/src/lib/utils/keyedResource.svelte.js
+++ b/src/lib/utils/keyedResource.svelte.js
@@ -30,6 +30,9 @@ export function keyedResource(key, fetcher) {
     const k = key();
     if (k === null || k === undefined) {
       activeKey = k;
+      // Invalidate any in-flight fetch for the previous key — otherwise a
+      // late resolution would repopulate the state we're about to clear.
+      token++;
       state.loading = false;
       state.value = undefined;
       state.error = null;

--- a/src/lib/utils/keyedResource.svelte.js
+++ b/src/lib/utils/keyedResource.svelte.js
@@ -1,0 +1,58 @@
+/**
+ * Reactive async resource keyed by a value.
+ *
+ * Runs `fetcher(key)` whenever `key()` changes, rejects stale in-flight
+ * results (last key wins, so a superseded fetch can never overwrite the
+ * current one), and exposes reactive `{ loading, value, error }`. A
+ * `null`/`undefined` key clears the resource without fetching. Re-renders
+ * that leave the key unchanged do NOT refetch.
+ *
+ * This is the shared form of the lazy-load-by-key pattern used across the
+ * community UI (SharePetDialog, CommunityPetDetail) — previously each
+ * component hand-rolled its own stale guard (a `cancelled` flag vs a
+ * `loadedHash` token), which is easy to get subtly wrong. Call it once
+ * during component initialisation (it registers a `$effect`).
+ *
+ * @template K, V
+ * @param {() => K | null | undefined} key   reactive key accessor
+ * @param {(key: K) => Promise<V>} fetcher    async loader for a key
+ * @returns {{ loading: boolean, value: V | undefined, error: unknown }}
+ */
+export function keyedResource(key, fetcher) {
+  const state = $state({ loading: false, value: undefined, error: null });
+  // Plain (non-reactive) bookkeeping so writing to it never re-triggers the
+  // effect. `activeKey` dedupes benign re-renders; `token` discards stale
+  // resolutions.
+  let activeKey;
+  let token = 0;
+
+  $effect(() => {
+    const k = key();
+    if (k === null || k === undefined) {
+      activeKey = k;
+      state.loading = false;
+      state.value = undefined;
+      state.error = null;
+      return;
+    }
+    // Same key, effect re-fired for an unrelated reactive read — don't refetch.
+    if (k === activeKey) return;
+    activeKey = k;
+    const my = ++token;
+    state.loading = true;
+    state.value = undefined;
+    state.error = null;
+    Promise.resolve(fetcher(k))
+      .then((v) => {
+        if (my === token) state.value = v;
+      })
+      .catch((e) => {
+        if (my === token) state.error = e;
+      })
+      .finally(() => {
+        if (my === token) state.loading = false;
+      });
+  });
+
+  return state;
+}

--- a/tests/unit/communityPetDetail.test.js
+++ b/tests/unit/communityPetDetail.test.js
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Covers the detail pane's lazy genome fetch after it was migrated onto the
+// shared keyedResource helper (issue #254 review): loading, loaded, a real
+// fetch error, and a taken-down (missing genomeData) result must each render
+// distinctly.
+
+let currentPet = null;
+const importingHash = { value: null };
+
+vi.mock('$lib/stores/community.svelte.js', () => ({
+  selectedSharedPet: () => currentPet,
+  get communityView() {
+    return { importingHash: importingHash.value };
+  },
+  importSelected: vi.fn(),
+  clearSelection: vi.fn(),
+}));
+
+const getSharedPet = vi.fn();
+vi.mock('$lib/services/shareService.js', () => ({
+  getSharedPet: (hash) => getSharedPet(hash),
+}));
+
+import CommunityPetDetail from '$lib/components/community/CommunityPetDetail.svelte';
+
+afterEach(() => {
+  cleanup();
+  currentPet = null;
+  importingHash.value = null;
+  getSharedPet.mockReset();
+});
+
+function makeSharedPet(overrides = {}) {
+  return {
+    contentHash: 'hash-7',
+    name: 'Buzz',
+    character: 'Player',
+    species: 'BeeWasp',
+    gender: 'Female',
+    breed: '',
+    breeder: 'Player',
+    notes: '',
+    tags: [],
+    uploadedAt: new Date('2026-05-10T12:00:00Z'),
+    schemaVersion: 1,
+    appVersion: '1.0.0',
+    ...overrides,
+  };
+}
+
+describe('CommunityPetDetail genome lazy-load', () => {
+  it('shows a loading state with Import disabled while the genome is fetching', () => {
+    currentPet = makeSharedPet();
+    getSharedPet.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { getByTestId } = render(CommunityPetDetail);
+    expect(getByTestId('community-genome-loading')).toBeTruthy();
+    expect(getByTestId('community-import')).toBeDisabled();
+    expect(getSharedPet).toHaveBeenCalledWith('hash-7');
+  });
+
+  it('renders the genome preview and enables Import once the full pet resolves', async () => {
+    currentPet = makeSharedPet();
+    getSharedPet.mockResolvedValue(makeSharedPet({ genomeData: 'GENOME-BODY' }));
+
+    const { getByText, getByTestId } = render(CommunityPetDetail);
+    await waitFor(() => expect(getByText('GENOME-BODY')).toBeTruthy());
+    expect(getByTestId('community-import')).toBeEnabled();
+  });
+
+  it('surfaces a fetch error distinctly (Import stays disabled)', async () => {
+    currentPet = makeSharedPet();
+    getSharedPet.mockRejectedValue(new Error('network down'));
+
+    const { getByText, getByTestId, queryByTestId } = render(CommunityPetDetail);
+    await waitFor(() => expect(getByText(/network down/)).toBeTruthy());
+    expect(queryByTestId('community-genome-loading')).toBeNull();
+    expect(getByTestId('community-import')).toBeDisabled();
+  });
+
+  it('reports a taken-down pet (resolved but no genomeData)', async () => {
+    currentPet = makeSharedPet();
+    getSharedPet.mockResolvedValue(makeSharedPet({ genomeData: undefined }));
+
+    const { getByText } = render(CommunityPetDetail);
+    await waitFor(() => expect(getByText(/may have been taken down/)).toBeTruthy());
+  });
+});

--- a/tests/unit/petService.test.js
+++ b/tests/unit/petService.test.js
@@ -217,9 +217,16 @@ describe('Pet Service', () => {
     // in-memory adapter returns whole rows regardless of the projection, so
     // assert at the SQL level by capturing the issued query. In production
     // (real SQLite) the projection is what actually drops the columns.
-    it('SELECTs an explicit column list that excludes the genome blobs', async () => {
+    //
+    // This also guards against the silent-drop bug class: it compares the
+    // captured list SELECT against the LIVE schema columns (SELECT * keys),
+    // so a future `ALTER TABLE pets ADD COLUMN` not reflected in
+    // ALL_PET_COLUMNS fails here instead of vanishing from list pets in prod.
+    it('list SELECT covers every pets column except the genome blobs and vestigial tags', async () => {
       await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
       const db = getDb();
+      const schemaCols = Object.keys((await db.select('SELECT * FROM pets LIMIT 1'))[0]);
+
       const queries = [];
       const originalSelect = db.select.bind(db);
       db.select = (q, params) => {
@@ -233,11 +240,15 @@ describe('Pet Service', () => {
       }
       const listQuery = queries.find((q) => /from pets/i.test(q) && !/count\(/i.test(q));
       expect(listQuery).toBeDefined();
-      expect(listQuery).not.toMatch(/genome_text/);
-      expect(listQuery).not.toMatch(/genome_data/);
-      // Still selects the columns list/detail consumers rely on.
-      for (const col of ['id', 'name', 'species', 'content_hash', 'positive_genes', 'sort_order']) {
-        expect(listQuery).toContain(col);
+
+      const excluded = new Set(['genome_data', 'genome_text', 'tags']);
+      for (const col of schemaCols) {
+        const inQuery = new RegExp(`\\b${col}\\b`).test(listQuery);
+        if (excluded.has(col)) {
+          expect(inQuery, `"${col}" should be excluded from the list SELECT`).toBe(false);
+        } else {
+          expect(inQuery, `"${col}" missing from the list SELECT — add it to ALL_PET_COLUMNS`).toBe(true);
+        }
       }
     });
   });

--- a/tests/unit/petService.test.js
+++ b/tests/unit/petService.test.js
@@ -212,6 +212,56 @@ describe('Pet Service', () => {
       expect(items[0].total_genes).toBeGreaterThan(0);
       expect(items[0].species).toBe('Horse');
     });
+
+    // Issue #254: the list path must not pull the heavy genome blobs. The
+    // in-memory adapter returns whole rows regardless of the projection, so
+    // assert at the SQL level by capturing the issued query. In production
+    // (real SQLite) the projection is what actually drops the columns.
+    it('SELECTs an explicit column list that excludes the genome blobs', async () => {
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
+      const db = getDb();
+      const queries = [];
+      const originalSelect = db.select.bind(db);
+      db.select = (q, params) => {
+        queries.push(q);
+        return originalSelect(q, params);
+      };
+      try {
+        await petService.getAllPets();
+      } finally {
+        db.select = originalSelect;
+      }
+      const listQuery = queries.find((q) => /from pets/i.test(q) && !/count\(/i.test(q));
+      expect(listQuery).toBeDefined();
+      expect(listQuery).not.toMatch(/genome_text/);
+      expect(listQuery).not.toMatch(/genome_data/);
+      // Still selects the columns list/detail consumers rely on.
+      for (const col of ['id', 'name', 'species', 'content_hash', 'positive_genes', 'sort_order']) {
+        expect(listQuery).toContain(col);
+      }
+    });
+  });
+
+  describe('getPetGenomeText', () => {
+    it('returns the raw genome text for an existing pet', async () => {
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });
+      const text = await petService.getPetGenomeText(upload.pet_id);
+      expect(typeof text).toBe('string');
+      expect(text.length).toBeGreaterThan(0);
+      // It is the byte-identical uploaded file, so it re-hashes to content_hash.
+      const full = await petService.getPet(upload.pet_id);
+      expect(text).toBe(full.genome_text);
+    });
+
+    it('returns null for a non-existent id', async () => {
+      expect(await petService.getPetGenomeText(999999)).toBeNull();
+    });
+
+    it('returns empty string for a legacy row with no raw text', async () => {
+      const upload = await petService.uploadPet(SAMPLE_HORSE, { name: 'Legacy', gender: 'Male' });
+      await getDb().execute('UPDATE pets SET genome_text = $t WHERE id = $id', { t: '', id: upload.pet_id });
+      expect(await petService.getPetGenomeText(upload.pet_id)).toBe('');
+    });
   });
 
   describe('updatePet', () => {

--- a/tests/unit/sharePetDialog.test.js
+++ b/tests/unit/sharePetDialog.test.js
@@ -102,6 +102,53 @@ describe('SharePetDialog lazy genome fetch', () => {
     expect(uploadPet).not.toHaveBeenCalled();
   });
 
+  it('uses genome_text from the prop without fetching when it is already present', async () => {
+    uploadPet.mockResolvedValue({ status: 'created' });
+    const onResult = vi.fn();
+
+    const { getByTestId } = render(SharePetDialog, {
+      pet: listPet({ genome_text: 'PROP-GENOME-TEXT' }),
+      onClose: vi.fn(),
+      onResult,
+    });
+
+    // No lazy fetch, no loading state — Share is immediately available.
+    expect(getPetGenomeText).not.toHaveBeenCalled();
+    expect(getByTestId('share-confirm')).toBeEnabled();
+
+    await fireEvent.click(getByTestId('share-confirm'));
+    await waitFor(() => expect(uploadPet).toHaveBeenCalledTimes(1));
+    expect(uploadPet.mock.calls[0][0].genome_text).toBe('PROP-GENOME-TEXT');
+  });
+
+  it('discards a stale in-flight fetch when the key is cleared before it resolves', async () => {
+    // keyedResource must invalidate the previous key's fetch when the key
+    // goes null/undefined — otherwise a late resolution repopulates state
+    // the dialog has already cleared.
+    let resolveText;
+    getPetGenomeText.mockReturnValue(
+      new Promise((r) => {
+        resolveText = r;
+      }),
+    );
+
+    const { getByTestId, rerender } = render(SharePetDialog, {
+      pet: listPet(),
+      onClose: vi.fn(),
+      onResult: vi.fn(),
+    });
+    expect(getByTestId('share-genome-loading')).toBeTruthy();
+
+    // Re-point the dialog at a pet without an id (key becomes undefined).
+    await rerender({ pet: listPet({ id: undefined }), onClose: vi.fn(), onResult: vi.fn() });
+
+    // The original fetch resolves late — its result must be ignored.
+    resolveText('STALE-GENOME-TEXT');
+    await Promise.resolve();
+    await waitFor(() => expect(getByTestId('share-confirm')).toBeDisabled());
+    expect(uploadPet).not.toHaveBeenCalled();
+  });
+
   it('shows a distinct error banner (not the legacy banner) when the fetch fails', async () => {
     // A transient DB read failure must not masquerade as a legacy pet that
     // needs re-importing — it gets its own retryable error state.

--- a/tests/unit/sharePetDialog.test.js
+++ b/tests/unit/sharePetDialog.test.js
@@ -90,7 +90,7 @@ describe('SharePetDialog lazy genome fetch', () => {
   it('shows the legacy banner and keeps Share disabled when the row has no raw text', async () => {
     getPetGenomeText.mockResolvedValue('');
 
-    const { getByTestId } = render(SharePetDialog, {
+    const { getByTestId, queryByTestId } = render(SharePetDialog, {
       pet: listPet(),
       onClose: vi.fn(),
       onResult: vi.fn(),
@@ -98,17 +98,25 @@ describe('SharePetDialog lazy genome fetch', () => {
 
     await waitFor(() => expect(getByTestId('share-no-raw-genome')).toBeTruthy());
     expect(getByTestId('share-confirm')).toBeDisabled();
+    expect(queryByTestId('share-genome-error')).toBeNull();
     expect(uploadPet).not.toHaveBeenCalled();
   });
 
-  it('skips the fetch when the prop already carries genome_text', async () => {
-    const { getByTestId } = render(SharePetDialog, {
-      pet: listPet({ genome_text: 'ALREADY-HERE' }),
+  it('shows a distinct error banner (not the legacy banner) when the fetch fails', async () => {
+    // A transient DB read failure must not masquerade as a legacy pet that
+    // needs re-importing — it gets its own retryable error state.
+    getPetGenomeText.mockRejectedValue(new Error('database is locked'));
+
+    const { getByTestId, queryByTestId } = render(SharePetDialog, {
+      pet: listPet(),
       onClose: vi.fn(),
       onResult: vi.fn(),
     });
 
-    await waitFor(() => expect(getByTestId('share-confirm')).toBeEnabled());
-    expect(getPetGenomeText).not.toHaveBeenCalled();
+    await waitFor(() => expect(getByTestId('share-genome-error')).toBeTruthy());
+    expect(getByTestId('share-genome-error')).toHaveTextContent(/database is locked/);
+    expect(queryByTestId('share-no-raw-genome')).toBeNull();
+    expect(getByTestId('share-confirm')).toBeDisabled();
+    expect(uploadPet).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/sharePetDialog.test.js
+++ b/tests/unit/sharePetDialog.test.js
@@ -1,0 +1,114 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Issue #254: the list path omits `genome_text`, so the pet handed to the
+// share dialog usually lacks it. The dialog must lazy-fetch by id before
+// it can share. These tests drive that path with `genome_text` absent on
+// the prop (the production list scenario) and control the fetch result.
+
+vi.mock('$lib/firebase.js', () => ({ isPlaceholderConfig: false }));
+vi.mock('$lib/utils/focusTrap.js', () => ({ focusTrap: () => ({}) }));
+
+const getPetGenomeText = vi.fn();
+vi.mock('$lib/services/petService.js', () => ({
+  getPetGenomeText: (id) => getPetGenomeText(id),
+}));
+
+const uploadPet = vi.fn();
+vi.mock('$lib/services/shareService.js', () => ({
+  uploadPet: (pet) => uploadPet(pet),
+  sanitizeTags: (tags) => tags ?? [],
+}));
+
+import SharePetDialog from '$lib/components/community/SharePetDialog.svelte';
+
+afterEach(() => {
+  cleanup();
+  getPetGenomeText.mockReset();
+  uploadPet.mockReset();
+});
+
+// A pet as it arrives from the list path: full metadata, NO genome_text.
+function listPet(overrides = {}) {
+  return {
+    id: 7,
+    name: 'Buzz',
+    species: 'BeeWasp',
+    gender: 'Female',
+    breed: '',
+    breeder: 'Player',
+    content_hash: 'hash-7',
+    notes: '',
+    tags: ['fast'],
+    ...overrides,
+  };
+}
+
+describe('SharePetDialog lazy genome fetch', () => {
+  it('disables Share while loading, then enables it once raw text resolves', async () => {
+    let resolveText;
+    getPetGenomeText.mockReturnValue(
+      new Promise((r) => {
+        resolveText = r;
+      }),
+    );
+
+    const { getByTestId } = render(SharePetDialog, {
+      pet: listPet(),
+      onClose: vi.fn(),
+      onResult: vi.fn(),
+    });
+
+    // Loading state: button disabled, loading banner shown.
+    expect(getByTestId('share-confirm')).toBeDisabled();
+    expect(getByTestId('share-genome-loading')).toBeTruthy();
+    expect(getPetGenomeText).toHaveBeenCalledWith(7);
+
+    resolveText('RAW-GENOME-TEXT');
+    await waitFor(() => expect(getByTestId('share-confirm')).toBeEnabled());
+  });
+
+  it('passes the lazily-fetched genome_text into uploadPet', async () => {
+    getPetGenomeText.mockResolvedValue('RAW-GENOME-TEXT');
+    uploadPet.mockResolvedValue({ status: 'created' });
+    const onResult = vi.fn();
+    const onClose = vi.fn();
+
+    const { getByTestId } = render(SharePetDialog, { pet: listPet(), onClose, onResult });
+    await waitFor(() => expect(getByTestId('share-confirm')).toBeEnabled());
+
+    await fireEvent.click(getByTestId('share-confirm'));
+
+    await waitFor(() => expect(uploadPet).toHaveBeenCalledTimes(1));
+    const shared = uploadPet.mock.calls[0][0];
+    expect(shared.genome_text).toBe('RAW-GENOME-TEXT');
+    expect(shared.content_hash).toBe('hash-7');
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+  });
+
+  it('shows the legacy banner and keeps Share disabled when the row has no raw text', async () => {
+    getPetGenomeText.mockResolvedValue('');
+
+    const { getByTestId } = render(SharePetDialog, {
+      pet: listPet(),
+      onClose: vi.fn(),
+      onResult: vi.fn(),
+    });
+
+    await waitFor(() => expect(getByTestId('share-no-raw-genome')).toBeTruthy());
+    expect(getByTestId('share-confirm')).toBeDisabled();
+    expect(uploadPet).not.toHaveBeenCalled();
+  });
+
+  it('skips the fetch when the prop already carries genome_text', async () => {
+    const { getByTestId } = render(SharePetDialog, {
+      pet: listPet({ genome_text: 'ALREADY-HERE' }),
+      onClose: vi.fn(),
+      onResult: vi.fn(),
+    });
+
+    await waitFor(() => expect(getByTestId('share-confirm')).toBeEnabled());
+    expect(getPetGenomeText).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #254. `getAllPets` did `SELECT *`, pulling the two heavy genome columns (`genome_data` + `genome_text`, up to 64 KiB each) on every list load — and `appState.loadPets()` fires on boot and after every upload / delete / update / community import. This switches to an explicit `LIST_PET_COLUMNS` list that excludes both blobs.

## Why it's safe

Nothing on the list/detail path reads the blobs off the in-memory `Pet`:
- Gene rendering re-reads `pet_genes` by id (`loadPetGridFromDb` / `loadAllPetLoci`).
- Backup export uses its own `SELECT * FROM pets`.
- The community **share** path is the only consumer of `genome_text` from a list pet.

## The one real gotcha (issue assumption was wrong)

The issue assumed `selectedPet` flows through `getPet(id)`. It doesn't — `selectPet(pet)` sets `selectedPet` directly from the list item (`PetList`/`StableTable`/`BreedingPairTable`). So naively dropping `genome_text` would make `SharePetDialog.hasRawGenome` false and disable Share for every pet. Fix: **`SharePetDialog` lazy-fetches `genome_text` by id** (`getPetGenomeText`) when it opens, with a brief loading state, and attaches it to the upload payload.

## Note on the in-memory test adapter

The in-memory DB adapter (test/dev) pattern-matches `SELECT … FROM <table>` and returns **whole rows, ignoring the projection** — so the payload win is production-only (real SQLite), and in-memory tests still see the full row. Consequences:
- The column exclusion is verified at the **SQL query-string level** (`getAllPets SELECTs an explicit column list that excludes the genome blobs`), not by inspecting returned rows.
- The `SharePetDialog` lazy-fetch can't be exercised by the in-memory e2e (genome_text is seeded from the full row there), so it's covered by a dedicated component test that renders with `genome_text` absent on the prop.

## Changes

- `types`: `genome_data` / `genome_text` now optional, documented as omitted on the list path and populated only by full-row fetches (`getPet`, `findPetByHash`).
- `petService`: `LIST_PET_COLUMNS`; new slim `getPetGenomeText(id)`.
- `SharePetDialog`: lazy-load `genome_text`; gate Share on the fetched value; loading state.
- `tests`: SQL-projection assertion, `getPetGenomeText` states, new `sharePetDialog.test.js` (lazy-fetch gating: loading → enabled, payload carries fetched text, legacy-empty stays disabled, seeded-prop skips fetch).

## Acceptance (from #254)

- [x] `getAllPets` SELECTs an explicit column list excluding `genome_text` (and `genome_data`).
- [x] `Pet.genome_text` typed optional (honest — list pets omit it).
- [x] Backup roundtrip still preserves `genome_text` (separate `PET_COLUMNS`, untouched).
- [x] Unit + e2e pass (502 unit, community e2e green).

## Test plan

- [x] `pnpm test` — 502 unit tests pass
- [x] `pnpm run lint:ci` — clean
- [x] `pnpm build` — clean, no Svelte warnings
- [x] `pnpm exec playwright test tests/e2e/community.spec.js` — 7 passed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)