### PR TITLE
Adopt shared StatusPane in pre-existing tab surfaces (#252)

### DIFF
--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -1,4 +1,5 @@
 <script>
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { rankBreedingPairs } from '$lib/services/breedingService.js';
 import { getAllAttributeNames, getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { breedingView } from '$lib/stores/breeding.svelte.js';
@@ -123,27 +124,24 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
 
     <section class="results">
         {#if errored}
-            <div class="status-pane error" role="alert" data-testid="breeding-error">
-                <p><strong>Couldn't rank breeding pairs.</strong></p>
-                <p class="muted">
-                    Something went wrong while computing scores. Check the browser
-                    console for details, then change a control to retry.
-                </p>
+            <div class="status-state" data-testid="breeding-error">
+                <StatusPane
+                    variant="error"
+                    title="Couldn't rank breeding pairs."
+                    body="Something went wrong while computing scores. Check the browser console for details, then change a control to retry."
+                />
             </div>
         {:else if loading && pairs.length === 0}
-            <div class="status-pane" data-testid="breeding-loading">
-                <div class="spinner"></div>
-                <p>Computing pair scores…</p>
+            <div class="status-state" data-testid="breeding-loading">
+                <StatusPane variant="loading" body="Computing pair scores…" />
             </div>
         {:else if eligibleForCurrent.male === 0 || eligibleForCurrent.female === 0}
-            <div class="status-pane empty" data-testid="breeding-empty">
-                <p>
-                    No pairs to rank — need at least one stabled
-                    <strong>{breedingView.species}</strong> of each gender.
-                </p>
-                <p class="muted">
-                    Currently: {eligibleForCurrent.male} ♂ × {eligibleForCurrent.female} ♀
-                </p>
+            <div class="status-state" data-testid="breeding-empty">
+                <StatusPane
+                    variant="empty"
+                    title="No pairs to rank"
+                    body={`Need at least one stabled ${breedingView.species} of each gender. Currently: ${eligibleForCurrent.male} ♂ × ${eligibleForCurrent.female} ♀`}
+                />
             </div>
         {:else}
             <div class="results-meta">
@@ -252,23 +250,11 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
         color: var(--text-muted);
     }
 
-    .status-pane {
+    /* Fills the results area and centres the shared StatusPane vertically. */
+    .status-state {
         flex: 1;
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 8px;
-        color: var(--text-muted);
     }
-
-    .status-pane.empty p,
-    .status-pane.error p {
-        margin: 0;
-    }
-
-    .status-pane.error {
-        color: var(--error-text, var(--text-secondary));
-    }
-
 </style>

--- a/src/lib/components/comparison/ComparisonView.svelte
+++ b/src/lib/components/comparison/ComparisonView.svelte
@@ -2,6 +2,7 @@
 import AttributeComparison from '$lib/components/comparison/AttributeComparison.svelte';
 import GeneStatsComparison from '$lib/components/comparison/GeneStatsComparison.svelte';
 import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { comparisonPets, comparisonReady, speciesMismatch } from '$lib/stores/comparison.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
@@ -71,9 +72,12 @@ const speciesLabel = $derived($comparisonPets[0] ? normalizeSpecies($comparisonP
         </div>
     {:else}
         <div class="empty-state">
-            <div class="empty-icon">⚖️</div>
-            <p class="state-title">Select two pets to compare</p>
-            <p class="state-text">Use the sidebar to pick two same-species pets for head-to-head comparison</p>
+            <StatusPane
+                variant="empty"
+                icon="⚖️"
+                title="Select two pets to compare"
+                body="Use the sidebar to pick two same-species pets for head-to-head comparison"
+            />
         </div>
     {/if}
 </div>
@@ -178,31 +182,11 @@ const speciesLabel = $derived($comparisonPets[0] ? normalizeSpecies($comparisonP
         padding: 20px;
     }
 
+    /* Fills the comparison area and centres the shared StatusPane vertically. */
     .empty-state {
         flex: 1;
         display: flex;
-        flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 8px;
-        color: var(--text-muted);
-    }
-
-    .empty-icon {
-        font-size: 48px;
-        opacity: 0.4;
-    }
-
-    .state-title {
-        font-size: 16px;
-        font-weight: 600;
-        color: var(--text-tertiary);
-        margin: 0;
-    }
-
-    .state-text {
-        font-size: 13px;
-        color: var(--text-muted);
-        margin: 0;
     }
 </style>

--- a/src/lib/components/comparison/GeneStatsComparison.svelte
+++ b/src/lib/components/comparison/GeneStatsComparison.svelte
@@ -1,4 +1,5 @@
 <script>
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { compareGeneStats } from '$lib/services/comparisonService.js';
 
 const { petA, petB } = $props();
@@ -58,12 +59,9 @@ const totalsB = $derived.by(() => {
 
 <div class="gene-stats-comparison">
     {#if loading}
-        <div class="loading-state">
-            <div class="spinner"></div>
-            <p>Loading gene stats...</p>
-        </div>
+        <StatusPane variant="loading" body="Loading gene stats..." />
     {:else if error}
-        <div class="error-state">⚠️ {error}</div>
+        <StatusPane variant="error" icon="⚠️" body={error} />
     {:else if results.length > 0}
         <table class="stats-table">
             <thead>
@@ -130,24 +128,6 @@ const totalsB = $derived.by(() => {
         width: 100%;
     }
 
-    .loading-state {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 8px;
-        padding: 40px;
-        color: var(--text-muted);
-        font-size: 13px;
-    }
-
-    .error-state {
-        padding: 12px 16px;
-        background: var(--error-bg);
-        border: 1px solid var(--error-border);
-        border-radius: 6px;
-        color: var(--error-text);
-        font-size: 13px;
-    }
 
     .stats-table {
         width: 100%;

--- a/src/lib/components/comparison/GenomeDiff.svelte
+++ b/src/lib/components/comparison/GenomeDiff.svelte
@@ -1,4 +1,5 @@
 <script>
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { diffGenomes } from '$lib/services/comparisonService.js';
 
 const { petA, petB } = $props();
@@ -66,12 +67,9 @@ function geneTypeClass(type) {
 
 <div class="genome-diff">
     {#if loading}
-        <div class="loading-state">
-            <div class="spinner"></div>
-            <p>Computing genome diff...</p>
-        </div>
+        <StatusPane variant="loading" body="Computing genome diff..." />
     {:else if error}
-        <div class="error-state">⚠️ {error}</div>
+        <StatusPane variant="error" icon="⚠️" body={error} />
     {:else if summary}
         <div class="diff-summary">
             <span class="similarity-badge">
@@ -153,25 +151,6 @@ function geneTypeClass(type) {
 <style>
     .genome-diff {
         width: 100%;
-    }
-
-    .loading-state {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: 8px;
-        padding: 40px;
-        color: var(--text-muted);
-        font-size: 13px;
-    }
-
-    .error-state {
-        padding: 12px 16px;
-        background: var(--error-bg);
-        border: 1px solid var(--error-border);
-        border-radius: 6px;
-        color: var(--error-text);
-        font-size: 13px;
     }
 
     .diff-summary {

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -2,6 +2,7 @@
 import { onDestroy, onMount } from 'svelte';
 import GenomeDiffControls from '$lib/components/comparison/GenomeDiffControls.svelte';
 import GeneTooltip from '$lib/components/gene/GeneTooltip.svelte';
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import {
   getAppearanceAttributes,
   getAppearanceConfig,
@@ -441,9 +442,9 @@ function handleCellLeave() {
 
 <div class="genome-grid-diff">
     {#if loading}
-        <div class="loading-state"><div class="spinner"></div><p>Loading genomes...</p></div>
+        <StatusPane variant="loading" body="Loading genomes..." />
     {:else if error}
-        <div class="error-state">⚠️ {error}</div>
+        <StatusPane variant="error" icon="⚠️" body={error} />
     {:else if summary}
         <GenomeDiffControls
             {summary}
@@ -546,8 +547,6 @@ function handleCellLeave() {
 
 <style>
     .genome-grid-diff { width: 100%; }
-    .loading-state { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 40px; color: var(--text-muted); font-size: 13px; }
-    .error-state { padding: 12px 16px; background: var(--error-bg); border: 1px solid var(--error-border); border-radius: 6px; color: var(--error-text); font-size: 13px; }
 
     .grid-container { overflow: auto; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-secondary); }
     .gene-grid-table { width: auto; border-collapse: collapse; table-layout: fixed; }

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1207,11 +1207,11 @@ export function getStatsData() {
 
 <div class="gene-visualizer" bind:this={containerElement}>
     {#if loading}
-        <StatusPane variant="loading" body="Loading gene data..." />
+        <div class="visualizer-state"><StatusPane variant="loading" body="Loading gene data..." /></div>
     {:else if error}
-        <StatusPane variant="error" body="Error: {error}" />
+        <div class="visualizer-state"><StatusPane variant="error" body="Error: {error}" /></div>
     {:else if !currentPet}
-        <StatusPane variant="empty" body="Select a pet to visualize its genes" />
+        <div class="visualizer-state"><StatusPane variant="empty" body="Select a pet to visualize its genes" /></div>
     {:else}
         <div class="visualizer-content">
             <div class="gene-section">
@@ -1633,6 +1633,15 @@ export function getStatsData() {
 
 <style>
     /* Gene colors defined as --gene-* CSS vars in :root in src/app.css */
+
+    /* Fills the visualizer column and centres the shared StatusPane vertically
+       (the states previously occupied a fixed 300px centred box). */
+    .visualizer-state {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
 
     .gene-visualizer {
         height: 100%;

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1,5 +1,6 @@
 <script>
 import { onDestroy, onMount } from 'svelte';
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import {
   getAllAppearanceDisplayInfo,
   getAllAttributeDisplayInfo,
@@ -1206,11 +1207,11 @@ export function getStatsData() {
 
 <div class="gene-visualizer" bind:this={containerElement}>
     {#if loading}
-        <div class="loading-state">Loading gene data...</div>
+        <StatusPane variant="loading" body="Loading gene data..." />
     {:else if error}
-        <div class="error-state">Error: {error}</div>
+        <StatusPane variant="error" body="Error: {error}" />
     {:else if !currentPet}
-        <div class="empty-state">Select a pet to visualize its genes</div>
+        <StatusPane variant="empty" body="Select a pet to visualize its genes" />
     {:else}
         <div class="visualizer-content">
             <div class="gene-section">
@@ -1639,21 +1640,6 @@ export function getStatsData() {
         flex-direction: column;
         background: var(--bg-primary);
         min-height: 0;
-    }
-
-    .loading-state,
-    .error-state,
-    .empty-state {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 300px;
-        color: var(--text-tertiary);
-        font-size: 16px;
-    }
-
-    .error-state {
-        color: var(--gene-negative);
     }
 
     .gene-visualizer {

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1209,7 +1209,7 @@ export function getStatsData() {
     {#if loading}
         <div class="visualizer-state"><StatusPane variant="loading" body="Loading gene data..." /></div>
     {:else if error}
-        <div class="visualizer-state"><StatusPane variant="error" body="Error: {error}" /></div>
+        <div class="visualizer-state"><StatusPane variant="error" body={`Error: ${error}`} /></div>
     {:else if !currentPet}
         <div class="visualizer-state"><StatusPane variant="empty" body="Select a pet to visualize its genes" /></div>
     {:else}

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -1,4 +1,5 @@
 <script>
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
@@ -415,9 +416,9 @@ const kbReorder = createKeyboardReorder({
                 ></div>
             {/if}
         {:else if $pets.length > 0 && (searchQuery || selectedTags.length > 0 || starredOnly || stabledOnly)}
-            <div class="empty-state">No pets match the current filters</div>
+            <StatusPane variant="empty" body="No pets match the current filters" />
         {:else}
-            <div class="empty-state">No pets yet. Upload a genome file to get started.</div>
+            <StatusPane variant="empty" body="No pets yet. Upload a genome file to get started." />
         {/if}
     </div>
 
@@ -705,13 +706,6 @@ const kbReorder = createKeyboardReorder({
     .delete-btn:hover {
         background: var(--error-bg);
         color: var(--error);
-    }
-
-    .empty-state {
-        padding: 24px 12px;
-        text-align: center;
-        color: var(--text-muted);
-        font-size: 13px;
     }
 
     .pet-list-footer {


### PR DESCRIPTION
Closes #252.

Replaces hand-rolled loading / empty / error markup across 7 pre-existing surfaces with the shared `<StatusPane>` extracted in PR #242, deleting each component's local `.loading-state` / `.error-state` / `.empty-state` CSS.

## Converted
- `comparison/GenomeDiff` — loading + error
- `comparison/GeneStatsComparison` — loading + error
- `comparison/GenomeGridDiff` — loading + error
- `comparison/ComparisonView` — empty (kept a `.empty-state` flex wrapper so the pane stays vertically centred in the area)
- `breeding/BreedingTab` — error / loading / empty; kept the `data-testid="breeding-*"` wrappers so any future selectors don't move
- `gene/GeneVisualizer` — loading / error / empty
- `pet/PetList` — the two empty-list messages

## Visual decisions
- The comparison error states previously used the louder `var(--error-bg)` inline box; they now use the shared pane styling (subtler, consistent with the community surfaces). Per the issue's note, chose consistency over the louder fill.
- `GeneVisualizer` loading now shows the standard spinner (it previously showed bare "Loading…" text) — more consistent with the other surfaces.
- Breeding's empty state maps its two lines to StatusPane `title` + `body` (the inline-bold species moves into the body string).

## Verification
- 528 unit + comparison/breeding/app e2e (48) pass; biome clean.
- Verified in-app: Compare empty (icon/title/body, vertically centred) and Breeding empty (testid preserved, dynamic body intact).
- No test targeted the removed classes/testids.

Pre-existing note: `svelte-check` still reports a "script left open" parse quirk in `GenomeGridDiff.svelte` that predates this PR and is unrelated to the markup swapped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)