### PR TITLE
Pending-import count badge on the auto-scan button (#295)

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -11,6 +11,7 @@ import {
   backfillPetGenesIfNeeded,
   backfillPositiveGenesIfNeeded,
 } from '$lib/services/petService.js';
+import { refreshPendingImportCount } from '$lib/stores/gameImport.js';
 import { appState } from '$lib/stores/pets.js';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 
@@ -39,6 +40,8 @@ async function runLiveScan() {
   } finally {
     liveScanRunning = false;
     pendingRescan = false;
+    // Whatever the scan imported, the pending badge should reflect what's left.
+    void refreshPendingImportCount();
   }
 }
 
@@ -55,6 +58,10 @@ $effect(() => {
 
   let cancelled = false;
   let activeStop = null;
+
+  // Recompute the pending badge whenever the watched folder is (re)armed —
+  // covers app startup (ready flips true) and the user changing the path.
+  void refreshPendingImportCount();
 
   void (async () => {
     try {

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -131,6 +131,10 @@ onMount(async () => {
     } catch (err) {
       console.warn('imported_files backfill aborted:', err);
     }
+    // The ledger the pending count reads is only populated once this backfill
+    // runs (legacy DBs start without it), so recompute now that it's seeded —
+    // otherwise the startup count can over-report until the next scan/event.
+    void refreshPendingImportCount();
   })();
 });
 </script>

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -4,6 +4,7 @@ import { normalizeSpecies } from '$lib/services/configService.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
+import { pendingImportCount, refreshPendingImportCount } from '$lib/stores/gameImport.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
 import { createDragState, createKeyboardReorder, moveByFilteredIndex } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
@@ -188,6 +189,8 @@ async function handleAutoScan() {
   } finally {
     autoScanning = false;
     autoScanProgress = null;
+    // Reflect whatever the scan left un-imported (e.g. files that failed).
+    void refreshPendingImportCount();
   }
 }
 
@@ -450,13 +453,20 @@ const kbReorder = createKeyboardReorder({
                 class="auto-scan-btn"
                 onclick={handleAutoScan}
                 disabled={uploading || autoScanning}
-                title="Auto-import new genome files from the game folder"
-                aria-label="Auto-import new genome files from the game folder"
+                title={$pendingImportCount > 0
+                    ? `Auto-import: ${$pendingImportCount} new genome file${$pendingImportCount === 1 ? '' : 's'} in the game folder`
+                    : 'Auto-import new genome files from the game folder'}
+                aria-label={$pendingImportCount > 0
+                    ? `Auto-import ${$pendingImportCount} new genome file${$pendingImportCount === 1 ? '' : 's'} from the game folder`
+                    : 'Auto-import new genome files from the game folder'}
             >
                 {#if autoScanProgress}
                     🔄 ({autoScanProgress.current}/{autoScanProgress.total})
                 {:else}
                     🔄
+                    {#if $pendingImportCount > 0}
+                        <span class="pending-badge" aria-hidden="true">{$pendingImportCount > 99 ? '99+' : $pendingImportCount}</span>
+                    {/if}
                 {/if}
             </button>
             <button
@@ -759,6 +769,7 @@ const kbReorder = createKeyboardReorder({
     }
 
     .auto-scan-btn {
+        position: relative;
         padding: 8px 10px;
         background: var(--bg-secondary);
         border: 1px solid var(--border-primary);
@@ -767,6 +778,26 @@ const kbReorder = createKeyboardReorder({
         cursor: pointer;
         transition: all 0.15s ease;
         flex-shrink: 0;
+    }
+
+    .pending-badge {
+        position: absolute;
+        top: -6px;
+        right: -6px;
+        min-width: 16px;
+        height: 16px;
+        padding: 0 4px;
+        box-sizing: border-box;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: var(--accent);
+        color: var(--bg-primary);
+        border-radius: 8px;
+        font-size: 10px;
+        font-weight: 700;
+        line-height: 1;
+        pointer-events: none;
     }
 
     .auto-scan-btn:hover:not(:disabled) {

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -11,7 +11,13 @@
 import { isTauri } from '$lib/utils/environment.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { sha256Hex } from '$lib/utils/hash.js';
-import { findPetGenomeTextByHash, hasImportedFile, recordImportedFile, uploadPet } from './petService.js';
+import {
+  filterImportedHashes,
+  findPetGenomeTextByHash,
+  hasImportedFile,
+  recordImportedFile,
+  uploadPet,
+} from './petService.js';
 import { getSetting, setSetting } from './settingsService.js';
 
 export type Platform = 'windows' | 'mac' | 'linux' | 'unknown';
@@ -251,11 +257,11 @@ export async function autoScanGameFolder(options?: {
  * "pending files".
  */
 export async function countUnimportedHashes(hashes: string[]): Promise<number> {
-  let pending = 0;
-  for (const hash of new Set(hashes)) {
-    if (!(await hasImportedFile(hash))) pending++;
-  }
-  return pending;
+  const distinct = [...new Set(hashes)];
+  if (distinct.length === 0) return 0;
+  // One ledger query for the whole batch rather than a round-trip per hash.
+  const imported = await filterImportedHashes(distinct);
+  return distinct.filter((hash) => !imported.has(hash)).length;
 }
 
 /**

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -244,6 +244,72 @@ export async function autoScanGameFolder(options?: {
 }
 
 /**
+ * Count distinct content-hashes not present in the `imported_files` ledger.
+ * Factored out of the folder I/O so the dedup logic is unit-testable against
+ * the real ledger without mocking Tauri's fs. Duplicate files (identical
+ * content) collapse to one pending entry, matching "pending pets" rather than
+ * "pending files".
+ */
+export async function countUnimportedHashes(hashes: string[]): Promise<number> {
+  let pending = 0;
+  for (const hash of new Set(hashes)) {
+    if (!(await hasImportedFile(hash))) pending++;
+  }
+  return pending;
+}
+
+/**
+ * Read-only dry run of the early part of `autoScanGameFolder`: how many
+ * genome files in the configured folder aren't in the ledger yet (i.e. would
+ * be imported by a scan). Keying off the ledger — not the live pet rows —
+ * means pets the user deliberately deleted stay skipped and aren't counted,
+ * matching the scan's own skip semantics. Returns 0 (rather than throwing)
+ * outside Tauri, when unconfigured, or when the folder isn't readable, so it's
+ * safe to call as a best-effort badge refresh.
+ */
+export async function countPendingImports(): Promise<number> {
+  if (!isTauri()) return 0;
+
+  const configured = await getConfiguredGameFolder();
+  if (isPlaceholderPath(configured)) return 0;
+
+  const folder = toRelativeHome(configured);
+  const fs = await import('@tauri-apps/plugin-fs');
+  const { BaseDirectory } = await import('@tauri-apps/api/path');
+  const baseOpts = { baseDir: BaseDirectory.Home };
+
+  let entries: Awaited<ReturnType<typeof fs.readDir>>;
+  try {
+    entries = await fs.readDir(folder, baseOpts);
+  } catch {
+    return 0;
+  }
+  const txtFiles = entries.filter((e) => e.isFile && e.name.toLowerCase().endsWith('.txt'));
+
+  // Read+hash in parallel chunks, same shape as autoScanGameFolder. Files that
+  // can't be read are skipped (a scan would surface them as failures; for a
+  // count they just don't contribute).
+  const READ_CHUNK = 8;
+  const hashes: string[] = [];
+  for (let i = 0; i < txtFiles.length; i += READ_CHUNK) {
+    const chunk = txtFiles.slice(i, i + READ_CHUNK);
+    const chunkHashes = await Promise.all(
+      chunk.map(async (e) => {
+        try {
+          const content = await fs.readTextFile(`${folder}/${e.name}`, baseOpts);
+          return await sha256Hex(content);
+        } catch {
+          return null;
+        }
+      }),
+    );
+    for (const hash of chunkHashes) if (hash !== null) hashes.push(hash);
+  }
+
+  return countUnimportedHashes(hashes);
+}
+
+/**
  * Watch the configured game folder for changes and invoke `onChange`
  * when a `.txt` event fires (debounced). Returns a stop function, or
  * `null` if there's nothing to watch (non-Tauri host, unconfigured

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -430,6 +430,21 @@ export async function hasImportedFile(contentHash: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+/**
+ * Of the given content hashes, return the subset already in the ledger, in a
+ * single query — the batch counterpart to `hasImportedFile`, so callers
+ * checking many hashes (e.g. the pending-import count) avoid N round-trips.
+ */
+export async function filterImportedHashes(contentHashes: readonly string[]): Promise<Set<string>> {
+  if (contentHashes.length === 0) return new Set();
+  const { placeholders, params } = buildInClauseParams(contentHashes, 'h');
+  const rows = await getDb().select<{ content_hash: string }[]>(
+    `SELECT content_hash FROM imported_files WHERE content_hash IN (${placeholders})`,
+    params,
+  );
+  return new Set(rows.map((r) => r.content_hash));
+}
+
 export interface UploadPetOptions {
   /** Fallback when the genome file's Entity name is empty. */
   name?: string;

--- a/src/lib/stores/gameImport.ts
+++ b/src/lib/stores/gameImport.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared state for the game-folder auto-import indicator (#295).
+ *
+ * `pendingImportCount` holds how many genome files in the configured folder
+ * aren't imported yet, so the auto-scan button can show a badge. It's refreshed
+ * from a few places (startup, the live folder watcher, after a manual scan, and
+ * on folder-path change) — hence a store rather than per-component state.
+ */
+
+import { writable } from 'svelte/store';
+import { countPendingImports } from '$lib/services/gameImport.js';
+
+export const pendingImportCount = writable(0);
+
+// Collapse overlapping refreshes (e.g. a watcher event landing mid-startup)
+// into one in-flight scan; the trailing caller just sees the latest count.
+let refreshing = false;
+
+/**
+ * Recompute the pending-import count, best-effort. Never throws — a failed
+ * scan leaves the previous value in place rather than flipping the badge.
+ */
+export async function refreshPendingImportCount(): Promise<void> {
+  if (refreshing) return;
+  refreshing = true;
+  try {
+    pendingImportCount.set(await countPendingImports());
+  } catch {
+    // Best-effort indicator; keep the last known value.
+  } finally {
+    refreshing = false;
+  }
+}

--- a/src/lib/stores/gameImport.ts
+++ b/src/lib/stores/gameImport.ts
@@ -13,21 +13,31 @@ import { countPendingImports } from '$lib/services/gameImport.js';
 export const pendingImportCount = writable(0);
 
 // Collapse overlapping refreshes (e.g. a watcher event landing mid-startup)
-// into one in-flight scan; the trailing caller just sees the latest count.
+// into one in-flight scan. A request that arrives during a scan isn't dropped —
+// it's queued so exactly one more recompute runs afterward, so a folder change
+// or scan that lands mid-refresh can't leave the count stale.
 let refreshing = false;
+let queued = false;
 
 /**
  * Recompute the pending-import count, best-effort. Never throws — a failed
  * scan leaves the previous value in place rather than flipping the badge.
  */
 export async function refreshPendingImportCount(): Promise<void> {
-  if (refreshing) return;
+  if (refreshing) {
+    queued = true;
+    return;
+  }
   refreshing = true;
   try {
-    pendingImportCount.set(await countPendingImports());
+    do {
+      queued = false;
+      pendingImportCount.set(await countPendingImports());
+    } while (queued);
   } catch {
     // Best-effort indicator; keep the last known value.
   } finally {
     refreshing = false;
+    queued = false;
   }
 }

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -129,6 +129,39 @@ describe('gameImport service', () => {
     });
   });
 
+  describe('countPendingImports', () => {
+    it('returns 0 outside Tauri', async () => {
+      expect(await gameImport.countPendingImports()).toBe(0);
+    });
+  });
+
+  describe('countUnimportedHashes', () => {
+    it('counts only hashes absent from the ledger', async () => {
+      const known = await sha256Hex(SAMPLE_BEEWASP);
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
+
+      expect(await gameImport.countUnimportedHashes([known, 'newhash1', 'newhash2'])).toBe(2);
+    });
+
+    it('deduplicates identical hashes so duplicate files count once', async () => {
+      expect(await gameImport.countUnimportedHashes(['dup', 'dup', 'dup'])).toBe(1);
+    });
+
+    it('does not count a hash already in the ledger from a deleted pet', async () => {
+      const hash = await sha256Hex(SAMPLE_BEEWASP);
+      const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
+      await petService.deletePet(upload.pet_id);
+
+      // Ledger retains the hash after deletion, so a deliberately-removed pet
+      // is not flagged as pending.
+      expect(await gameImport.countUnimportedHashes([hash])).toBe(0);
+    });
+
+    it('returns 0 for no hashes', async () => {
+      expect(await gameImport.countUnimportedHashes([])).toBe(0);
+    });
+  });
+
   describe('imported_files ledger', () => {
     it('records hash on successful upload', async () => {
       const hash = await sha256Hex(SAMPLE_BEEWASP);

--- a/tests/unit/gameImport.test.js
+++ b/tests/unit/gameImport.test.js
@@ -162,6 +162,21 @@ describe('gameImport service', () => {
     });
   });
 
+  describe('filterImportedHashes', () => {
+    it('returns only the hashes present in the ledger', async () => {
+      const known = await sha256Hex(SAMPLE_BEEWASP);
+      await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Test', gender: 'Female' });
+
+      const result = await petService.filterImportedHashes([known, 'absent1', 'absent2']);
+      expect(result).toBeInstanceOf(Set);
+      expect([...result]).toEqual([known]);
+    });
+
+    it('returns an empty set for no input', async () => {
+      expect([...(await petService.filterImportedHashes([]))]).toEqual([]);
+    });
+  });
+
   describe('imported_files ledger', () => {
     it('records hash on successful upload', async () => {
       const hash = await sha256Hex(SAMPLE_BEEWASP);


### PR DESCRIPTION
Closes #295.

## Change
The auto-scan button (🔄) shows a small count badge when the configured game folder has genome files that aren't imported yet.

- `countPendingImports()` (gameImport.ts): read-only dry run of the early part of `autoScanGameFolder` — lists + hashes the folder's `.txt` files and counts hashes absent from the `imported_files` ledger. Keying off the ledger (not live pet rows) means pets the user deliberately deleted stay skipped and aren't counted, matching the scan's own semantics. Returns 0 (never throws) outside Tauri, when unconfigured, or when the folder isn't readable.
- The count is held in a small store (`stores/gameImport.ts`) and refreshed at startup, after the live folder watcher runs, after a manual scan, and when `import.gameFolderPath` changes. Overlapping refreshes collapse to one in-flight scan.
- Badge shows when count > 0 (hidden at 0), caps display at `99+`, and the button's title/aria-label reflect the real count (singular/plural).

## Tests
- Unit (`gameImport.test.js`): `countUnimportedHashes` — counts only not-in-ledger hashes, dedupes identical hashes, excludes a deleted pet's retained ledger entry; `countPendingImports` returns 0 outside Tauri.
- Verified live against the dev server by driving the real store: badge renders for 1 (singular label), 3, and 150 (`99+`), and is absent at 0; positioning/styling confirmed via screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)