### PR TITLE
Keyboard-accessible reordering for pets and gallery (#105)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -230,6 +230,20 @@ textarea {
   }
 }
 
+/* Visually hidden but exposed to assistive tech — for aria-live regions and
+   off-screen labels. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* --- Shared inline banner (status / warning / error strips) --- */
 .banner {
   padding: 10px 12px;

--- a/src/lib/components/pet/PetImageGallery.svelte
+++ b/src/lib/components/pet/PetImageGallery.svelte
@@ -7,7 +7,7 @@ import {
   reorderImages,
   uploadImage,
 } from '$lib/services/imageService.js';
-import { createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
+import { arrayMove, createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
@@ -125,11 +125,7 @@ async function handleDrop(e, dropIndex) {
   }
 
   const previous = [...images];
-  const reordered = [...images];
-  const [moved] = reordered.splice(drag.draggedIndex, 1);
-  reordered.splice(dropIndex, 0, moved);
-
-  images = reordered;
+  images = arrayMove(images, drag.draggedIndex, dropIndex);
   drag.draggedIndex = null;
 
   try {
@@ -139,26 +135,21 @@ async function handleDrop(e, dropIndex) {
   }
 }
 
-// Keyboard-accessible reordering (#105).
+// Keyboard-accessible reordering (#105). The thumbnail grid renders every
+// image in backing-array order with no filtering, so the handle index equals
+// the `images` index. If image filtering is ever added, gate the handle (as
+// PetList does with `isDraggable`) and map indices by id, or this will reorder
+// by a misaligned index.
 let reorderAnnouncement = $state('');
-let preGrabOrder = null;
 const kbReorder = createKeyboardReorder({
   count: () => images.length,
   reorder: (from, to) => {
-    const list = [...images];
-    const [moved] = list.splice(from, 1);
-    list.splice(to, 0, moved);
-    images = list;
+    images = arrayMove(images, from, to);
   },
-  onGrab: () => {
-    preGrabOrder = [...images];
-  },
-  persist: async () => {
-    try {
-      await reorderImages(images.map((img) => img.id));
-    } catch {
-      if (preGrabOrder) images = preGrabOrder;
-    }
+  persist: () => reorderImages(images.map((img) => img.id)),
+  snapshot: () => [...images],
+  restore: (snap) => {
+    images = snap;
   },
   label: (i) => images[i]?.original_name || 'image',
   announce: (msg) => {
@@ -196,7 +187,7 @@ $effect(() => {
       <p class="empty-hint">Upload screenshots of your pet to build a gallery</p>
     </div>
   {:else}
-    <div class="sr-only" aria-live="assertive" role="status">{reorderAnnouncement}</div>
+    <div class="sr-only" aria-live="polite" role="status">{reorderAnnouncement}</div>
     <div class="thumbnail-grid">
       {#each images as img, i (img.id)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/pet/PetImageGallery.svelte
+++ b/src/lib/components/pet/PetImageGallery.svelte
@@ -7,7 +7,7 @@ import {
   reorderImages,
   uploadImage,
 } from '$lib/services/imageService.js';
-import { createDragState } from '$lib/utils/dragReorder.svelte.js';
+import { createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
@@ -139,6 +139,36 @@ async function handleDrop(e, dropIndex) {
   }
 }
 
+// Keyboard-accessible reordering (#105).
+let reorderAnnouncement = $state('');
+let preGrabOrder = null;
+const kbReorder = createKeyboardReorder({
+  count: () => images.length,
+  reorder: (from, to) => {
+    const list = [...images];
+    const [moved] = list.splice(from, 1);
+    list.splice(to, 0, moved);
+    images = list;
+  },
+  onGrab: () => {
+    preGrabOrder = [...images];
+  },
+  persist: async () => {
+    try {
+      await reorderImages(images.map((img) => img.id));
+    } catch {
+      if (preGrabOrder) images = preGrabOrder;
+    }
+  },
+  label: (i) => images[i]?.original_name || 'image',
+  announce: (msg) => {
+    reorderAnnouncement = msg;
+  },
+  focusItem: (i) => {
+    document.querySelectorAll('.thumbnail-grid .reorder-handle')[i]?.focus();
+  },
+});
+
 onDestroy(() => clearTimeout(statusTimer));
 
 $effect(() => {
@@ -166,6 +196,7 @@ $effect(() => {
       <p class="empty-hint">Upload screenshots of your pet to build a gallery</p>
     </div>
   {:else}
+    <div class="sr-only" aria-live="assertive" role="status">{reorderAnnouncement}</div>
     <div class="thumbnail-grid">
       {#each images as img, i (img.id)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -173,6 +204,7 @@ $effect(() => {
           class="thumbnail-card"
           class:dragging={drag.draggedIndex === i}
           class:drag-over={drag.dragOverIndex === i && drag.draggedIndex !== i}
+          class:kb-grabbed={kbReorder.isGrabbed(i)}
           draggable="true"
           ondragstart={(e) => drag.handleDragStart(e, i)}
           ondragover={(e) => drag.handleDragOver(e, i)}
@@ -180,6 +212,15 @@ $effect(() => {
           ondrop={(e) => handleDrop(e, i)}
           ondragend={drag.handleDragEnd}
         >
+          <button
+            type="button"
+            class="reorder-handle"
+            aria-label="Reorder {img.original_name || 'image'}"
+            aria-grabbed={kbReorder.isGrabbed(i)}
+            title="Reorder: press Space to grab, arrow keys to move, Space to drop"
+            onkeydown={(e) => kbReorder.handleKeydown(e, i)}
+            onblur={kbReorder.handleBlur}
+          >⠿</button>
           <button class="thumbnail-btn" onclick={() => openLightbox(i)}>
             <img src={img.url} alt={img.original_name} loading="lazy" />
           </button>
@@ -313,6 +354,45 @@ $effect(() => {
   .thumbnail-card.drag-over {
     border-color: var(--accent);
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.3);
+  }
+
+  .thumbnail-card.kb-grabbed {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent);
+  }
+
+  .reorder-handle {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    z-index: 1;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.45);
+    color: #fff;
+    cursor: grab;
+    font-size: 13px;
+    line-height: 1;
+    opacity: 0;
+  }
+
+  .thumbnail-card:hover .reorder-handle,
+  .thumbnail-card:focus-within .reorder-handle,
+  .reorder-handle:focus-visible {
+    opacity: 1;
+  }
+
+  .reorder-handle:focus-visible {
+    outline: 2px solid var(--accent);
+  }
+
+  .reorder-handle[aria-grabbed='true'] {
+    cursor: grabbing;
+    background: var(--accent);
+    opacity: 1;
   }
 
   .thumbnail-btn {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -4,7 +4,7 @@ import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
-import { createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
+import { arrayMove, createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
@@ -288,25 +288,12 @@ async function handleDrop(e, dropIndex) {
 // (`isDraggable`), so a card's index in `filteredPets` equals its index in
 // `$pets` and we can reorder the backing list directly.
 let reorderAnnouncement = $state('');
-let preGrabOrder = null;
 const kbReorder = createKeyboardReorder({
   count: () => $pets.length,
-  reorder: (from, to) => {
-    const list = [...$pets];
-    const [moved] = list.splice(from, 1);
-    list.splice(to, 0, moved);
-    pets.set(list);
-  },
-  onGrab: () => {
-    preGrabOrder = [...$pets];
-  },
-  persist: async () => {
-    try {
-      await appState.reorderPets($pets.map((p) => p.id));
-    } catch {
-      if (preGrabOrder) pets.set(preGrabOrder);
-    }
-  },
+  reorder: (from, to) => pets.set(arrayMove($pets, from, to)),
+  persist: () => appState.reorderPets($pets.map((p) => p.id)),
+  snapshot: () => [...$pets],
+  restore: (snap) => pets.set(snap),
   label: (i) => $pets[i]?.name || 'Unnamed',
   announce: (msg) => {
     reorderAnnouncement = msg;
@@ -352,7 +339,7 @@ const kbReorder = createKeyboardReorder({
         {/if}
     </div>
 
-    <div class="sr-only" aria-live="assertive" role="status">{reorderAnnouncement}</div>
+    <div class="sr-only" aria-live="polite" role="status">{reorderAnnouncement}</div>
     <div class="pet-list-items" aria-label="Pet list">
         {#if filteredPets.length > 0}
             {#each filteredPets as pet, index (pet.id)}

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -4,7 +4,7 @@ import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
-import { createDragState } from '$lib/utils/dragReorder.svelte.js';
+import { createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
@@ -283,6 +283,38 @@ async function handleDrop(e, dropIndex) {
     pets.set(previous);
   }
 }
+
+// Keyboard-accessible reordering (#105). Only active while unfiltered
+// (`isDraggable`), so a card's index in `filteredPets` equals its index in
+// `$pets` and we can reorder the backing list directly.
+let reorderAnnouncement = $state('');
+let preGrabOrder = null;
+const kbReorder = createKeyboardReorder({
+  count: () => $pets.length,
+  reorder: (from, to) => {
+    const list = [...$pets];
+    const [moved] = list.splice(from, 1);
+    list.splice(to, 0, moved);
+    pets.set(list);
+  },
+  onGrab: () => {
+    preGrabOrder = [...$pets];
+  },
+  persist: async () => {
+    try {
+      await appState.reorderPets($pets.map((p) => p.id));
+    } catch {
+      if (preGrabOrder) pets.set(preGrabOrder);
+    }
+  },
+  label: (i) => $pets[i]?.name || 'Unnamed',
+  announce: (msg) => {
+    reorderAnnouncement = msg;
+  },
+  focusItem: (i) => {
+    document.querySelectorAll('.pet-list-items .reorder-handle')[i]?.focus();
+  },
+});
 </script>
 
 <div class="pet-list">
@@ -320,6 +352,7 @@ async function handleDrop(e, dropIndex) {
         {/if}
     </div>
 
+    <div class="sr-only" aria-live="assertive" role="status">{reorderAnnouncement}</div>
     <div class="pet-list-items" aria-label="Pet list">
         {#if filteredPets.length > 0}
             {#each filteredPets as pet, index (pet.id)}
@@ -328,6 +361,7 @@ async function handleDrop(e, dropIndex) {
                     class="pet-card-wrapper"
                     class:drag-over={drag.dragOverIndex === index && drag.draggedIndex !== index}
                     class:dragging={drag.draggedIndex === index}
+                    class:kb-grabbed={kbReorder.isGrabbed(index)}
                     draggable={isDraggable}
                     ondragstart={(e) => drag.handleDragStart(e, index)}
                     ondragover={(e) => drag.handleDragOver(e, index)}
@@ -335,6 +369,17 @@ async function handleDrop(e, dropIndex) {
                     ondrop={(e) => handleDrop(e, index)}
                     ondragend={drag.handleDragEnd}
                 >
+                    {#if isDraggable}
+                        <button
+                            type="button"
+                            class="reorder-handle"
+                            aria-label="Reorder {pet.name || 'Unnamed'}"
+                            aria-grabbed={kbReorder.isGrabbed(index)}
+                            title="Reorder: press Space to grab, arrow keys to move, Space to drop"
+                            onkeydown={(e) => kbReorder.handleKeydown(e, index)}
+                            onblur={kbReorder.handleBlur}
+                        >⠿</button>
+                    {/if}
                     {#if $compareSelectMode}
                         <input
                             type="checkbox"
@@ -585,6 +630,44 @@ async function handleDrop(e, dropIndex) {
 
     .pet-card-wrapper.drag-over {
         border-top: 2px solid var(--accent);
+    }
+
+    .pet-card-wrapper.kb-grabbed {
+        outline: 2px solid var(--accent);
+        outline-offset: 1px;
+        border-radius: 8px;
+    }
+
+    .reorder-handle {
+        flex: 0 0 auto;
+        width: 18px;
+        height: 32px;
+        padding: 0;
+        border: none;
+        background: none;
+        color: var(--text-tertiary);
+        cursor: grab;
+        font-size: 14px;
+        line-height: 1;
+        opacity: 0;
+        border-radius: 4px;
+    }
+
+    .pet-card-wrapper:hover .reorder-handle,
+    .pet-card-wrapper:focus-within .reorder-handle,
+    .reorder-handle:focus-visible {
+        opacity: 1;
+    }
+
+    .reorder-handle:focus-visible {
+        outline: 2px solid var(--accent);
+        color: var(--text-primary);
+    }
+
+    .reorder-handle[aria-grabbed='true'] {
+        cursor: grabbing;
+        color: var(--accent);
+        opacity: 1;
     }
 
     .drop-zone-end {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -4,7 +4,7 @@ import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
-import { arrayMove, createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
+import { createDragState, createKeyboardReorder, moveByFilteredIndex } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
@@ -284,17 +284,19 @@ async function handleDrop(e, dropIndex) {
   }
 }
 
-// Keyboard-accessible reordering (#105). Only active while unfiltered
-// (`isDraggable`), so a card's index in `filteredPets` equals its index in
-// `$pets` and we can reorder the backing list directly.
+// Keyboard-accessible reordering (#105). Handle indices are positions in the
+// rendered `filteredPets`, which can be a subset of `$pets` (the starred/stabled
+// marker filters narrow it even while `isDraggable` is true). So translate the
+// move to `$pets` by pet id — the same id-resolution the drag `handleDrop` uses
+// — rather than indexing `$pets` directly.
 let reorderAnnouncement = $state('');
 const kbReorder = createKeyboardReorder({
-  count: () => $pets.length,
-  reorder: (from, to) => pets.set(arrayMove($pets, from, to)),
+  count: () => filteredPets.length,
+  reorder: (from, to) => pets.set(moveByFilteredIndex($pets, filteredPets, from, to, (p) => p.id)),
   persist: () => appState.reorderPets($pets.map((p) => p.id)),
   snapshot: () => [...$pets],
   restore: (snap) => pets.set(snap),
-  label: (i) => $pets[i]?.name || 'Unnamed',
+  label: (i) => filteredPets[i]?.name || 'Unnamed',
   announce: (msg) => {
     reorderAnnouncement = msg;
   },

--- a/src/lib/utils/dragReorder.svelte.ts
+++ b/src/lib/utils/dragReorder.svelte.ts
@@ -14,6 +14,34 @@ export function arrayMove<T>(list: T[], from: number, to: number): T[] {
 }
 
 /**
+ * Translate a move expressed in a filtered view — `from`/`to` are indices into
+ * `view` — into a reordering of the full `list`, matching items by `idOf`.
+ * Used when the rendered list is a subset of the backing list (e.g. the pet
+ * list under an active marker filter): indexing the backing list directly would
+ * move the wrong items. Moving down places the item after the target; moving up,
+ * before it. Returns a new list (or the original if indices don't resolve).
+ */
+export function moveByFilteredIndex<T>(
+  list: T[],
+  view: T[],
+  from: number,
+  to: number,
+  idOf: (item: T) => unknown,
+): T[] {
+  const moved = view[from];
+  const target = view[to];
+  if (!moved || !target) return list;
+  const copy = [...list];
+  const fromIdx = copy.findIndex((x) => idOf(x) === idOf(moved));
+  if (fromIdx < 0) return list;
+  copy.splice(fromIdx, 1);
+  const targetIdx = copy.findIndex((x) => idOf(x) === idOf(target));
+  if (targetIdx < 0) return list;
+  copy.splice(to > from ? targetIdx + 1 : targetIdx, 0, moved);
+  return copy;
+}
+
+/**
  * Shared drag-and-drop reorder state and handlers.
  * Components provide their own handleDrop since the reorder logic differs
  * (PetList resolves through a filtered list, gallery operates on a flat array).
@@ -122,20 +150,32 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
     suppressBlur = false;
   }
 
-  async function drop(): Promise<number | null> {
+  async function drop(): Promise<{ index: number; persisted: boolean } | null> {
     if (grabbedIndex === null) return null;
     const moved = grabbedIndex !== originIndex;
     const at = grabbedIndex;
     grabbedIndex = null;
     originIndex = null;
-    if (moved) {
-      try {
-        await opts.persist();
-      } catch {
-        opts.restore(preGrab);
-      }
+    if (!moved) return { index: at, persisted: true };
+    try {
+      await opts.persist();
+      return { index: at, persisted: true };
+    } catch {
+      // Roll back the optimistic move; report failure so the caller doesn't
+      // announce a successful drop.
+      opts.restore(preGrab);
+      return { index: at, persisted: false };
     }
-    return at;
+  }
+
+  /** Announce the outcome of a drop (shared by Space-drop and blur-commit). */
+  function announceDrop(res: { index: number; persisted: boolean } | null) {
+    if (!res) return;
+    if (res.persisted) {
+      opts.announce(`Dropped ${opts.label(res.index)} at position ${res.index + 1} of ${opts.count()}.`);
+    } else {
+      opts.announce('Could not save the new order — it was restored.');
+    }
   }
 
   return {
@@ -162,8 +202,7 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
               'Use up and down arrows to move, space to drop, escape to cancel.',
           );
         } else {
-          const at = await drop();
-          if (at !== null) opts.announce(`Dropped ${opts.label(at)} at position ${at + 1} of ${count}.`);
+          announceDrop(await drop());
         }
         return;
       }
@@ -202,7 +241,7 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
     /** Commit the current position when focus genuinely leaves a grabbed handle. */
     async handleBlur() {
       if (suppressBlur) return;
-      await drop();
+      announceDrop(await drop());
     },
   };
 }

--- a/src/lib/utils/dragReorder.svelte.ts
+++ b/src/lib/utils/dragReorder.svelte.ts
@@ -1,6 +1,19 @@
 import { tick } from 'svelte';
 
 /**
+ * Pure list move: return a copy of `list` with the item at `from` removed and
+ * reinserted at `to` (interpreted in the post-removal array, matching a
+ * splice-out/splice-in). Shared by the drag and keyboard reorder paths so the
+ * move logic lives in exactly one place.
+ */
+export function arrayMove<T>(list: T[], from: number, to: number): T[] {
+  const copy = [...list];
+  const [moved] = copy.splice(from, 1);
+  copy.splice(to, 0, moved);
+  return copy;
+}
+
+/**
  * Shared drag-and-drop reorder state and handlers.
  * Components provide their own handleDrop since the reorder logic differs
  * (PetList resolves through a filtered list, gallery operates on a flat array).
@@ -55,13 +68,18 @@ export interface KeyboardReorderOptions {
   /** Focus the reorder handle at `index` (called after the DOM settles so the
    * moved item keeps focus across a keyed `{#each}` reorder). */
   focusItem: (index: number) => void;
-  /** Snapshot the pre-grab order so a failed persist() can roll back. */
-  onGrab?: () => void;
+  /** Capture the current order so a failed persist() can roll back to it. */
+  snapshot: () => Snapshot;
+  /** Restore an order captured by `snapshot()` (rollback on persist failure). */
+  restore: (snap: Snapshot) => void;
   /** Human label for the item at `index`, used in screen-reader announcements. */
   label: (index: number) => string;
   /** Emit a message; wire to an aria-live region. */
   announce: (message: string) => void;
 }
+
+/** Opaque order snapshot captured by `snapshot()` and replayed by `restore()`. */
+type Snapshot = unknown;
 
 /**
  * Keyboard-accessible reordering (#105) — the a11y counterpart to
@@ -85,6 +103,9 @@ export interface KeyboardReorderOptions {
 export function createKeyboardReorder(opts: KeyboardReorderOptions) {
   let grabbedIndex = $state<number | null>(null);
   let originIndex: number | null = null;
+  // Order captured at grab time so a failed persist() (or some other consumer
+  // need) can roll back without each component hand-rolling the snapshot.
+  let preGrab: Snapshot;
   // Guards the blur that a keyed reorder fires while we relocate focus.
   let suppressBlur = false;
 
@@ -94,7 +115,10 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
     opts.reorder(from, to);
     grabbedIndex = to;
     await tick();
-    opts.focusItem(to);
+    // A concurrent external list update during the tick (e.g. a background
+    // reload) may have cleared or invalidated the grab — only refocus a handle
+    // that's still in range.
+    if (grabbedIndex !== null && grabbedIndex < opts.count()) opts.focusItem(grabbedIndex);
     suppressBlur = false;
   }
 
@@ -104,7 +128,13 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
     const at = grabbedIndex;
     grabbedIndex = null;
     originIndex = null;
-    if (moved) await opts.persist();
+    if (moved) {
+      try {
+        await opts.persist();
+      } catch {
+        opts.restore(preGrab);
+      }
+    }
     return at;
   }
 
@@ -126,7 +156,7 @@ export function createKeyboardReorder(opts: KeyboardReorderOptions) {
         if (grabbedIndex === null) {
           grabbedIndex = index;
           originIndex = index;
-          opts.onGrab?.();
+          preGrab = opts.snapshot();
           opts.announce(
             `Grabbed ${opts.label(index)}, position ${index + 1} of ${count}. ` +
               'Use up and down arrows to move, space to drop, escape to cancel.',

--- a/src/lib/utils/dragReorder.svelte.ts
+++ b/src/lib/utils/dragReorder.svelte.ts
@@ -1,3 +1,5 @@
+import { tick } from 'svelte';
+
 /**
  * Shared drag-and-drop reorder state and handlers.
  * Components provide their own handleDrop since the reorder logic differs
@@ -39,6 +41,138 @@ export function createDragState() {
     handleDragEnd() {
       draggedIndex = null;
       dragOverIndex = null;
+    },
+  };
+}
+
+export interface KeyboardReorderOptions {
+  /** Current number of reorderable items. */
+  count: () => number;
+  /** Move the item at `from` to `to` in the in-memory list (no persistence). */
+  reorder: (from: number, to: number) => void;
+  /** Persist the current order. Called once on drop, only if the item moved. */
+  persist: () => void | Promise<void>;
+  /** Focus the reorder handle at `index` (called after the DOM settles so the
+   * moved item keeps focus across a keyed `{#each}` reorder). */
+  focusItem: (index: number) => void;
+  /** Snapshot the pre-grab order so a failed persist() can roll back. */
+  onGrab?: () => void;
+  /** Human label for the item at `index`, used in screen-reader announcements. */
+  label: (index: number) => string;
+  /** Emit a message; wire to an aria-live region. */
+  announce: (message: string) => void;
+}
+
+/**
+ * Keyboard-accessible reordering (#105) — the a11y counterpart to
+ * `createDragState`, driven by a focusable reorder handle per item:
+ *
+ *   - Space / Enter   grab the item, or drop it if already grabbed
+ *   - ArrowUp / Down  (while grabbed) move the item one slot
+ *   - Escape          (while grabbed) cancel and restore the original position
+ *   - blur            (while grabbed) commit at the current position
+ *
+ * Tab moves between handles natively (every handle is tabbable). Arrow keys do
+ * nothing until an item is grabbed, so they never fight native focus movement.
+ *
+ * A keyed `{#each}` reorder detaches the focused handle, which fires `blur`
+ * (and would otherwise drop the grab after one move). We suppress that
+ * transient blur and re-focus the handle at its new index once the DOM settles
+ * (`tick`), so a grab survives repeated arrow presses. The component supplies
+ * the list mutation, persistence, focus and labels so this stays list-shape
+ * agnostic.
+ */
+export function createKeyboardReorder(opts: KeyboardReorderOptions) {
+  let grabbedIndex = $state<number | null>(null);
+  let originIndex: number | null = null;
+  // Guards the blur that a keyed reorder fires while we relocate focus.
+  let suppressBlur = false;
+
+  /** Reorder in place, then keep focus on the moved handle after the DOM updates. */
+  async function moveGrabbed(from: number, to: number) {
+    suppressBlur = true;
+    opts.reorder(from, to);
+    grabbedIndex = to;
+    await tick();
+    opts.focusItem(to);
+    suppressBlur = false;
+  }
+
+  async function drop(): Promise<number | null> {
+    if (grabbedIndex === null) return null;
+    const moved = grabbedIndex !== originIndex;
+    const at = grabbedIndex;
+    grabbedIndex = null;
+    originIndex = null;
+    if (moved) await opts.persist();
+    return at;
+  }
+
+  return {
+    get grabbedIndex() {
+      return grabbedIndex;
+    },
+    isGrabbed(index: number) {
+      return grabbedIndex === index;
+    },
+
+    async handleKeydown(e: KeyboardEvent, index: number) {
+      const count = opts.count();
+      if (count <= 0) return;
+
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (grabbedIndex === null) {
+          grabbedIndex = index;
+          originIndex = index;
+          opts.onGrab?.();
+          opts.announce(
+            `Grabbed ${opts.label(index)}, position ${index + 1} of ${count}. ` +
+              'Use up and down arrows to move, space to drop, escape to cancel.',
+          );
+        } else {
+          const at = await drop();
+          if (at !== null) opts.announce(`Dropped ${opts.label(at)} at position ${at + 1} of ${count}.`);
+        }
+        return;
+      }
+
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        if (grabbedIndex === null) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const to = grabbedIndex + (e.key === 'ArrowDown' ? 1 : -1);
+        if (to < 0 || to >= count) return;
+        await moveGrabbed(grabbedIndex, to);
+        opts.announce(`${opts.label(to)} moved to position ${to + 1} of ${count}.`);
+        return;
+      }
+
+      if (e.key === 'Escape' && grabbedIndex !== null) {
+        e.preventDefault();
+        e.stopPropagation();
+        const origin = originIndex ?? grabbedIndex;
+        if (grabbedIndex !== origin) {
+          suppressBlur = true;
+          opts.reorder(grabbedIndex, origin);
+          grabbedIndex = null;
+          originIndex = null;
+          await tick();
+          opts.focusItem(origin);
+          suppressBlur = false;
+        } else {
+          grabbedIndex = null;
+          originIndex = null;
+        }
+        opts.announce(`Cancelled. ${opts.label(origin)} returned to position ${origin + 1} of ${count}.`);
+      }
+    },
+
+    /** Commit the current position when focus genuinely leaves a grabbed handle. */
+    async handleBlur() {
+      if (suppressBlur) return;
+      await drop();
     },
   };
 }

--- a/tests/e2e/keyboard.spec.js
+++ b/tests/e2e/keyboard.spec.js
@@ -116,6 +116,64 @@ test.describe('Keyboard Navigation', () => {
     });
   });
 
+  test.describe('Keyboard Reordering (Issue #105)', () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto('/');
+      await waitForPets(page);
+    });
+
+    async function petNames(page) {
+      return page.locator('.pet-list-items .pet-card-name').allInnerTexts();
+    }
+
+    test('grab, move, and drop reorders the list and keeps focus on the moved item', async ({ page }) => {
+      const before = await petNames(page);
+      test.skip(before.length < 2, 'needs at least two pets');
+
+      const firstHandle = page.locator('.pet-list-items .reorder-handle').first();
+      await firstHandle.focus();
+      await expect(firstHandle).toHaveAttribute('aria-grabbed', 'false');
+
+      // Grab the first item.
+      await page.keyboard.press('Space');
+      await expect(firstHandle).toHaveAttribute('aria-grabbed', 'true');
+      await expect(page.locator('.pet-list [aria-live]')).toContainText('Grabbed');
+
+      // Move it down one slot — it should swap with the former second item.
+      await page.keyboard.press('ArrowDown');
+      const afterMove = await petNames(page);
+      expect(afterMove[0]).toBe(before[1]);
+      expect(afterMove[1]).toBe(before[0]);
+
+      // The grabbed item's handle keeps focus across the keyed reorder.
+      const grabbedHandle = page.locator('.pet-list-items .reorder-handle').nth(1);
+      await expect(grabbedHandle).toBeFocused();
+      await expect(grabbedHandle).toHaveAttribute('aria-grabbed', 'true');
+
+      // Drop it.
+      await page.keyboard.press('Space');
+      await expect(page.locator('.reorder-handle[aria-grabbed="true"]')).toHaveCount(0);
+      await expect(page.locator('.pet-list [aria-live]')).toContainText('Dropped');
+      // Order holds after dropping.
+      expect(await petNames(page)).toEqual(afterMove);
+    });
+
+    test('Escape cancels a move and restores the original order', async ({ page }) => {
+      const before = await petNames(page);
+      test.skip(before.length < 2, 'needs at least two pets');
+
+      await page.locator('.pet-list-items .reorder-handle').first().focus();
+      await page.keyboard.press('Space');
+      await page.keyboard.press('ArrowDown');
+      expect((await petNames(page))[0]).toBe(before[1]);
+
+      await page.keyboard.press('Escape');
+      expect(await petNames(page)).toEqual(before);
+      await expect(page.locator('.reorder-handle[aria-grabbed="true"]')).toHaveCount(0);
+      await expect(page.locator('.pet-list [aria-live]')).toContainText('Cancelled');
+    });
+  });
+
   test.describe('Settings Modal', () => {
     test('Escape closes the modal', async ({ page }) => {
       await page.goto('/');

--- a/tests/unit/keyboardReorder.test.js
+++ b/tests/unit/keyboardReorder.test.js
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
+
+// Fake keyboard event with the only two methods the helper calls.
+function key(k) {
+  return { key: k, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+}
+
+describe('createKeyboardReorder', () => {
+  let items;
+  let persist;
+  let announce;
+  let focusItem;
+  let kb;
+
+  beforeEach(() => {
+    items = ['Alpha', 'Bravo', 'Charlie'];
+    persist = vi.fn().mockResolvedValue(undefined);
+    announce = vi.fn();
+    focusItem = vi.fn();
+    kb = createKeyboardReorder({
+      count: () => items.length,
+      reorder: (from, to) => {
+        const [moved] = items.splice(from, 1);
+        items.splice(to, 0, moved);
+      },
+      persist,
+      focusItem,
+      label: (i) => items[i],
+      announce,
+    });
+  });
+
+  it('grabs on Space, exposing grabbedIndex without mutating or persisting', async () => {
+    await kb.handleKeydown(key(' '), 1);
+    expect(kb.grabbedIndex).toBe(1);
+    expect(kb.isGrabbed(1)).toBe(true);
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(persist).not.toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves the grabbed item with ArrowDown and tracks the new index, deferring persist to drop', async () => {
+    await kb.handleKeydown(key(' '), 0); // grab Alpha
+    await kb.handleKeydown(key('ArrowDown'), 0);
+    expect(items).toEqual(['Bravo', 'Alpha', 'Charlie']);
+    expect(kb.grabbedIndex).toBe(1);
+    expect(focusItem).toHaveBeenCalledWith(1); // focus follows the moved handle
+    expect(persist).not.toHaveBeenCalled();
+
+    await kb.handleKeydown(key(' '), 1); // drop
+    expect(kb.grabbedIndex).toBeNull();
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not move past the last position', async () => {
+    await kb.handleKeydown(key(' '), 2); // grab Charlie (last)
+    await kb.handleKeydown(key('ArrowDown'), 2);
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(kb.grabbedIndex).toBe(2);
+  });
+
+  it('does not move past the first position', async () => {
+    await kb.handleKeydown(key(' '), 0); // grab Alpha (first)
+    await kb.handleKeydown(key('ArrowUp'), 0);
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(kb.grabbedIndex).toBe(0);
+  });
+
+  it('Escape restores the original position and does not persist', async () => {
+    await kb.handleKeydown(key(' '), 0); // grab Alpha
+    await kb.handleKeydown(key('ArrowDown'), 0); // -> [Bravo, Alpha, Charlie]
+    await kb.handleKeydown(key('ArrowDown'), 1); // -> [Bravo, Charlie, Alpha]
+    expect(items).toEqual(['Bravo', 'Charlie', 'Alpha']);
+
+    await kb.handleKeydown(key('Escape'), 2);
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(kb.grabbedIndex).toBeNull();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('ignores arrow keys when nothing is grabbed', async () => {
+    await kb.handleKeydown(key('ArrowDown'), 0);
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    expect(kb.grabbedIndex).toBeNull();
+  });
+
+  it('drop without movement does not persist', async () => {
+    await kb.handleKeydown(key(' '), 1); // grab
+    await kb.handleKeydown(key(' '), 1); // drop, unmoved
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('blur commits a moved item', async () => {
+    await kb.handleKeydown(key(' '), 0);
+    await kb.handleKeydown(key('ArrowDown'), 0);
+    await kb.handleBlur();
+    expect(kb.grabbedIndex).toBeNull();
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents default and stops propagation for handled keys so they do not bubble', async () => {
+    const grab = key(' ');
+    await kb.handleKeydown(grab, 0);
+    expect(grab.preventDefault).toHaveBeenCalled();
+    expect(grab.stopPropagation).toHaveBeenCalled();
+
+    const move = key('ArrowDown');
+    await kb.handleKeydown(move, 0);
+    expect(move.preventDefault).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/keyboardReorder.test.js
+++ b/tests/unit/keyboardReorder.test.js
@@ -26,6 +26,10 @@ describe('createKeyboardReorder', () => {
       },
       persist,
       focusItem,
+      snapshot: () => [...items],
+      restore: (snap) => {
+        items = snap;
+      },
       label: (i) => items[i],
       announce,
     });
@@ -89,6 +93,16 @@ describe('createKeyboardReorder', () => {
     await kb.handleKeydown(key(' '), 1); // grab
     await kb.handleKeydown(key(' '), 1); // drop, unmoved
     expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('rolls back to the pre-grab order when persist fails', async () => {
+    persist.mockRejectedValueOnce(new Error('db down'));
+    await kb.handleKeydown(key(' '), 0); // grab Alpha
+    await kb.handleKeydown(key('ArrowDown'), 0); // optimistic -> [Bravo, Alpha, Charlie]
+    expect(items).toEqual(['Bravo', 'Alpha', 'Charlie']);
+
+    await kb.handleKeydown(key(' '), 1); // drop -> persist rejects -> restore snapshot
+    expect(items).toEqual(['Alpha', 'Bravo', 'Charlie']);
   });
 
   it('blur commits a moved item', async () => {

--- a/tests/unit/keyboardReorder.test.js
+++ b/tests/unit/keyboardReorder.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
+import { arrayMove, createKeyboardReorder, moveByFilteredIndex } from '$lib/utils/dragReorder.svelte.js';
 
 // Fake keyboard event with the only two methods the helper calls.
 function key(k) {
@@ -122,5 +122,54 @@ describe('createKeyboardReorder', () => {
     const move = key('ArrowDown');
     await kb.handleKeydown(move, 0);
     expect(move.preventDefault).toHaveBeenCalled();
+  });
+
+  it('announces a restore (not a successful drop) when persist fails on drop', async () => {
+    persist.mockRejectedValueOnce(new Error('db down'));
+    await kb.handleKeydown(key(' '), 0);
+    await kb.handleKeydown(key('ArrowDown'), 0);
+    announce.mockClear();
+    await kb.handleKeydown(key(' '), 1); // drop -> persist rejects
+    expect(announce).toHaveBeenCalledWith(expect.stringMatching(/restored/i));
+    expect(announce).not.toHaveBeenCalledWith(expect.stringMatching(/^Dropped/));
+  });
+
+  it('announces the drop on blur-commit (not silent for screen readers)', async () => {
+    await kb.handleKeydown(key(' '), 0);
+    await kb.handleKeydown(key('ArrowDown'), 0);
+    announce.mockClear();
+    await kb.handleBlur();
+    expect(announce).toHaveBeenCalledWith(expect.stringMatching(/^Dropped/));
+  });
+});
+
+describe('moveByFilteredIndex', () => {
+  const id = (x) => x.id;
+  const full = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+
+  it('matches arrayMove when the view is the full list', () => {
+    const out = moveByFilteredIndex(full, full, 0, 1, id);
+    expect(out.map(id)).toEqual(arrayMove(full, 0, 1).map(id));
+    expect(out.map(id)).toEqual(['b', 'a', 'c', 'd']);
+  });
+
+  it('reorders the FULL list correctly when the view is a filtered subset', () => {
+    // View hides 'b' and 'd' (e.g. a marker filter): view = [a, c].
+    const view = [full[0], full[2]];
+    // Move 'a' (view idx 0) down past 'c' (view idx 1): 'a' should land just
+    // after 'c' in the full list, NOT swap with 'b'.
+    const out = moveByFilteredIndex(full, view, 0, 1, id);
+    expect(out.map(id)).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('moving up in a filtered view places the item before the target in the full list', () => {
+    const view = [full[0], full[2]]; // [a, c]
+    // Move 'c' (view idx 1) up above 'a' (view idx 0).
+    const out = moveByFilteredIndex(full, view, 1, 0, id);
+    expect(out.map(id)).toEqual(['c', 'a', 'b', 'd']);
+  });
+
+  it('returns the original list when indices do not resolve', () => {
+    expect(moveByFilteredIndex(full, [], 0, 1, id)).toBe(full);
   });
 });


### PR DESCRIPTION
Closes #105.

Adds a keyboard path to the pet-list and gallery reordering, which were previously HTML5 drag-and-drop only (non-focusable `draggable` divs behind `svelte-ignore` a11y suppressions).

## Interaction
A focusable reorder handle (`⠿`) per pet card / thumbnail:
- **Space / Enter** — grab (or drop if already grabbed)
- **ArrowUp / Down** — move the grabbed item one slot
- **Escape** — cancel and restore the original position
- **blur** — commit at the current position

State is conveyed via `aria-grabbed` on the handle and a visually-hidden `aria-live` region announcing grab / move / drop / cancel.

## Implementation
- New `createKeyboardReorder` in `dragReorder.svelte.ts` — the a11y counterpart to `createDragState`. List-shape agnostic: the component supplies `count`, `reorder`, `persist`, `focusItem`, `label`, `announce`.
- Persistence reuses the existing `appState.reorderPets` / `reorderImages` path with rollback; it fires once on drop (not per keystroke).
- A keyed `{#each}` reorder detaches the focused handle (fires `blur`, which would otherwise drop the grab after one move). The helper suppresses that transient blur and re-focuses the moved handle after `tick()`, so a grab survives repeated arrow presses. This was caught and fixed during in-app Playwright verification.
- Added `.sr-only` utility to `app.css`.

## Tests
- `keyboardReorder.test.js` — 9 unit tests (grab/move/bounds/drop/escape/blur/persist-only-if-moved/focus-follow).
- `keyboard.spec.js` — 2 e2e tests (grab→move→drop reorders + keeps focus; Escape restores).
- Verified manually in the running app (grab, multi-move, drop, escape; focus + announcements).

521 unit tests + 131 e2e pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)