### PR TITLE
Drag-and-drop genome upload onto the pet list (#98)

### DIFF
--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -8,6 +8,7 @@ import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$li
 import { createDragState, createKeyboardReorder, moveByFilteredIndex } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
+import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
 import { getBasename } from '$lib/utils/path.js';
 import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
@@ -112,43 +113,89 @@ async function toggleMarker(petId, key, value) {
   await appState.setPetMarker(petId, key, value).catch(() => {});
 }
 
-async function handleUpload() {
+// Upload a batch of genome sources (file paths or dropped files), reusing the
+// shared sequential runner. Reloads the list once and surfaces a per-file
+// failure summary. Guarded so picker and drop uploads can't run concurrently.
+async function uploadSources(sources) {
+  if (sources.length === 0 || uploading || autoScanning) return;
+  uploading = true;
+  error.set(null);
   try {
-    const filePaths = await pickGenomeFiles();
-    if (filePaths.length === 0) return;
-
-    uploading = true;
-    error.set(null);
-    const total = filePaths.length;
-    const failures = [];
-
-    // Sequential upload — consider parallel with concurrency limit if this becomes a bottleneck
-    for (let i = 0; i < filePaths.length; i++) {
-      uploadProgress = { current: i + 1, total };
-      const fileName = getBasename(filePaths[i]);
-      try {
-        const content = await readFileContent(filePaths[i]);
-        const result = await appState.uploadPetQuiet(content);
-        if (result.status === 'error') {
-          failures.push(`${fileName}: ${result.message}`);
-        }
-      } catch (err) {
-        failures.push(`${fileName}: ${err.message}`);
-      }
-    }
-
+    const { total, succeeded, failures } = await runGenomeUpload(sources, {
+      upload: (content) => appState.uploadPetQuiet(content),
+      onProgress: (current, t) => {
+        uploadProgress = { current, total: t };
+      },
+    });
     await appState.loadPets();
-
     if (failures.length > 0) {
-      const succeeded = total - failures.length;
       error.set(`${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`);
     }
   } catch (err) {
-    error.set(`Upload failed: ${err.message}`);
+    error.set(`Upload failed: ${errorMessage(err)}`);
   } finally {
     uploading = false;
     uploadProgress = null;
   }
+}
+
+async function handleUpload() {
+  let filePaths;
+  try {
+    filePaths = await pickGenomeFiles();
+  } catch (err) {
+    error.set(`Upload failed: ${errorMessage(err)}`);
+    return;
+  }
+  await uploadSources(filePaths.map((path) => ({ name: getBasename(path), read: () => readFileContent(path) })));
+}
+
+// Drag-and-drop genome upload (#98). dragDropEnabled is false in
+// tauri.conf.json (so Tauri doesn't intercept events used for card
+// reordering), which leaves the webview's native HTML5 drag events to us.
+// External OS file drags carry a 'Files' type; internal card-reorder drags
+// don't — so isFileDrag() tells the two apart.
+let fileDragActive = $state(false);
+
+function handleFileDragOver(e) {
+  if (!isFileDrag(e.dataTransfer)) return;
+  e.preventDefault();
+  if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  fileDragActive = true;
+}
+
+function handleFileDragLeave(e) {
+  if (!isFileDrag(e.dataTransfer)) return;
+  // Ignore leaves into descendant elements; only clear when the cursor leaves
+  // the panel entirely (relatedTarget is null when leaving the window).
+  if (e.currentTarget.contains(e.relatedTarget)) return;
+  fileDragActive = false;
+}
+
+async function handleFileDrop(e) {
+  if (!isFileDrag(e.dataTransfer)) return;
+  e.preventDefault();
+  fileDragActive = false;
+  const dropped = Array.from(e.dataTransfer?.files ?? []);
+  if (dropped.length === 0) return;
+
+  const { accepted, rejected } = selectGenomeFiles(dropped);
+  if (accepted.length === 0) {
+    error.set('No genome files (.txt) in the dropped items.');
+    return;
+  }
+  await uploadSources(accepted.map((file) => ({ name: file.name, read: () => file.text() })));
+  if (rejected.length > 0 && !$error) {
+    error.set(`Skipped ${rejected.length} non-genome file${rejected.length === 1 ? '' : 's'}.`);
+  }
+}
+
+// External file drags also bubble through the per-card reorder handlers. Skip
+// the reorder path for them so they don't show the reorder indicator or fight
+// the panel-level drop handler.
+function handleCardDragOver(e, index) {
+  if (isFileDrag(e.dataTransfer)) return;
+  drag.handleDragOver(e, index);
 }
 
 async function handleAutoScan() {
@@ -307,7 +354,19 @@ const kbReorder = createKeyboardReorder({
 });
 </script>
 
-<div class="pet-list">
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="pet-list"
+    class:file-drag-active={fileDragActive}
+    ondragover={handleFileDragOver}
+    ondragleave={handleFileDragLeave}
+    ondrop={handleFileDrop}
+>
+    {#if fileDragActive}
+        <div class="file-drop-overlay" aria-hidden="true">
+            <span>Drop genome files to upload</span>
+        </div>
+    {/if}
     <div class="pet-list-header">
         <input
             class="text-input text-input--lg"
@@ -354,7 +413,7 @@ const kbReorder = createKeyboardReorder({
                     class:kb-grabbed={kbReorder.isGrabbed(index)}
                     draggable={isDraggable}
                     ondragstart={(e) => drag.handleDragStart(e, index)}
-                    ondragover={(e) => drag.handleDragOver(e, index)}
+                    ondragover={(e) => handleCardDragOver(e, index)}
                     ondragleave={drag.handleDragLeave}
                     ondrop={(e) => handleDrop(e, index)}
                     ondragend={drag.handleDragEnd}
@@ -523,9 +582,35 @@ const kbReorder = createKeyboardReorder({
     }
 
     .pet-list {
+        position: relative;
         display: flex;
         flex-direction: column;
         height: 100%;
+    }
+
+    .file-drop-overlay {
+        position: absolute;
+        inset: 0;
+        z-index: 5;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        /* Let drag events fall through to the panel handlers underneath. */
+        pointer-events: none;
+        background: var(--bg-selected);
+        border: 2px dashed var(--accent);
+        border-radius: 8px;
+        opacity: 0.95;
+    }
+
+    .file-drop-overlay span {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--accent-text);
+        padding: 12px 20px;
+        border-radius: 8px;
+        background: var(--bg-primary);
+        box-shadow: var(--shadow-lg);
     }
 
     .pet-list-header {

--- a/src/lib/utils/genomeUpload.ts
+++ b/src/lib/utils/genomeUpload.ts
@@ -4,20 +4,23 @@
  * the drop-filtering rules can be unit-tested without a component harness.
  */
 
+import type { UploadPetResult } from '$lib/services/petService.js';
+
 /** A pending upload: a display name plus a lazy reader for its text content. */
 export interface UploadSource {
   name: string;
   read: () => Promise<string>;
 }
 
-export interface UploadResult {
-  status: string;
-  message?: string;
-}
-
 export interface RunUploadOptions {
-  /** Persist one genome's text; mirrors `appState.uploadPetQuiet`. */
-  upload: (content: string) => Promise<UploadResult>;
+  /**
+   * Persist one genome's text; the `appState.uploadPetQuiet` / `uploadPet`
+   * contract. Typed against `UploadPetResult` so `status` is the actual
+   * union and `message` is always present — the failure formatter relies on
+   * both, and a loose `string`/optional shape would let `${name}: undefined`
+   * slip through.
+   */
+  upload: (content: string) => Promise<UploadPetResult>;
   /** Progress callback, 1-based current of total. */
   onProgress?: (current: number, total: number) => void;
 }

--- a/src/lib/utils/genomeUpload.ts
+++ b/src/lib/utils/genomeUpload.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared genome-upload helpers used by both the file-picker upload and the
+ * drag-and-drop upload in PetList. Kept UI-agnostic so the orchestration and
+ * the drop-filtering rules can be unit-tested without a component harness.
+ */
+
+/** A pending upload: a display name plus a lazy reader for its text content. */
+export interface UploadSource {
+  name: string;
+  read: () => Promise<string>;
+}
+
+export interface UploadResult {
+  status: string;
+  message?: string;
+}
+
+export interface RunUploadOptions {
+  /** Persist one genome's text; mirrors `appState.uploadPetQuiet`. */
+  upload: (content: string) => Promise<UploadResult>;
+  /** Progress callback, 1-based current of total. */
+  onProgress?: (current: number, total: number) => void;
+}
+
+export interface UploadSummary {
+  total: number;
+  succeeded: number;
+  /** `"<name>: <reason>"` for each source that failed to read or import. */
+  failures: string[];
+}
+
+/**
+ * Upload each source sequentially. A read error or an `error` upload result is
+ * collected as a failure rather than aborting the batch — one bad file never
+ * blocks the rest. Returns counts the caller can surface to the user.
+ */
+export async function runGenomeUpload(
+  sources: UploadSource[],
+  { upload, onProgress }: RunUploadOptions,
+): Promise<UploadSummary> {
+  const total = sources.length;
+  const failures: string[] = [];
+
+  for (let i = 0; i < total; i++) {
+    onProgress?.(i + 1, total);
+    const { name, read } = sources[i];
+    try {
+      const content = await read();
+      const result = await upload(content);
+      if (result.status === 'error') failures.push(`${name}: ${result.message}`);
+    } catch (err) {
+      failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { total, succeeded: total - failures.length, failures };
+}
+
+/** True when a drag carries OS files (vs. an internal card-reorder drag). */
+export function isFileDrag(dataTransfer: DataTransfer | null): boolean {
+  if (!dataTransfer) return false;
+  return Array.from(dataTransfer.types).includes('Files');
+}
+
+/**
+ * Partition dropped files into genome files we accept (`.txt`, matching the
+ * file-picker filter) and the rest. Case-insensitive on the extension.
+ */
+export function selectGenomeFiles(files: File[]): { accepted: File[]; rejected: File[] } {
+  const accepted: File[] = [];
+  const rejected: File[] = [];
+  for (const file of files) {
+    if (file.name.toLowerCase().endsWith('.txt')) accepted.push(file);
+    else rejected.push(file);
+  }
+  return { accepted, rejected };
+}

--- a/tests/e2e/drop-upload.spec.js
+++ b/tests/e2e/drop-upload.spec.js
@@ -1,0 +1,77 @@
+import { expect, test } from '@playwright/test';
+import { waitForPets } from './helpers.js';
+
+// Drag-and-drop genome upload (#98). The webview's native HTML5 drag events
+// reach the app (dragDropEnabled is false in tauri.conf.json), so we drive the
+// feature with synthetic DragEvents carrying a DataTransfer. A real OS drag
+// can't be scripted, but the handler path — file detection, reading, upload —
+// is identical.
+
+/** Dispatch a synthetic file drop of the given {name, url|content} files onto the pet list. */
+async function dropFilesOnList(page, files) {
+  await page.evaluate(async (files) => {
+    const dt = new DataTransfer();
+    for (const f of files) {
+      const content = f.url ? await (await fetch(f.url)).text() : f.content;
+      dt.items.add(new File([content], f.name, { type: 'text/plain' }));
+    }
+    // A real OS file drag exposes the 'Files' type; jsdom/Chromium won't set it
+    // from items.add alone, so pin it to match what the handler keys off.
+    Object.defineProperty(dt, 'types', { value: ['Files'], configurable: true });
+    document
+      .querySelector('.pet-list')
+      .dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }));
+  }, files);
+}
+
+test.describe('Genome drop-to-upload (#98)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await waitForPets(page);
+  });
+
+  test('shows a drop overlay while files are dragged over the list', async ({ page }) => {
+    await page.evaluate(() => {
+      const dt = new DataTransfer();
+      Object.defineProperty(dt, 'types', { value: ['Files'], configurable: true });
+      document
+        .querySelector('.pet-list')
+        .dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }));
+    });
+    await expect(page.locator('.file-drop-overlay')).toBeVisible();
+    await expect(page.locator('.file-drop-overlay')).toHaveText(/Drop genome files/);
+
+    // Leaving the panel (null relatedTarget) clears the overlay.
+    await page.evaluate(() => {
+      const dt = new DataTransfer();
+      Object.defineProperty(dt, 'types', { value: ['Files'], configurable: true });
+      document
+        .querySelector('.pet-list')
+        .dispatchEvent(new DragEvent('dragleave', { bubbles: true, cancelable: true, dataTransfer: dt }));
+    });
+    await expect(page.locator('.file-drop-overlay')).toHaveCount(0);
+  });
+
+  test('rejects dropped non-genome files with a message', async ({ page }) => {
+    await dropFilesOnList(page, [{ name: 'cat.png', content: 'not a genome' }]);
+
+    await expect(page.locator('.error-banner')).toContainText('No genome files (.txt)');
+    await expect(page.locator('.pet-count')).toHaveText('3 pets');
+  });
+
+  test('uploads a dropped genome file into the list', async ({ page }) => {
+    // Sample Horse ships as demo data, so delete it first to prove the drop
+    // re-adds it (content-hash dedup makes re-uploading an existing pet a no-op).
+    const horse = page.locator('.pet-card-wrapper', { hasText: 'Sample Horse' });
+    await horse.hover();
+    await horse.locator('.delete-btn').click();
+    await page.locator('.confirm-dialog .btn-danger').click();
+    await expect(page.locator('.pet-count')).toHaveText('2 pets');
+
+    await dropFilesOnList(page, [{ name: 'Genes_SampleHorse.txt', url: '/data/Genes_SampleHorse.txt' }]);
+
+    await expect(page.locator('.pet-count')).toHaveText('3 pets');
+    await expect(page.locator('.pet-card-name', { hasText: 'Sample Horse' })).toBeVisible();
+    await expect(page.locator('.error-banner')).toHaveCount(0);
+  });
+});

