### PR TITLE
Tier 1 quick wins (#253, #256, #281, #255)

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -93,6 +93,26 @@ UI) per `firebase.json`. The `demo-` project ID prefix tells the SDK to
 skip Google-side config validation, so the local emulator works even
 when `src/lib/firebase.ts` still has its placeholder `apiKey`.
 
+## Running the app against the emulator (dev)
+
+Since the real public config is committed, `pnpm dev` / `pnpm tauri:dev`
+talk to the **live production catalogue** by default: reads count against
+the Spark quota and any share/import writes real documents. To point a dev
+build at the local emulator instead, set the opt-in env var:
+
+```bash
+# Terminal 1 — start the emulator
+pnpm exec firebase emulators:start --only firestore --project demo-gorgonetics
+
+# Terminal 2 — run the app against it
+VITE_USE_FIRESTORE_EMULATOR=true pnpm dev
+```
+
+`src/lib/firebase.ts` calls `connectFirestoreEmulator(firestore, 'localhost', 8080)`
+only when `import.meta.env.DEV` **and** `VITE_USE_FIRESTORE_EMULATOR=true`.
+It's off by default — some workflows want to hit production from dev — and
+ignored entirely in production builds.
+
 ## Takedowns (v1)
 
 There is no in-app delete in v1. To remove an offending pet:

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -31,10 +31,8 @@ async function runLiveScan() {
   try {
     do {
       pendingRescan = false;
-      const result = await autoScanGameFolder();
-      if (result.imported > 0 || result.backfilled > 0) {
-        void appState.loadPets();
-      }
+      // autoScanGameFolder refreshes the pets store itself on a DB change (#253).
+      await autoScanGameFolder();
     } while (pendingRescan);
   } catch (err) {
     console.warn('live game-folder scan failed:', err);

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -173,10 +173,7 @@ async function handleAutoScan() {
       return;
     }
 
-    if (result.imported > 0 || result.backfilled > 0) {
-      await appState.loadPets();
-    }
-
+    // autoScanGameFolder refreshes the pets store itself on a DB change (#253).
     const backfillNote = result.backfilled > 0 ? `, ${result.backfilled} unlocked for sharing` : '';
     const summary = `Auto-import: ${result.imported} new, ${result.skipped} already imported${backfillNote} (of ${result.scanned} files).`;
     if (result.failures.length > 0) {

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -11,7 +11,7 @@
  */
 
 import { getApp, getApps, initializeApp } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
 
 const PLACEHOLDER_API_KEY = 'PLACEHOLDER_REPLACE_AFTER_PROJECT_CREATION';
 
@@ -54,3 +54,22 @@ export function assertFirebaseConfigured(): void {
 // already exists`). Reusing the existing instance is the documented pattern.
 export const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const firestore = getFirestore(app);
+
+// Opt-in Firestore emulator for local dev (#281). Since #279 committed the
+// real public config, every build — including `pnpm dev` — otherwise talks to
+// the live production catalogue, burning read quota and writing real docs.
+// Set VITE_USE_FIRESTORE_EMULATOR=true to route share/import at the local
+// emulator (localhost:8080, per firebase.json) instead. Dev-only and opt-in:
+// some workflows still want to hit production, so this stays off by default.
+// See docs/firebase-setup.md.
+if (import.meta.env.DEV && import.meta.env.VITE_USE_FIRESTORE_EMULATOR === 'true') {
+  try {
+    connectFirestoreEmulator(firestore, 'localhost', 8080);
+    console.info('[firebase] Connected to Firestore emulator at localhost:8080 (VITE_USE_FIRESTORE_EMULATOR).');
+  } catch (err) {
+    // connectFirestoreEmulator throws if Firestore has already been used or
+    // re-connected (e.g. Vite HMR re-running this module). Harmless — the
+    // first connection stands.
+    console.warn('[firebase] Firestore emulator connection skipped:', err);
+  }
+}

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -235,7 +235,9 @@ export async function autoScanGameFolder(options?: {
   // surfaces via the store's own error state, so it must not reject the scan.
   if (result.imported > 0 || result.backfilled > 0) {
     const { appState } = await import('$lib/stores/pets.js');
-    await appState.loadPets().catch(() => {});
+    // loadPets() handles its own errors (surfaces via the store's error state)
+    // and never rejects, so awaiting it bare is safe.
+    await appState.loadPets();
   }
 
   return result;

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -229,13 +229,13 @@ export async function autoScanGameFolder(options?: {
   // Refresh the in-memory pets store ourselves when the scan changed the DB,
   // so every caller doesn't have to remember the post-scan `loadPets()` chant
   // (#253). Dynamic import keeps this UI-store dependency out of the service's
-  // static graph and off the non-Tauri path. Fire-and-forget: the scan result
-  // is already complete and shouldn't block on the reload.
+  // static graph and off the non-Tauri path. Awaited so callers that await
+  // autoScanGameFolder (e.g. PetList building its summary toast) observe the
+  // fresh list rather than rendering against stale rows; a reload failure
+  // surfaces via the store's own error state, so it must not reject the scan.
   if (result.imported > 0 || result.backfilled > 0) {
     const { appState } = await import('$lib/stores/pets.js');
-    appState.loadPets().catch(() => {
-      /* a failed reload surfaces via the store's own error state */
-    });
+    await appState.loadPets().catch(() => {});
   }
 
   return result;

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -226,6 +226,18 @@ export async function autoScanGameFolder(options?: {
     }
   }
 
+  // Refresh the in-memory pets store ourselves when the scan changed the DB,
+  // so every caller doesn't have to remember the post-scan `loadPets()` chant
+  // (#253). Dynamic import keeps this UI-store dependency out of the service's
+  // static graph and off the non-Tauri path. Fire-and-forget: the scan result
+  // is already complete and shouldn't block on the reload.
+  if (result.imported > 0 || result.backfilled > 0) {
+    const { appState } = await import('$lib/stores/pets.js');
+    appState.loadPets().catch(() => {
+      /* a failed reload surfaces via the store's own error state */
+    });
+  }
+
   return result;
 }
 

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -237,8 +237,9 @@ export async function importSelected(fullPet: SharedPet): Promise<ImportResult> 
     } else if (result.status === 'already-imported') {
       // Backfill / race-recheck branch mutated an existing row's community
       // tag + genome_text in place, so a targeted append won't reflect it —
-      // fall back to a full reload.
-      appState.loadPets().catch(() => {});
+      // fall back to a full reload. loadPets() handles its own errors and
+      // never rejects, so fire-and-forget with void.
+      void appState.loadPets();
     }
     return result;
   } catch (err) {

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -225,18 +225,20 @@ export async function importSelected(fullPet: SharedPet): Promise<ImportResult> 
   communityView.importingHash = fullPet.contentHash;
   try {
     const result = await importCommunityPet(fullPet);
-    // Refresh the local pets store on any state-changing result so the
-    // Pets / Stable views see the new row (or, for the backfill /
-    // race-recheck branches, the freshly-applied community tag and
-    // genome_text on the existing row) without a manual reload. We
-    // deliberately don't await this — the toast can land before the
-    // background refetch completes.
-    if (result.status === 'imported' || result.status === 'already-imported') {
-      appState.loadPets().catch(() => {
-        // The pet is committed locally; a refresh failure is a UI sync
-        // issue, not an import failure. The Pets tab's own onMount will
-        // pick it up on next navigation.
-      });
+    // Refresh the local pets store so the Pets / Stable views see the change
+    // without a manual reload. We deliberately don't await — the toast can
+    // land before the background refetch completes. A refresh failure is a
+    // UI sync issue, not an import failure; the Pets tab's onMount picks it
+    // up on next navigation.
+    if (result.status === 'imported') {
+      // Fresh insert at MAX(sort_order)+1 — append just that row (#256)
+      // instead of an O(N) full reload.
+      appState.appendPet(result.pet_id).catch(() => {});
+    } else if (result.status === 'already-imported') {
+      // Backfill / race-recheck branch mutated an existing row's community
+      // tag + genome_text in place, so a targeted append won't reflect it —
+      // fall back to a full reload.
+      appState.loadPets().catch(() => {});
     }
     return result;
   } catch (err) {

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -202,6 +202,22 @@ export const appState = {
     return petService.uploadPet(content, options);
   },
 
+  /**
+   * Append a single freshly-created pet to the in-memory list instead of the
+   * O(N) full `loadPets()` reload (#256). Community imports land at
+   * `MAX(sort_order)+1`, so the new row sorts last under getAllPets'
+   * `ORDER BY sort_order, name` — appending matches that order. The heavy
+   * `genome_text` / `genome_data` blobs are stripped to keep the list-store
+   * shape aligned with the list path (#254). No-op if the id is already
+   * present or the fetch returns nothing.
+   */
+  async appendPet(petId: number) {
+    const pet = await petService.getPet(petId);
+    if (!pet) return;
+    const { genome_text, genome_data, ...listPet } = pet;
+    pets.update((list) => (list.some((p) => p.id === petId) ? list : [...list, listPet as Pet]));
+  },
+
   async reorderPets(orderedIds: number[]) {
     try {
       await petService.reorderPets(orderedIds);

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -215,7 +215,23 @@ export const appState = {
     const pet = await petService.getPet(petId);
     if (!pet) return;
     const { genome_text, genome_data, ...listPet } = pet;
-    pets.update((list) => (list.some((p) => p.id === petId) ? list : [...list, listPet as Pet]));
+    let appended = false;
+    pets.update((list) => {
+      if (list.some((p) => p.id === petId)) return list;
+      appended = true;
+      return [...list, listPet as Pet];
+    });
+    // Invalidate any loadPets() already in flight: its getAllPets() snapshot
+    // predates this freshly-imported row, so letting it resolve would run
+    // pets.set() over our append (appendPet bypasses the last-writer-wins
+    // guard otherwise). A loadPets() started after this bump re-snapshots and
+    // already includes the row, so it's safe. We also clear `loading`: a
+    // superseded loadPets skips its own `loading.set(false)` (generation
+    // mismatch), so as the new latest writer appendPet owns that reset.
+    if (appended) {
+      loadGeneration++;
+      loading.set(false);
+    }
   },
 
   async reorderPets(orderedIds: number[]) {

--- a/tests/fixtures/sharePet.js
+++ b/tests/fixtures/sharePet.js
@@ -1,0 +1,73 @@
+/**
+ * Shared local-Pet fixtures for the share-service test surface (#255).
+ *
+ * Previously two `makePet` factories had drifted across the unit
+ * (`shareService.test.js`) and emulator (`shareService.emulator.test.js`)
+ * suites — different signatures, one with a placeholder content_hash and
+ * one computing the real digest. This is the single source of truth.
+ *
+ * `uploadPet` re-hashes `genome_text` and rejects rows whose stored
+ * `content_hash` doesn't match, so the default fixture is a coherent pair
+ * (`content_hash === sha256(genome_text)`). The hash is precomputed at module
+ * load via top-level await so `makePet` stays synchronous for test bodies.
+ */
+import { Gender } from '$lib/types/index.js';
+import { sha256Hex } from '$lib/utils/hash.js';
+
+/** Canonical raw gene-report text and its real SHA-256. */
+export const DEFAULT_RAW_TEXT = '[Overview]\nCharacter=PlayerOne\nEntity=Buzz\n[Genes]\n';
+export const DEFAULT_RAW_TEXT_HASH = await sha256Hex(DEFAULT_RAW_TEXT);
+
+/**
+ * Production-shape local `Pet`. Defaults to a coherent
+ * (`content_hash === sha256(genome_text)`) row built from `DEFAULT_RAW_TEXT`.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.rawText]      genome text (defaults to DEFAULT_RAW_TEXT)
+ * @param {string} [opts.contentHash]  explicit hash; defaults to the digest of
+ *   `DEFAULT_RAW_TEXT` when `rawText` is the default, else `''` (use `freshPet`
+ *   for a real digest of arbitrary text — hashing is async)
+ * @param {object} [opts.overrides]    any further field overrides (snake_case,
+ *   e.g. `{ content_hash: '' }` or `{ genome_text: '' }`), applied last
+ */
+export function makePet({ rawText = DEFAULT_RAW_TEXT, contentHash, ...overrides } = {}) {
+  return {
+    id: 1,
+    name: 'Buzz',
+    species: 'BeeWasp',
+    gender: Gender.FEMALE,
+    breed: '',
+    breeder: 'PlayerOne',
+    content_hash: contentHash ?? (rawText === DEFAULT_RAW_TEXT ? DEFAULT_RAW_TEXT_HASH : ''),
+    genome_data: JSON.stringify({ name: 'Buzz', breeder: 'PlayerOne', genes: {} }),
+    genome_text: rawText,
+    notes: '',
+    tags: ['fast', 'fierce'],
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-01T00:00:00Z',
+    intelligence: 50,
+    toughness: 50,
+    friendliness: 50,
+    ruggedness: 50,
+    enthusiasm: 50,
+    virility: 50,
+    ferocity: 50,
+    temperament: 0,
+    positive_genes: 0,
+    starred: false,
+    stabled: false,
+    is_pet_quality: false,
+    ...overrides,
+  };
+}
+
+/**
+ * A coherent Pet whose `content_hash` is the real SHA-256 of a seed-derived
+ * genome text — distinct seeds yield distinct hashes, so emulator tests can
+ * upload several pets without content-hash-ID collisions.
+ */
+export async function freshPet(seed = 'pet') {
+  const rawText = `[Overview]\nCharacter=Player${seed}\nEntity=Buzz${seed}\n[Genes]\n`;
+  const contentHash = await sha256Hex(rawText);
+  return makePet({ rawText, contentHash, breeder: `Player${seed}` });
+}

--- a/tests/fixtures/sharePet.js
+++ b/tests/fixtures/sharePet.js
@@ -25,12 +25,22 @@ export const DEFAULT_RAW_TEXT_HASH = await sha256Hex(DEFAULT_RAW_TEXT);
  * @param {object} [opts]
  * @param {string} [opts.rawText]      genome text (defaults to DEFAULT_RAW_TEXT)
  * @param {string} [opts.contentHash]  explicit hash; defaults to the digest of
- *   `DEFAULT_RAW_TEXT` when `rawText` is the default, else `''` (use `freshPet`
- *   for a real digest of arbitrary text — hashing is async)
- * @param {object} [opts.overrides]    any further field overrides (snake_case,
- *   e.g. `{ content_hash: '' }` or `{ genome_text: '' }`), applied last
+ *   `DEFAULT_RAW_TEXT` when `rawText` is the default
+ * @param {...*} [opts.overrides]      any other own properties are spread onto
+ *   the pet as field overrides (snake_case, e.g. `makePet({ content_hash: '' })`
+ *   or `makePet({ genome_text: '' })`), applied last
  */
 export function makePet({ rawText = DEFAULT_RAW_TEXT, contentHash, ...overrides } = {}) {
+  // Resolve a coherent content_hash. We can only sync-derive it for the
+  // default text; arbitrary rawText must hash async (use freshPet) or carry an
+  // explicit hash. An explicit content_hash override (including '') is honoured
+  // via `overrides`. Fail loud at the fixture boundary rather than letting an
+  // incoherent pet trip a vaguer error deep inside uploadPet.
+  const hash =
+    contentHash ?? overrides.content_hash ?? (rawText === DEFAULT_RAW_TEXT ? DEFAULT_RAW_TEXT_HASH : undefined);
+  if (hash === undefined) {
+    throw new Error('makePet: pass contentHash (or use freshPet) when overriding rawText — hashing is async');
+  }
   return {
     id: 1,
     name: 'Buzz',
@@ -38,7 +48,7 @@ export function makePet({ rawText = DEFAULT_RAW_TEXT, contentHash, ...overrides 
     gender: Gender.FEMALE,
     breed: '',
     breeder: 'PlayerOne',
-    content_hash: contentHash ?? (rawText === DEFAULT_RAW_TEXT ? DEFAULT_RAW_TEXT_HASH : ''),
+    content_hash: hash,
     genome_data: JSON.stringify({ name: 'Buzz', breeder: 'PlayerOne', genes: {} }),
     genome_text: rawText,
     notes: '',

--- a/tests/integration/shareService.emulator.test.js
+++ b/tests/integration/shareService.emulator.test.js
@@ -33,6 +33,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { getSharedPet, listPets, uploadPet } from '$lib/services/shareService.js';
 import { Gender } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
+import { freshPet } from '../fixtures/sharePet.js';
 
 const META_COLLECTION = 'pets';
 const GENOME_COLLECTION = 'genomes';
@@ -67,47 +68,6 @@ afterEach(async () => {
     { method: 'DELETE' },
   );
 });
-
-function makePet(rawText, overrides = {}) {
-  // Production-shape Pet: content_hash = sha256(rawText), genome_text holds
-  // the raw file text (used by shareService.uploadPet), and genome_data is
-  // the JSON-stringified parsed form (used locally for visualization). The
-  // share path reads genome_text, not genome_data.
-  return {
-    id: 1,
-    name: 'Buzz',
-    species: 'BeeWasp',
-    gender: Gender.FEMALE,
-    breed: '',
-    breeder: 'PlayerOne',
-    content_hash: '',
-    genome_data: JSON.stringify({ name: 'Buzz', breeder: 'PlayerOne', genes: {} }),
-    genome_text: rawText,
-    notes: '',
-    tags: ['fast'],
-    created_at: '2026-05-01T00:00:00Z',
-    updated_at: '2026-05-01T00:00:00Z',
-    intelligence: 50,
-    toughness: 50,
-    friendliness: 50,
-    ruggedness: 50,
-    enthusiasm: 50,
-    virility: 50,
-    ferocity: 50,
-    temperament: 0,
-    positive_genes: 0,
-    starred: false,
-    stabled: false,
-    is_pet_quality: false,
-    ...overrides,
-  };
-}
-
-async function freshPet(seed = 'pet') {
-  const rawText = `[Overview]\nCharacter=Player${seed}\nEntity=Buzz${seed}\n[Genes]\n`;
-  const content_hash = await sha256Hex(rawText);
-  return makePet(rawText, { content_hash, breeder: `Player${seed}` });
-}
 
 describe('shareService end-to-end via emulator', () => {
   it('uploads, lists (metadata only), then fetches the full pet with genome', async () => {

--- a/tests/unit/communityStore.test.js
+++ b/tests/unit/communityStore.test.js
@@ -20,6 +20,7 @@ vi.mock('$lib/services/shareService.js', () => ({
 vi.mock('$lib/stores/pets.js', () => ({
   appState: {
     loadPets: vi.fn().mockResolvedValue(undefined),
+    appendPet: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -169,6 +170,7 @@ describe('community.svelte.ts — loadInitial', () => {
 describe('community.svelte.ts — importSelected', () => {
   beforeEach(() => {
     appState.loadPets.mockResolvedValue(undefined);
+    appState.appendPet.mockResolvedValue(undefined);
   });
 
   it('serializes imports: a second concurrent call rejects with an in-progress message', async () => {
@@ -191,30 +193,35 @@ describe('community.svelte.ts — importSelected', () => {
     await firstPromise;
   });
 
-  it('triggers appState.loadPets() on imported status', async () => {
+  it('appends the single new row on imported status (no full reload)', async () => {
+    // Fresh insert lands at MAX(sort_order)+1, so a targeted append is enough
+    // and avoids the O(N) full reload (#256).
     importCommunityPet.mockResolvedValueOnce({ status: 'imported', message: 'ok', pet_id: 1 });
     await importSelected(makeSharedPet('imp', { genomeData: 'raw' }));
     // The refresh is fire-and-forget — await a microtask so it runs.
     await Promise.resolve();
-    expect(appState.loadPets).toHaveBeenCalledTimes(1);
+    expect(appState.appendPet).toHaveBeenCalledTimes(1);
+    expect(appState.appendPet).toHaveBeenCalledWith(1);
+    expect(appState.loadPets).not.toHaveBeenCalled();
   });
 
-  it('triggers appState.loadPets() on already-imported (backfill / race-recovery mutate local state too)', async () => {
-    // Regression guard: an earlier revision only refreshed on
-    // 'imported', so the backfill / race-recovery paths (which apply
-    // the community tag to an existing row) left the in-memory pets
-    // store stale until the user navigated away and back.
+  it('does a full reload on already-imported (backfill / race-recovery mutate an existing row)', async () => {
+    // The backfill / race-recovery paths apply the community tag + genome_text
+    // to an EXISTING row, which a targeted append can't reflect — so this
+    // branch still needs the full reload.
     importCommunityPet.mockResolvedValueOnce({ status: 'already-imported', message: 'linked', pet_id: 7 });
     await importSelected(makeSharedPet('back', { genomeData: 'raw' }));
     await Promise.resolve();
     expect(appState.loadPets).toHaveBeenCalledTimes(1);
+    expect(appState.appendPet).not.toHaveBeenCalled();
   });
 
-  it('does NOT trigger appState.loadPets() on error', async () => {
+  it('does NOT refresh the pets store on error', async () => {
     importCommunityPet.mockResolvedValueOnce({ status: 'error', message: 'boom' });
     await importSelected(makeSharedPet('err', { genomeData: 'raw' }));
     await Promise.resolve();
     expect(appState.loadPets).not.toHaveBeenCalled();
+    expect(appState.appendPet).not.toHaveBeenCalled();
   });
 
   it('releases the importingHash slot after completion (success and failure both)', async () => {

--- a/tests/unit/petsStore.test.js
+++ b/tests/unit/petsStore.test.js
@@ -263,5 +263,32 @@ describe('Pets Store', () => {
       await appState.appendPet(999999);
       expect(get(pets)).toHaveLength(0);
     });
+
+    it('survives a slower in-flight loadPets that snapshotted before the append', async () => {
+      const upload = await appState.uploadPetQuiet(SAMPLE_BEEWASP, { gender: 'Female' });
+
+      // A loadPets() whose getAllPets() snapshot predates the append (empty
+      // list) is left pending, then resolves AFTER appendPet runs.
+      let resolveStale;
+      vi.spyOn(petService, 'getAllPets').mockReturnValueOnce(
+        new Promise((r) => {
+          resolveStale = r;
+        }),
+      );
+      const stalePromise = appState.loadPets();
+
+      await appState.appendPet(upload.pet_id);
+      expect(get(pets).some((p) => p.id === upload.pet_id)).toBe(true);
+
+      // The stale snapshot resolves last; the generation bump in appendPet must
+      // cause loadPets to discard it instead of clobbering the appended row.
+      resolveStale({ items: [] });
+      await stalePromise;
+
+      expect(get(pets).some((p) => p.id === upload.pet_id)).toBe(true);
+      // appendPet, as the new latest writer, also cleared the loading flag the
+      // superseded loadPets left set.
+      expect(get(loading)).toBe(false);
+    });
   });
 });

--- a/tests/unit/petsStore.test.js
+++ b/tests/unit/petsStore.test.js
@@ -233,4 +233,35 @@ describe('Pets Store', () => {
       expect(get(loading)).toBe(false);
     });
   });
+
+  describe('appendPet', () => {
+    it('appends a single fetched pet without a full reload, stripping heavy blobs', async () => {
+      const upload = await appState.uploadPetQuiet(SAMPLE_BEEWASP, { gender: 'Female' });
+      expect(upload.pet_id).toBeDefined();
+
+      // Store starts empty (no loadPets) — appendPet adds just the one row.
+      expect(get(pets)).toHaveLength(0);
+      await appState.appendPet(upload.pet_id);
+
+      const list = get(pets);
+      expect(list).toHaveLength(1);
+      expect(list[0].id).toBe(upload.pet_id);
+      expect(list[0].name).toBeTruthy();
+      // List-path shape: the heavy blobs getAllPets omits (#254) are stripped.
+      expect(list[0].genome_text).toBeUndefined();
+      expect(list[0].genome_data).toBeUndefined();
+    });
+
+    it('is a no-op when the pet is already in the store', async () => {
+      const upload = await appState.uploadPetQuiet(SAMPLE_BEEWASP, { name: 'Once', gender: 'Female' });
+      await appState.appendPet(upload.pet_id);
+      await appState.appendPet(upload.pet_id);
+      expect(get(pets)).toHaveLength(1);
+    });
+
+    it('is a no-op when the id does not exist', async () => {
+      await appState.appendPet(999999);
+      expect(get(pets)).toHaveLength(0);
+    });
+  });
 });

--- a/tests/unit/shareService.test.js
+++ b/tests/unit/shareService.test.js
@@ -66,6 +66,7 @@ import {
 } from '$lib/services/shareService.js';
 import { Gender } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
+import { makePet, DEFAULT_RAW_TEXT as RAW_TEXT, DEFAULT_RAW_TEXT_HASH as RAW_TEXT_HASH } from '../fixtures/sharePet.js';
 
 afterEach(() => {
   // Clear call-history for every spy. Then individually reset the
@@ -86,44 +87,6 @@ afterEach(() => {
 
 function lastBatch() {
   return batchCalls.at(-1);
-}
-
-// `uploadPet` re-hashes `genome_text` and rejects rows whose stored
-// `content_hash` doesn't match — so makePet must produce a coherent
-// fixture rather than a placeholder. Precomputed at module load via
-// top-level await so test bodies stay synchronous.
-const RAW_TEXT = '[Overview]\nCharacter=PlayerOne\nEntity=Buzz\n[Genes]\n';
-const RAW_TEXT_HASH = await sha256Hex(RAW_TEXT);
-
-function makePet(overrides = {}) {
-  return {
-    id: 1,
-    name: 'Buzz',
-    species: 'BeeWasp',
-    gender: Gender.FEMALE,
-    breed: '',
-    breeder: 'PlayerOne',
-    content_hash: RAW_TEXT_HASH,
-    genome_data: JSON.stringify({ name: 'Buzz', breeder: 'PlayerOne', genes: {} }),
-    genome_text: RAW_TEXT,
-    notes: '',
-    tags: ['fast', 'fierce'],
-    created_at: '2026-05-01T00:00:00Z',
-    updated_at: '2026-05-01T00:00:00Z',
-    intelligence: 50,
-    toughness: 50,
-    friendliness: 50,
-    ruggedness: 50,
-    enthusiasm: 50,
-    virility: 50,
-    ferocity: 50,
-    temperament: 0,
-    positive_genes: 0,
-    starred: false,
-    stabled: false,
-    is_pet_quality: false,
-    ...overrides,
-  };
 }
 
 describe('shareService.uploadPet', () => {


### PR DESCRIPTION
Four scoped follow-ups from the community/sharing work. Independent commits, one per issue.

- **#253** — `autoScanGameFolder` refreshes the pets store itself; drops the duplicated post-scan `loadPets()` from AuthWrapper and PetList. Dynamic store import keeps the dependency off the service's static graph and the non-Tauri path.
- **#256** — community import appends just the new row (`appState.appendPet`) instead of a full `loadPets()` reload. The `already-imported` (backfill/race) branch mutates an existing row in place and still does a full reload.
- **#281** — opt-in Firestore emulator for local dev via `VITE_USE_FIRESTORE_EMULATOR=true`; off by default, dev-only. Documented in `docs/firebase-setup.md`.
- **#255** — extracted the two drifted `makePet`/`freshPet` factories into `tests/fixtures/sharePet.js`. `validMetadata`/`validGenome` left in the emulator suite (single-copy, firebase-coupled — moving them would couple the unit suite to firebase for no dedup benefit; deviates from the issue's wishlist on purpose).

511 unit tests pass; biome clean. Emulator suite (#255) validated in CI — no local Java.

Closes #253, #256, #281, #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)