### PR TITLE
Warn before exporting a large image library (#92)

### DIFF
--- a/.chub/annotations/eslint--eslint-plugin-testing-library.yaml
+++ b/.chub/annotations/eslint--eslint-plugin-testing-library.yaml
@@ -1,0 +1,8 @@
+id: eslint/eslint-plugin-testing-library
+notes: []
+issues: []
+fixes: []
+practices:
+- author: jlopezpena
+  date: 2026-06-12
+  note: 'In Svelte component tests, select elements by accessible role/name, not by positional DOM index. Replace `document.querySelectorAll(''input[type="checkbox"]'')[2]` with `getByRole(''checkbox'', { name: /Pet images/i })` — the index-based form silently targets the wrong control when the layout changes (extra checkbox added/reordered) and the test keeps passing. For a label-wrapped input, the accessible name is the label''s text content, so a substring regex on `name` matches reliably. The `prefer-query-by-role` / `no-node-access` rules enforce this.'

--- a/src/lib/components/layout/ExportDialog.svelte
+++ b/src/lib/components/layout/ExportDialog.svelte
@@ -21,9 +21,18 @@ let exporting = $state(false);
 const showImageWarning = $derived(includeImages && imageCount >= LARGE_IMAGE_LIBRARY);
 
 $effect(() => {
-  getTotalImageCount().then((count) => {
-    imageCount = count;
-  });
+  let active = true;
+  getTotalImageCount()
+    .then((count) => {
+      if (active) imageCount = count;
+    })
+    .catch(() => {
+      // Count is only used to decide whether to show a warning; if it fails
+      // we leave the warning hidden rather than block the export dialog.
+    });
+  return () => {
+    active = false;
+  };
 });
 
 async function handleExport() {

--- a/src/lib/components/layout/ExportDialog.svelte
+++ b/src/lib/components/layout/ExportDialog.svelte
@@ -1,7 +1,14 @@
 <script>
+import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { exportDatabase } from '$lib/services/backupService.js';
 import { getTotalImageCount } from '$lib/services/imageService.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
+
+// The zip is built entirely in memory (JSZip `generateAsync`), so a very large
+// image library can briefly hold ~2× its total bytes (issue #92). Each image is
+// capped at 20 MB on upload, so count is a reasonable proxy: warn once a library
+// is large enough that the in-memory export could fail on a low-memory machine.
+const LARGE_IMAGE_LIBRARY = 100;
 
 const { onClose, onResult } = $props();
 
@@ -10,6 +17,8 @@ let includePets = $state(true);
 let includeImages = $state(true);
 let imageCount = $state(0);
 let exporting = $state(false);
+
+const showImageWarning = $derived(includeImages && imageCount >= LARGE_IMAGE_LIBRARY);
 
 $effect(() => {
   getTotalImageCount().then((count) => {
@@ -72,6 +81,15 @@ async function handleExport() {
           </span>
         </div>
       </label>
+
+      {#if showImageWarning}
+        <div class="image-warning" data-testid="export-image-warning">
+          <StatusBanner
+            type="warn"
+            message={`Backing up ${imageCount} images builds the archive in memory and may fail on a low-memory machine. If the export fails, retry with images unchecked.`}
+          />
+        </div>
+      {/if}
     </div>
 
     <div class="dialog-footer">
@@ -105,5 +123,9 @@ async function handleExport() {
 
   .checkbox-row:last-of-type {
     border-bottom: none;
+  }
+
+  .image-warning {
+    margin-top: 12px;
   }
 </style>

--- a/tests/unit/exportDialog.test.js
+++ b/tests/unit/exportDialog.test.js
@@ -42,11 +42,11 @@ describe('ExportDialog image-size warning (#92)', () => {
 
   it('does not warn for a typical-sized library', async () => {
     getTotalImageCount.mockResolvedValue(40);
-    const { queryByTestId } = renderDialog();
+    const { getByText, queryByTestId } = renderDialog();
 
-    // Let the count effect resolve, then confirm no warning.
-    await waitFor(() => expect(queryByTestId('share-genome-loading')).toBeNull());
-    await Promise.resolve();
+    // Wait for the count to actually land (it renders in the images checkbox
+    // description) before asserting the warning is absent.
+    await waitFor(() => expect(getByText(/40 images/)).toBeInTheDocument());
     expect(queryByTestId('export-image-warning')).toBeNull();
   });
 

--- a/tests/unit/exportDialog.test.js
+++ b/tests/unit/exportDialog.test.js
@@ -52,13 +52,12 @@ describe('ExportDialog image-size warning (#92)', () => {
 
   it('hides the warning when images are excluded, even with a large library', async () => {
     getTotalImageCount.mockResolvedValue(250);
-    const { getByTestId, queryByTestId } = renderDialog();
+    const { getByRole, getByTestId, queryByTestId } = renderDialog();
 
     await waitFor(() => expect(getByTestId('export-image-warning')).toBeInTheDocument());
 
-    // Uncheck "Pet images" (third checkbox) — the warning must disappear.
-    const checkboxes = document.querySelectorAll('input[type="checkbox"]');
-    await fireEvent.click(checkboxes[2]);
+    // Uncheck "Pet images" — the warning must disappear.
+    await fireEvent.click(getByRole('checkbox', { name: /Pet images/i }));
 
     expect(queryByTestId('export-image-warning')).toBeNull();
   });

--- a/tests/unit/exportDialog.test.js
+++ b/tests/unit/exportDialog.test.js
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Issue #92 slice: the export dialog warns when the image library is large
+// enough that the in-memory zip build could fail on a low-memory machine.
+
+vi.mock('$lib/utils/focusTrap.js', () => ({ focusTrap: () => ({}) }));
+
+const getTotalImageCount = vi.fn();
+vi.mock('$lib/services/imageService.js', () => ({
+  getTotalImageCount: () => getTotalImageCount(),
+}));
+
+vi.mock('$lib/services/backupService.js', () => ({
+  exportDatabase: vi.fn(),
+}));
+
+import ExportDialog from '$lib/components/layout/ExportDialog.svelte';
+
+afterEach(() => {
+  cleanup();
+  getTotalImageCount.mockReset();
+});
+
+function renderDialog() {
+  return render(ExportDialog, { onClose: vi.fn(), onResult: vi.fn() });
+}
+
+describe('ExportDialog image-size warning (#92)', () => {
+  it('shows the warning when the image library is large and images are included', async () => {
+    getTotalImageCount.mockResolvedValue(100);
+    const { getByTestId } = renderDialog();
+
+    await waitFor(() => {
+      const warning = getByTestId('export-image-warning');
+      expect(warning).toBeInTheDocument();
+      expect(warning).toHaveTextContent(/100 images/);
+      expect(warning).toHaveTextContent(/low-memory/i);
+    });
+  });
+
+  it('does not warn for a typical-sized library', async () => {
+    getTotalImageCount.mockResolvedValue(40);
+    const { queryByTestId } = renderDialog();
+
+    // Let the count effect resolve, then confirm no warning.
+    await waitFor(() => expect(queryByTestId('share-genome-loading')).toBeNull());
+    await Promise.resolve();
+    expect(queryByTestId('export-image-warning')).toBeNull();
+  });
+
+  it('hides the warning when images are excluded, even with a large library', async () => {
+    getTotalImageCount.mockResolvedValue(250);
+    const { getByTestId, queryByTestId } = renderDialog();
+
+    await waitFor(() => expect(getByTestId('export-image-warning')).toBeInTheDocument());
+
+    // Uncheck "Pet images" (third checkbox) — the warning must disappear.
+    const checkboxes = document.querySelectorAll('input[type="checkbox"]');
+    await fireEvent.click(checkboxes[2]);
+
+    expect(queryByTestId('export-image-warning')).toBeNull();
+  });
+});


### PR DESCRIPTION
Partial fix for #92 — the export-dialog warning slice. **Leaves #92 open** for the actual streaming work.

## Why
`backupService.exportDatabase` builds the zip entirely in memory via JSZip `generateAsync({ type: 'uint8array' })`, so a very large image library transiently holds roughly 2× its total bytes and can OOM the webview. Streaming the archive is the real fix (and the bulk of #92); this adds the cheap guard the issue also proposed ("a file count/size warning in the export dialog").

## What
- A `<StatusBanner type="warn">` appears in the export dialog once the library reaches `LARGE_IMAGE_LIBRARY = 100` images **and** "Pet images" is checked, suggesting a retry with images unchecked if the export fails.
- Count is used as the size proxy: each image is hard-capped at 20 MB on upload (`imageService`), and `pet_images` stores no byte size, so a true total would need an `fs.stat` per file on dialog open — not worth it for a warning.
- No change to the export path itself.

## Tests
- `tests/unit/exportDialog.test.js` — warns at 100 images, silent at 40, and hides when images are unchecked even with 250.
- 531 unit + backup e2e pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)