--- a/tests/unit/genomeUpload.test.js
+++ b/tests/unit/genomeUpload.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
+
+// Minimal stand-in for an upload source; `read` resolves to genome text.
+function source(name, content) {
+  return { name, read: () => Promise.resolve(content) };
+}
+
+describe('runGenomeUpload', () => {
+  it('uploads every source and reports all successful', async () => {
+    const upload = vi.fn().mockResolvedValue({ status: 'success' });
+    const summary = await runGenomeUpload([source('a.txt', 'A'), source('b.txt', 'B')], { upload });
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload).toHaveBeenNthCalledWith(1, 'A');
+    expect(summary).toEqual({ total: 2, succeeded: 2, failures: [] });
+  });
+
+  it('reports per-file progress, 1-based', async () => {
+    const upload = vi.fn().mockResolvedValue({ status: 'success' });
+    const onProgress = vi.fn();
+    await runGenomeUpload([source('a.txt', 'A'), source('b.txt', 'B')], { upload, onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 1, 2);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 2, 2);
+  });
+
+  it('collects upload-error results without aborting the batch', async () => {
+    const upload = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 'error', message: 'bad genome' })
+      .mockResolvedValueOnce({ status: 'success' });
+    const summary = await runGenomeUpload([source('bad.txt', 'X'), source('ok.txt', 'Y')], { upload });
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['bad.txt: bad genome'] });
+  });
+
+  it('treats a read failure as a failure for that file only', async () => {
+    const upload = vi.fn().mockResolvedValue({ status: 'success' });
+    const sources = [
+      { name: 'unreadable.txt', read: () => Promise.reject(new Error('EACCES')) },
+      source('ok.txt', 'Y'),
+    ];
+    const summary = await runGenomeUpload(sources, { upload });
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['unreadable.txt: EACCES'] });
+  });
+
+  it('returns an empty summary for no sources', async () => {
+    const upload = vi.fn();
+    const summary = await runGenomeUpload([], { upload });
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(summary).toEqual({ total: 0, succeeded: 0, failures: [] });
+  });
+});
+
+describe('isFileDrag', () => {
+  it('is true when the drag carries OS files', () => {
+    expect(isFileDrag({ types: ['Files'] })).toBe(true);
+    expect(isFileDrag({ types: ['text/plain', 'Files'] })).toBe(true);
+  });
+
+  it('is false for internal drags without files', () => {
+    expect(isFileDrag({ types: ['text/plain'] })).toBe(false);
+    expect(isFileDrag({ types: [] })).toBe(false);
+    expect(isFileDrag(null)).toBe(false);
+  });
+});
+
+describe('selectGenomeFiles', () => {
+  const file = (name) => ({ name });
+
+  it('accepts .txt files case-insensitively and rejects the rest', () => {
+    const { accepted, rejected } = selectGenomeFiles([
+      file('pet1.txt'),
+      file('pet2.TXT'),
+      file('image.png'),
+      file('notes.md'),
+    ]);
+
+    expect(accepted.map((f) => f.name)).toEqual(['pet1.txt', 'pet2.TXT']);
+    expect(rejected.map((f) => f.name)).toEqual(['image.png', 'notes.md']);
+  });
+
+  it('returns empty partitions for no files', () => {
+    expect(selectGenomeFiles([])).toEqual({ accepted: [], rejected: [] });
+  });
+});


