### PR TITLE
Stream backup export natively to bound memory (#92)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,8 +131,14 @@ Output: `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/Gorgonetics
 - **No raw fetch**: All data access through service layer, not HTTP calls
 
 ### Rust (src-tauri/)
-- Minimal — only plugin registration and Tauri boilerplate
-- No custom Tauri commands (all logic in TypeScript)
+- Minimal — plugin registration, Tauri boilerplate, and a small set of custom
+  commands only for work the webview genuinely can't do well in JS:
+  - `db_execute_transaction` — real multi-statement SQLite transactions
+    (tauri-plugin-sql exposes only per-statement execute; see issue #153)
+  - `write_zip` — streams the backup archive to disk so a large image library
+    is never fully resident in the JS heap (issue #92)
+- Default to TypeScript; add a command only when there's a memory, atomicity,
+  or capability reason the frontend can't satisfy.
 
 ### Quality Gates (enforced by CI)
 ```bash

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "tauri-plugin-sql",
  "tauri-plugin-updater",
  "tokio",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -4782,7 +4783,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -5291,6 +5292,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -6593,6 +6600,18 @@ dependencies = [
  "crc32fast",
  "indexmap 2.13.0",
  "memchr",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,11 @@ tauri-plugin-fs = "2"
 # so multi-statement atomicity needs a custom command (see issue #153).
 sqlx = { version = "0.8", default-features = false, features = ["sqlite", "runtime-tokio"] }
 tokio = { version = "1", features = ["sync"] }
+# write_zip streams the backup archive to disk so a large image library is
+# never fully resident in the webview's JS heap (issue #92). Stored-only:
+# images are already-compressed PNG/JPEG, so deflate buys nothing and we skip
+# the flate2 dependency.
+zip = { version = "7", default-features = false }
 
 [target."cfg(not(any(target_os = \"android\", target_os = \"ios\")))".dependencies]
 tauri-plugin-updater = "2"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -162,12 +162,15 @@ fn write_zip_inner(
         }
         let mut src = match File::open(base.join(&entry.source_rel)) {
             Ok(f) => f,
-            // Missing/unreadable between the JS existence check and now: skip
-            // rather than abort the whole export.
-            Err(_) => {
+            // A file that vanished between the JS existence check and now is
+            // skipped (the export still succeeds). Any other open error
+            // (permissions, I/O) is surfaced rather than silently producing an
+            // incomplete backup.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 images_skipped.push(entry.archive_path.clone());
                 continue;
             }
+            Err(e) => return Err(format!("open {}: {e}", entry.source_rel)),
         };
         zw.start_file(&entry.archive_path, opts)
             .map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,13 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Component, Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use sqlx::Executor;
-use tauri::State;
+use tauri::{Manager, State};
 use tauri_plugin_sql::{DbInstances, DbPool};
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 /// One statement inside a transaction request.
 #[derive(Deserialize)]
@@ -59,13 +64,16 @@ async fn db_execute_transaction(
                 if let Some(i) = n.as_i64() {
                     q = q.bind(i);
                 } else if let Some(u) = n.as_u64() {
-                    let i = i64::try_from(u)
-                        .map_err(|_| format!("numeric parameter out of range for SQLite INTEGER: {u}"))?;
+                    let i = i64::try_from(u).map_err(|_| {
+                        format!("numeric parameter out of range for SQLite INTEGER: {u}")
+                    })?;
                     q = q.bind(i);
                 } else if let Some(f) = n.as_f64() {
                     q = q.bind(f);
                 } else {
-                    return Err(format!("numeric parameter cannot be represented in SQLite: {n}"));
+                    return Err(format!(
+                        "numeric parameter cannot be represented in SQLite: {n}"
+                    ));
                 }
             } else {
                 q = q.bind(v);
@@ -81,13 +89,124 @@ async fn db_execute_transaction(
     Ok(results)
 }
 
+/// A JSON/text member written inline (genes.json, pets.json, metadata.json…).
+#[derive(Deserialize)]
+struct ZipTextEntry {
+    archive_path: String,
+    contents: String,
+}
+
+/// An on-disk file streamed into the archive without loading it into memory.
+/// `source_rel` is resolved against the app data dir; it is never an absolute
+/// or parent-escaping path (validated below).
+#[derive(Deserialize)]
+struct ZipFileEntry {
+    archive_path: String,
+    source_rel: String,
+}
+
+#[derive(Serialize)]
+struct WriteZipResult {
+    images_written: u32,
+    /// Archive paths whose source file was missing/unreadable at write time.
+    /// The matching pet_images.json record is harmless — import skips entries
+    /// with no archive member.
+    images_skipped: Vec<String>,
+}
+
+/// Reject absolute paths and any `..`/root/prefix component. Only plain names
+/// and `.` are allowed, so a crafted entry can't write or read outside the
+/// intended tree.
+fn is_safe_relpath(p: &str) -> bool {
+    if p.is_empty() {
+        return false;
+    }
+    Path::new(p)
+        .components()
+        .all(|c| matches!(c, Component::Normal(_) | Component::CurDir))
+}
+
+/// Stream a zip archive to `output_path`: text entries written inline, file
+/// entries copied straight from disk into the writer. Memory stays flat (one
+/// `io::copy` buffer) regardless of image-library size — the point of #92.
+/// Everything is Stored (no compression): images are already-compressed and
+/// JSON shrinkage isn't worth a deflate dependency.
+fn write_zip_inner(
+    base: PathBuf,
+    output_path: String,
+    text_entries: Vec<ZipTextEntry>,
+    file_entries: Vec<ZipFileEntry>,
+) -> Result<WriteZipResult, String> {
+    let file = File::create(&output_path).map_err(|e| format!("create {output_path}: {e}"))?;
+    let mut zw = ZipWriter::new(BufWriter::new(file));
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+
+    for entry in &text_entries {
+        if !is_safe_relpath(&entry.archive_path) {
+            return Err(format!("unsafe archive path: {}", entry.archive_path));
+        }
+        zw.start_file(&entry.archive_path, opts)
+            .map_err(|e| e.to_string())?;
+        zw.write_all(entry.contents.as_bytes())
+            .map_err(|e| e.to_string())?;
+    }
+
+    let mut images_written = 0u32;
+    let mut images_skipped = Vec::new();
+    for entry in &file_entries {
+        if !is_safe_relpath(&entry.archive_path) {
+            return Err(format!("unsafe archive path: {}", entry.archive_path));
+        }
+        if !is_safe_relpath(&entry.source_rel) {
+            return Err(format!("unsafe source path: {}", entry.source_rel));
+        }
+        let mut src = match File::open(base.join(&entry.source_rel)) {
+            Ok(f) => f,
+            // Missing/unreadable between the JS existence check and now: skip
+            // rather than abort the whole export.
+            Err(_) => {
+                images_skipped.push(entry.archive_path.clone());
+                continue;
+            }
+        };
+        zw.start_file(&entry.archive_path, opts)
+            .map_err(|e| e.to_string())?;
+        std::io::copy(&mut src, &mut zw).map_err(|e| e.to_string())?;
+        images_written += 1;
+    }
+
+    zw.finish().map_err(|e| e.to_string())?;
+    Ok(WriteZipResult {
+        images_written,
+        images_skipped,
+    })
+}
+
+/// Write a backup archive, streaming image files from the app data dir so the
+/// whole library is never resident in the JS heap (issue #92). Heavy I/O runs
+/// on the blocking pool to keep the async runtime responsive.
+#[tauri::command]
+async fn write_zip(
+    app: tauri::AppHandle,
+    output_path: String,
+    text_entries: Vec<ZipTextEntry>,
+    file_entries: Vec<ZipFileEntry>,
+) -> Result<WriteZipResult, String> {
+    let base = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    tauri::async_runtime::spawn_blocking(move || {
+        write_zip_inner(base, output_path, text_entries, file_entries)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![db_execute_transaction])
+        .invoke_handler(tauri::generate_handler![db_execute_transaction, write_zip])
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -105,4 +224,73 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    #[test]
+    fn rejects_unsafe_paths() {
+        assert!(is_safe_relpath("images/abc/photo.png"));
+        assert!(is_safe_relpath("genes.json"));
+        assert!(!is_safe_relpath(""));
+        assert!(!is_safe_relpath("/etc/passwd"));
+        assert!(!is_safe_relpath("../secret"));
+        assert!(!is_safe_relpath("images/../../escape"));
+    }
+
+    #[test]
+    fn streams_text_and_file_entries_and_skips_missing() {
+        let dir = std::env::temp_dir().join(format!("gorg_ziptest_{}", std::process::id()));
+        let src_dir = dir.join("images/7");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let img_bytes = b"\x89PNG\r\n\x1a\nfake-image-data";
+        std::fs::write(src_dir.join("a.png"), img_bytes).unwrap();
+        let out = dir.join("backup.zip");
+
+        let result = write_zip_inner(
+            dir.clone(),
+            out.to_string_lossy().into_owned(),
+            vec![ZipTextEntry {
+                archive_path: "metadata.json".into(),
+                contents: "{\"v\":2}".into(),
+            }],
+            vec![
+                ZipFileEntry {
+                    archive_path: "images/h/a.png".into(),
+                    source_rel: "images/7/a.png".into(),
+                },
+                ZipFileEntry {
+                    archive_path: "images/h/gone.png".into(),
+                    source_rel: "images/7/gone.png".into(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(result.images_written, 1);
+        assert_eq!(result.images_skipped, vec!["images/h/gone.png".to_string()]);
+
+        // Read the archive back and verify members + byte-exact image payload.
+        let mut archive = zip::ZipArchive::new(File::open(&out).unwrap()).unwrap();
+        let mut meta = String::new();
+        archive
+            .by_name("metadata.json")
+            .unwrap()
+            .read_to_string(&mut meta)
+            .unwrap();
+        assert_eq!(meta, "{\"v\":2}");
+        let mut got = Vec::new();
+        archive
+            .by_name("images/h/a.png")
+            .unwrap()
+            .read_to_end(&mut got)
+            .unwrap();
+        assert_eq!(got, img_bytes);
+        assert!(archive.by_name("images/h/gone.png").is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/src/lib/services/backupService.ts
+++ b/src/lib/services/backupService.ts
@@ -16,7 +16,7 @@ import type {
 import { isTauri } from '$lib/utils/environment.js';
 import { now } from '$lib/utils/timestamp.js';
 import { getDb, type TxStatement } from './database.js';
-import { saveExportBinaryFile } from './fileService.js';
+import { pickExportSavePath, saveExportBinaryFile } from './fileService.js';
 import { CURRENT_SCHEMA_VERSION, getSchemaVersion } from './migrationService.js';
 
 const EXPORT_FORMAT = 'gorgonetics-backup' as const;
@@ -70,10 +70,42 @@ const PET_COLUMNS = [
 
 // --- Export ---
 
-export async function exportDatabase(options: ExportOptions): Promise<ExportResult> {
+/** A text member of the archive, written inline (JSON files). */
+interface ZipTextEntry {
+  archive_path: string;
+  contents: string;
+}
+
+/**
+ * An image file streamed into the archive natively. `source_rel` is resolved
+ * against the app data dir by the Rust `write_zip` command, which reads it
+ * straight from disk — the bytes never enter the JS heap (issue #92).
+ */
+interface ZipFileEntry {
+  archive_path: string;
+  source_rel: string;
+}
+
+interface WriteZipResult {
+  images_written: number;
+  images_skipped: string[];
+}
+
+/**
+ * Gather everything that goes into a backup archive.
+ *
+ * JSON members are collected as in-memory strings; image files are collected
+ * as path pairs (source on disk -> path inside the archive) rather than bytes.
+ * In Tauri, each referenced image is existence-checked (a cheap stat, not a
+ * read) so the manifest only lists files that are actually present.
+ */
+async function gatherBackupContents(
+  options: ExportOptions,
+): Promise<{ textEntries: ZipTextEntry[]; fileEntries: ZipFileEntry[]; counts: ExportResult }> {
   const db = getDb();
   const schemaVersion = await getSchemaVersion();
-  const zip = new JSZip();
+  const textEntries: ZipTextEntry[] = [];
+  const fileEntries: ZipFileEntry[] = [];
   let geneCount = 0;
   let petCount = 0;
   let imageCount = 0;
@@ -82,14 +114,13 @@ export async function exportDatabase(options: ExportOptions): Promise<ExportResu
     const genes = await db.select<Record<string, unknown>[]>(
       'SELECT * FROM genes ORDER BY animal_type, chromosome, gene',
     );
-    zip.file('genes.json', JSON.stringify(genes));
+    textEntries.push({ archive_path: 'genes.json', contents: JSON.stringify(genes) });
     geneCount = genes.length;
   }
 
-  let petsExport: Record<string, unknown>[] = [];
   if (options.includePets || options.includeImages) {
     const pets = await db.select<Record<string, unknown>[]>('SELECT * FROM pets ORDER BY name');
-    petsExport = pets.map((pet) => {
+    const petsExport = pets.map((pet) => {
       const copy = { ...pet };
       delete copy.id;
       if (typeof copy.genome_data === 'string') {
@@ -102,63 +133,64 @@ export async function exportDatabase(options: ExportOptions): Promise<ExportResu
       return copy;
     });
     if (options.includePets) {
-      zip.file('pets.json', JSON.stringify(petsExport));
+      textEntries.push({ archive_path: 'pets.json', contents: JSON.stringify(petsExport) });
       petCount = petsExport.length;
 
       // Export pet tags from junction table, keyed by content_hash for portability
       const tagRows = await db.select<{ content_hash: string; tag: string }[]>(
         'SELECT p.content_hash, pt.tag FROM pet_tags pt JOIN pets p ON pt.pet_id = p.id ORDER BY p.content_hash, pt.tag',
       );
-      zip.file('pet_tags.json', JSON.stringify(tagRows));
+      textEntries.push({ archive_path: 'pet_tags.json', contents: JSON.stringify(tagRows) });
     }
   }
 
   if (options.includeImages) {
-    const imageRows = await db.select<Record<string, unknown>[]>(
-      'SELECT pi.*, p.content_hash FROM pet_images pi JOIN pets p ON pi.pet_id = p.id ORDER BY pi.pet_id, pi.created_at',
-    );
-
-    // Read image files in parallel batches and track which succeeded
     const exportedImages: Record<string, unknown>[] = [];
+    // Images can only be streamed from disk under Tauri; in the browser/test
+    // fallback there is no filesystem to read, so the manifest stays empty
+    // (matching the previous behaviour).
     if (isTauri()) {
-      const { readFile, BaseDirectory } = await import('@tauri-apps/plugin-fs');
-      const BATCH = 10;
+      const imageRows = await db.select<Record<string, unknown>[]>(
+        'SELECT pi.*, p.content_hash FROM pet_images pi JOIN pets p ON pi.pet_id = p.id ORDER BY pi.pet_id, pi.created_at',
+      );
+      const { exists, BaseDirectory } = await import('@tauri-apps/plugin-fs');
+      const BATCH = 20;
       for (let i = 0; i < imageRows.length; i += BATCH) {
         const batch = imageRows.slice(i, i + BATCH);
-        const results = await Promise.allSettled(
-          batch.map(async (row) => {
-            const data = await readFile(`images/${row.pet_id}/${row.filename}`, { baseDir: BaseDirectory.AppData });
-            return { row, data };
-          }),
+        const checks = await Promise.all(
+          batch.map(async (row) => ({
+            row,
+            present: await exists(`images/${row.pet_id}/${row.filename}`, { baseDir: BaseDirectory.AppData }),
+          })),
         );
-        for (const r of results) {
-          if (r.status === 'fulfilled') {
-            const { row, data } = r.value;
-            zip.file(`images/${row.content_hash}/${row.filename}`, data);
-            exportedImages.push({
-              content_hash: row.content_hash,
-              filename: row.filename,
-              original_name: row.original_name,
-              caption: row.caption ?? '',
-              tags: row.tags ?? '[]',
-              created_at: row.created_at,
-              sort_order: row.sort_order ?? 0,
-            });
-            imageCount++;
-          }
+        for (const { row, present } of checks) {
+          if (!present) continue;
+          fileEntries.push({
+            archive_path: `images/${row.content_hash}/${row.filename}`,
+            source_rel: `images/${row.pet_id}/${row.filename}`,
+          });
+          exportedImages.push({
+            content_hash: row.content_hash,
+            filename: row.filename,
+            original_name: row.original_name,
+            caption: row.caption ?? '',
+            tags: row.tags ?? '[]',
+            created_at: row.created_at,
+            sort_order: row.sort_order ?? 0,
+          });
+          imageCount++;
         }
       }
     }
-    zip.file('images/pet_images.json', JSON.stringify(exportedImages));
+    textEntries.push({ archive_path: 'images/pet_images.json', contents: JSON.stringify(exportedImages) });
   }
 
-  const ts = now();
   const metadata: GorgonExportMetadata = {
     format: EXPORT_FORMAT,
     format_version: EXPORT_FORMAT_VERSION,
     schema_version: schemaVersion || CURRENT_SCHEMA_VERSION,
     app_version: APP_VERSION,
-    exported_at: ts,
+    exported_at: now(),
     contents: {
       genes: options.includeGenes,
       pets: options.includePets,
@@ -166,13 +198,39 @@ export async function exportDatabase(options: ExportOptions): Promise<ExportResu
     },
     record_counts: { genes: geneCount, pets: petCount, images: imageCount },
   };
-  zip.file('metadata.json', JSON.stringify(metadata, null, 2));
+  textEntries.push({ archive_path: 'metadata.json', contents: JSON.stringify(metadata, null, 2) });
 
+  return {
+    textEntries,
+    fileEntries,
+    counts: { saved: false, genes: geneCount, pets: petCount, images: imageCount },
+  };
+}
+
+export async function exportDatabase(options: ExportOptions): Promise<ExportResult> {
+  const { textEntries, fileEntries, counts } = await gatherBackupContents(options);
+  const dateStr = now().split('T')[0];
+  const filename = `gorgonetics-backup-${dateStr}.zip`;
+
+  if (isTauri()) {
+    // Native streaming path: Rust copies each image straight from disk into
+    // the archive, so a large library never materialises in the JS heap.
+    const outputPath = await pickExportSavePath(filename);
+    if (!outputPath) return { ...counts, saved: false };
+    const { invoke } = await import('@tauri-apps/api/core');
+    const result = await invoke<WriteZipResult>('write_zip', { outputPath, textEntries, fileEntries });
+    // Report what actually landed in the archive: a file that vanished between
+    // the existence check and the write is dropped by Rust.
+    return { ...counts, saved: true, images: result.images_written };
+  }
+
+  // Browser/test fallback: no native command, so build the (image-less)
+  // archive in memory with JSZip.
+  const zip = new JSZip();
+  for (const entry of textEntries) zip.file(entry.archive_path, entry.contents);
   const zipData = await zip.generateAsync({ type: 'uint8array' });
-  const dateStr = ts.split('T')[0];
-  const saved = await saveExportBinaryFile(`gorgonetics-backup-${dateStr}.zip`, zipData);
-
-  return { saved, genes: geneCount, pets: petCount, images: imageCount };
+  const saved = await saveExportBinaryFile(filename, zipData);
+  return { ...counts, saved };
 }
 
 // --- Import ---

--- a/src/lib/services/fileService.ts
+++ b/src/lib/services/fileService.ts
@@ -37,6 +37,23 @@ export async function readBinaryFile(path: string): Promise<Uint8Array> {
   throw new Error('Binary file reading not available outside Tauri');
 }
 
+/**
+ * Run the OS "Save As" dialog for a backup archive and return the chosen
+ * path (null if cancelled or not in Tauri). Used by the streaming export
+ * path, where the zip is written natively by the `write_zip` command rather
+ * than handed back through JS as a Uint8Array.
+ */
+export async function pickExportSavePath(defaultFilename: string): Promise<string | null> {
+  if (!isTauri()) return null;
+  const { save } = await import('@tauri-apps/plugin-dialog');
+  const path = await save({
+    defaultPath: defaultFilename,
+    filters: [{ name: 'Zip Archives', extensions: ['zip'] }],
+    title: 'Export Gorgonetics Backup',
+  });
+  return path ?? null;
+}
+
 export async function saveExportBinaryFile(defaultFilename: string, data: Uint8Array): Promise<boolean> {
   if (isTauri()) {
     const { save } = await import('@tauri-apps/plugin-dialog');

--- a/tests/unit/exportDatabase.test.js
+++ b/tests/unit/exportDatabase.test.js
@@ -1,0 +1,150 @@
+import JSZip from 'jszip';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Issue #92: exportDatabase streams images natively under Tauri (never loading
+// them into the JS heap) and falls back to an in-memory JSZip build in the
+// browser/test environment. These tests cover both branches and the existence
+// filtering / count reconciliation around the native write_zip command.
+
+const isTauri = vi.fn();
+vi.mock('$lib/utils/environment.js', () => ({ isTauri: () => isTauri() }));
+
+const select = vi.fn();
+vi.mock('$lib/services/database.js', () => ({ getDb: () => ({ select }) }));
+
+vi.mock('$lib/services/migrationService.js', () => ({
+  CURRENT_SCHEMA_VERSION: 14,
+  getSchemaVersion: () => Promise.resolve(14),
+}));
+
+const pickExportSavePath = vi.fn();
+const saveExportBinaryFile = vi.fn();
+vi.mock('$lib/services/fileService.js', () => ({
+  pickExportSavePath: (...a) => pickExportSavePath(...a),
+  saveExportBinaryFile: (...a) => saveExportBinaryFile(...a),
+}));
+
+const invoke = vi.fn();
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...a) => invoke(...a) }));
+
+const exists = vi.fn();
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  exists: (...a) => exists(...a),
+  BaseDirectory: { AppData: 'AppData' },
+}));
+
+import { exportDatabase } from '$lib/services/backupService.js';
+
+const GENES = [{ animal_type: 'BeeWasp', chromosome: 'chr01', gene: '01A1' }];
+const PETS = [{ id: 1, name: 'TestBee', content_hash: 'hash_abc', genome_data: '{"genes":{}}' }];
+const IMAGE_ROWS = [
+  { pet_id: 1, filename: 'a.png', content_hash: 'hash_abc', original_name: 'a.png', created_at: '2026-01-01' },
+  { pet_id: 1, filename: 'b.png', content_hash: 'hash_abc', original_name: 'b.png', created_at: '2026-01-01' },
+];
+
+// Route db.select() by the SQL it receives.
+function defaultSelect(sql) {
+  if (sql.includes('FROM genes')) return Promise.resolve(GENES);
+  if (sql.includes('FROM pets ORDER BY name')) return Promise.resolve(PETS);
+  if (sql.includes('FROM pet_tags')) return Promise.resolve([{ content_hash: 'hash_abc', tag: 'starter' }]);
+  if (sql.includes('FROM pet_images')) return Promise.resolve(IMAGE_ROWS);
+  return Promise.resolve([]);
+}
+
+const ALL = { includeGenes: true, includePets: true, includeImages: true };
+
+beforeEach(() => {
+  select.mockImplementation(defaultSelect);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('exportDatabase — browser fallback', () => {
+  beforeEach(() => {
+    isTauri.mockReturnValue(false);
+    saveExportBinaryFile.mockResolvedValue(true);
+  });
+
+  it('builds an in-memory zip with the JSON members and no image files', async () => {
+    const result = await exportDatabase(ALL);
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(saveExportBinaryFile).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ saved: true, genes: 1, pets: 1, images: 0 });
+
+    const [, data] = saveExportBinaryFile.mock.calls[0];
+    const zip = await JSZip.loadAsync(data);
+    expect(zip.file('genes.json')).toBeTruthy();
+    expect(zip.file('pets.json')).toBeTruthy();
+    expect(zip.file('pet_tags.json')).toBeTruthy();
+    expect(zip.file('images/pet_images.json')).toBeTruthy();
+    // No filesystem in the browser path, so no image members are streamed in.
+    expect(await zip.file('images/pet_images.json').async('string')).toBe('[]');
+    expect(zip.file('images/hash_abc/a.png')).toBeNull();
+  });
+
+  it('reports not-saved when the browser save is declined', async () => {
+    saveExportBinaryFile.mockResolvedValue(false);
+    const result = await exportDatabase(ALL);
+    expect(result.saved).toBe(false);
+  });
+});
+
+describe('exportDatabase — native streaming path', () => {
+  beforeEach(() => {
+    isTauri.mockReturnValue(true);
+    pickExportSavePath.mockResolvedValue('/tmp/backup.zip');
+    exists.mockResolvedValue(true);
+    invoke.mockResolvedValue({ images_written: 2, images_skipped: [] });
+  });
+
+  it('invokes write_zip with text + file entries and reports the written count', async () => {
+    const result = await exportDatabase(ALL);
+
+    expect(saveExportBinaryFile).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    const [command, args] = invoke.mock.calls[0];
+    expect(command).toBe('write_zip');
+    expect(args.outputPath).toBe('/tmp/backup.zip');
+
+    const textPaths = args.textEntries.map((e) => e.archive_path);
+    expect(textPaths).toEqual(
+      expect.arrayContaining(['genes.json', 'pets.json', 'pet_tags.json', 'images/pet_images.json', 'metadata.json']),
+    );
+    // Images are passed as path pairs, not bytes.
+    expect(args.fileEntries).toEqual([
+      { archive_path: 'images/hash_abc/a.png', source_rel: 'images/1/a.png' },
+      { archive_path: 'images/hash_abc/b.png', source_rel: 'images/1/b.png' },
+    ]);
+    expect(result).toMatchObject({ saved: true, images: 2 });
+  });
+
+  it('omits images whose source file is missing at export time', async () => {
+    exists.mockImplementation((path) => Promise.resolve(!path.endsWith('b.png')));
+    invoke.mockResolvedValue({ images_written: 1, images_skipped: [] });
+
+    await exportDatabase(ALL);
+
+    const [, args] = invoke.mock.calls[0];
+    expect(args.fileEntries).toEqual([{ archive_path: 'images/hash_abc/a.png', source_rel: 'images/1/a.png' }]);
+    const manifest = JSON.parse(args.textEntries.find((e) => e.archive_path === 'images/pet_images.json').contents);
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].filename).toBe('a.png');
+  });
+
+  it('reports the count Rust actually wrote, not the count offered', async () => {
+    // A file vanished between the existence check and the native write.
+    invoke.mockResolvedValue({ images_written: 1, images_skipped: ['images/hash_abc/b.png'] });
+    const result = await exportDatabase(ALL);
+    expect(result.images).toBe(1);
+  });
+
+  it('does not invoke write_zip when the save dialog is cancelled', async () => {
+    pickExportSavePath.mockResolvedValue(null);
+    const result = await exportDatabase(ALL);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result.saved).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #92 (core part; the dialog warning shipped in #286).

## Problem
`exportDatabase` read every image into the JS heap (`readFile` + `zip.file(name, data)`) and then `generateAsync({type:'uint8array'})` materialized the whole compressed archive again — peak ≈2× total image bytes, all in the webview, which could OOM on large libraries.

## Change
New Rust `write_zip` command streams each image straight from disk into the archive (`File::open` → `io::copy` → `ZipWriter`), so peak memory is one copy buffer regardless of library size. Image bytes never enter the JS heap.

- JS gathers JSON members as strings and images as `{archive_path, source_rel}` path pairs, existence-checks each image (a stat, not a read), then invokes `write_zip`.
- Sources are resolved against the app data dir in Rust and validated against absolute/`..` paths.
- Files missing between the existence check and the write are skipped; the command returns the actual written count, which is what the UI reports.
- Stored (no compression): images are already-compressed PNG/JPEG, so deflate buys nothing and we avoid the `flate2` dependency.
- Browser/test path keeps the in-memory JSZip build (no filesystem to stream from).

## Tests
- Rust: `write_zip_inner` round-trips text + file entries byte-exact, skips missing sources; path-safety rejects absolute/`..`.
- JS: `exportDatabase.test.js` covers both branches, existence filtering, count reconciliation, and save-cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)