### PR DESCRIPTION
Closes #98.

## Change
Drag genome files from the OS file explorer onto the pet list to upload them, alongside the existing file picker.

- `dragDropEnabled: false` in `tauri.conf.json` leaves the webview's native HTML5 drag events to the app, so the panel handles them directly.
- External OS drags are told apart from internal card-reorder drags by the `Files` `dataTransfer` type (`isFileDrag`). The per-card reorder handler bails on file drags so they don't trigger the reorder indicator or fight the panel drop handler.
- Dropped `.txt` files are read in the webview via `File.text()` and run through the existing `uploadPetQuiet` flow (same path as bulk upload); non-`.txt` files are rejected with a message, and any mixed-in non-genome files are reported as skipped.
- A drop overlay appears while files are dragged over the panel.
- Upload orchestration (`runGenomeUpload`) and drop filtering (`isFileDrag`, `selectGenomeFiles`) are extracted to `genomeUpload.ts`; the file-picker upload now shares the same runner.

## Tests
- Unit (`genomeUpload.test.js`): upload batching, per-file progress, failure isolation, file-drag detection, `.txt` filtering.
- E2E (`drop-upload.spec.js`): overlay shows/hides on drag, non-genome rejection, and a dropped genome appearing in the list.
- Verified live against the dev server: dragover overlay, genome drop adding a pet, and non-genome rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)