### PR TITLE
feat(updater): pre-update backup for rollback safety (#111)

### DIFF
--- a/docs/update-rollback.md
+++ b/docs/update-rollback.md
@@ -1,0 +1,71 @@
+# Update rollback — pre-update backup
+
+The in-app auto-updater (#110) overwrites the install in place. The Tauri
+updater has no built-in backup or rollback, so a failure during the swap (disk
+full, power loss, a broken new build) could leave a corrupt install. As a safety
+net (#111), the app copies the current install aside **before** the install step
+and removes that copy once the new version launches successfully.
+
+This is a manual-restore safety net, not an automatic rollback. Automatic
+rollback of a build that won't launch would need an external watchdog process
+the app can't provide while it's the thing that crashed; that is intentionally
+out of scope.
+
+## How it works
+
+1. On "Install & restart", the updater downloads the new version, then the app
+   calls the `backup_before_update` command, which copies the current install
+   into `<app-data>/update-backup/payload/` and writes a `manifest.json`
+   alongside it recording the from/to versions and the original install path.
+2. The new version installs over the old one and the app relaunches.
+3. On the next launch, startup compares the running version against the
+   manifest's `to_version`. If they match, the update landed — the backup is
+   deleted. If they don't (the app is still on the old version), the update
+   failed and the backup is **kept** for manual restore.
+
+The backup is taken on a best-effort basis: if the copy fails (e.g. no disk
+space) the update still proceeds, since blocking a requested update on a missed
+safety net is worse than proceeding without it.
+
+### Backup location (`<app-data>`)
+
+- macOS: `~/Library/Application Support/com.gorgonetics.app/update-backup/`
+- Windows: `%APPDATA%\com.gorgonetics.app\update-backup\`
+- Linux: `~/.local/share/com.gorgonetics.app/update-backup/`
+
+The exact identifier follows the app's `identifier` in `tauri.conf.json`; the
+manifest's `source_path` records where the backup must be restored to.
+
+## Restoring manually
+
+Only needed if an update failed and the app won't start correctly. Quit the app
+first. Read `update-backup/manifest.json` for `source_path` (where the install
+lives) and `backup_path` (the copy).
+
+**macOS** — replace the `.app` bundle:
+
+```bash
+rm -rf "<source_path>"
+cp -R "<backup_path>" "<source_path>"
+```
+
+If macOS refuses to open the restored app (Gatekeeper/quarantine), clear the
+quarantine attribute:
+
+```bash
+xattr -dr com.apple.quarantine "<source_path>"
+```
+
+**Linux** — replace the AppImage file:
+
+```bash
+cp -f "<backup_path>" "<source_path>"
+chmod +x "<source_path>"
+```
+
+**Windows** — replace the install directory contents. With the app closed, copy
+everything from `backup_path` back over `source_path` (the install folder),
+overwriting existing files.
+
+After a successful manual restore, delete the `update-backup` directory so the
+app doesn't treat the stale copy as a pending rollback.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -203,13 +203,209 @@ async fn write_zip(
     .map_err(|e| e.to_string())?
 }
 
+/// Records a pre-update copy of the current install so a botched update can be
+/// restored manually. `to_version` is the version being installed; when the app
+/// next launches reporting that version, the update succeeded and the backup is
+/// deleted on startup (see `run`). Persisted as JSON at
+/// `<app_data>/update-backup/manifest.json`.
+#[derive(Serialize, Deserialize, Clone)]
+struct UpdateBackupManifest {
+    /// Version that was running when the backup was taken (the one to restore).
+    from_version: String,
+    /// Version being installed. Startup cleanup keys off this.
+    to_version: String,
+    /// Absolute path of the install artifact that was copied.
+    source_path: String,
+    /// Absolute path of the backup copy under the app data dir.
+    backup_path: String,
+}
+
+/// Locate the on-disk install artifact for the running app, per platform:
+/// the `.app` bundle (macOS), the AppImage file (Linux), or the install
+/// directory containing the executable (Windows). Derived from `exe` so the
+/// core logic is unit-testable without a live Tauri context.
+fn install_artifact_for(exe: &Path) -> Result<PathBuf, String> {
+    #[cfg(target_os = "macos")]
+    {
+        // exe is .../Gorgonetics.app/Contents/MacOS/Gorgonetics — walk up to
+        // the bundle root.
+        for anc in exe.ancestors() {
+            if anc.extension().is_some_and(|e| e == "app") {
+                return Ok(anc.to_path_buf());
+            }
+        }
+        Err("could not locate .app bundle from executable path".into())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // The AppImage runtime exports APPIMAGE as the absolute path of the
+        // running image. Absent it, the app was started some other way (cargo
+        // run, extracted bundle) and there is no single artifact to back up.
+        let _ = exe;
+        std::env::var("APPIMAGE")
+            .map(PathBuf::from)
+            .map_err(|_| "not running as an AppImage (APPIMAGE unset)".into())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        exe.parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| "executable has no parent directory".into())
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = exe;
+        Err("update backup is not supported on this platform".into())
+    }
+}
+
+/// Recursively copy `src` to `dst`, preserving symlinks (macOS `.app` bundles
+/// rely on versioned symlinks under `Contents/Frameworks`). Files are copied
+/// byte-for-byte; an existing `dst` tree is assumed already cleared by the
+/// caller.
+fn copy_tree(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if src.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            let ty = entry.file_type()?;
+            let from = entry.path();
+            let to = dst.join(entry.file_name());
+            if ty.is_symlink() {
+                let target = std::fs::read_link(&from)?;
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(&target, &to)?;
+                #[cfg(not(unix))]
+                {
+                    let _ = target;
+                    std::fs::copy(&from, &to)?;
+                }
+            } else if ty.is_dir() {
+                copy_tree(&from, &to)?;
+            } else {
+                std::fs::copy(&from, &to)?;
+            }
+        }
+    } else {
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, dst)?;
+    }
+    Ok(())
+}
+
+/// Directory holding the most recent pre-update backup and its manifest.
+fn backup_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("update-backup"))
+}
+
+fn read_backup_manifest(dir: &Path) -> Result<Option<UpdateBackupManifest>, String> {
+    let path = dir.join("manifest.json");
+    match std::fs::read_to_string(&path) {
+        Ok(s) => serde_json::from_str(&s).map(Some).map_err(|e| e.to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// A backup is stale once the running version matches the version it was taken
+/// for — that means the update it guarded has installed and launched
+/// successfully, so the backup can be discarded.
+fn backup_is_obsolete(manifest: &UpdateBackupManifest, current_version: &str) -> bool {
+    manifest.to_version == current_version
+}
+
+/// Copy the current install to the backup directory and write a manifest, so a
+/// failed update can be manually restored. Best-effort by design: the JS caller
+/// treats a failure as non-fatal and proceeds with the update. Any prior backup
+/// is discarded first. Heavy I/O runs on the blocking pool.
+#[tauri::command]
+async fn backup_before_update(
+    app: tauri::AppHandle,
+    to_version: String,
+) -> Result<UpdateBackupManifest, String> {
+    let from_version = app.package_info().version.to_string();
+    let dir = backup_dir(&app)?;
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let source = install_artifact_for(&exe)?;
+        let name = source
+            .file_name()
+            .ok_or("install artifact has no file name")?;
+
+        // Clear any stale backup (e.g. from an earlier failed update).
+        if dir.exists() {
+            std::fs::remove_dir_all(&dir).map_err(|e| e.to_string())?;
+        }
+        let payload = dir.join("payload");
+        let dest = payload.join(name);
+        std::fs::create_dir_all(&payload).map_err(|e| e.to_string())?;
+        copy_tree(&source, &dest).map_err(|e| format!("copy install to backup: {e}"))?;
+
+        let manifest = UpdateBackupManifest {
+            from_version,
+            to_version,
+            source_path: source.to_string_lossy().into_owned(),
+            backup_path: dest.to_string_lossy().into_owned(),
+        };
+        let json = serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
+        std::fs::write(dir.join("manifest.json"), json).map_err(|e| e.to_string())?;
+        Ok(manifest)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Read the current backup manifest, if any. Surfaced to the UI so a failed
+/// update can point the user at the restore path.
+#[tauri::command]
+fn get_update_backup(app: tauri::AppHandle) -> Result<Option<UpdateBackupManifest>, String> {
+    read_backup_manifest(&backup_dir(&app)?)
+}
+
+/// Delete the pre-update backup. Called on startup once the update is confirmed
+/// (see `run`) and exposed for an explicit "discard backup" action.
+#[tauri::command]
+fn cleanup_update_backup(app: tauri::AppHandle) -> Result<(), String> {
+    let dir = backup_dir(&app)?;
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// On startup, drop the pre-update backup if the running version shows the
+/// guarded update landed. A surviving backup (still on the old version) means
+/// the update failed; it is kept for manual restore.
+fn cleanup_backup_on_launch(app: &tauri::AppHandle) {
+    let Ok(dir) = backup_dir(app) else { return };
+    let current = app.package_info().version.to_string();
+    if let Ok(Some(manifest)) = read_backup_manifest(&dir) {
+        if backup_is_obsolete(&manifest, &current) {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_sql::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
-        .invoke_handler(tauri::generate_handler![db_execute_transaction, write_zip])
+        .invoke_handler(tauri::generate_handler![
+            db_execute_transaction,
+            write_zip,
+            backup_before_update,
+            get_update_backup,
+            cleanup_update_backup
+        ])
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -223,6 +419,8 @@ pub fn run() {
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
             #[cfg(desktop)]
             app.handle().plugin(tauri_plugin_process::init())?;
+            #[cfg(desktop)]
+            cleanup_backup_on_launch(app.handle());
             Ok(())
         })
         .run(tauri::generate_context!())
@@ -293,6 +491,81 @@ mod tests {
             .unwrap();
         assert_eq!(got, img_bytes);
         assert!(archive.by_name("images/h/gone.png").is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn backup_obsolete_only_when_version_matches() {
+        let manifest = UpdateBackupManifest {
+            from_version: "0.6.3".into(),
+            to_version: "0.6.4".into(),
+            source_path: "/x".into(),
+            backup_path: "/y".into(),
+        };
+        // Still on the old version → update hasn't landed → keep the backup.
+        assert!(!backup_is_obsolete(&manifest, "0.6.3"));
+        // Running the installed version → update succeeded → discard.
+        assert!(backup_is_obsolete(&manifest, "0.6.4"));
+    }
+
+    #[test]
+    fn read_manifest_absent_is_none() {
+        let dir = std::env::temp_dir().join(format!("gorg_nomanifest_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(read_backup_manifest(&dir).unwrap().is_none());
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn copy_tree_preserves_files_symlinks_and_nesting() {
+        let root = std::env::temp_dir().join(format!("gorg_copytree_{}", std::process::id()));
+        let src = root.join("src");
+        let nested = src.join("Contents/MacOS");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("bin"), b"binary").unwrap();
+        std::fs::write(src.join("Info.plist"), b"plist").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("Contents/MacOS/bin", src.join("link")).unwrap();
+
+        let dst = root.join("dst");
+        copy_tree(&src, &dst).unwrap();
+
+        assert_eq!(std::fs::read(dst.join("Contents/MacOS/bin")).unwrap(), b"binary");
+        assert_eq!(std::fs::read(dst.join("Info.plist")).unwrap(), b"plist");
+        #[cfg(unix)]
+        {
+            let meta = std::fs::symlink_metadata(dst.join("link")).unwrap();
+            assert!(meta.file_type().is_symlink());
+            assert_eq!(
+                std::fs::read_link(dst.join("link")).unwrap(),
+                Path::new("Contents/MacOS/bin")
+            );
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn read_manifest_roundtrips_written_json() {
+        let dir = std::env::temp_dir().join(format!("gorg_manifest_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let manifest = UpdateBackupManifest {
+            from_version: "0.6.3".into(),
+            to_version: "0.6.4".into(),
+            source_path: "/Applications/Gorgonetics.app".into(),
+            backup_path: "/data/update-backup/payload/Gorgonetics.app".into(),
+        };
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_string_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let read = read_backup_manifest(&dir).unwrap().unwrap();
+        assert_eq!(read.to_version, "0.6.4");
+        assert_eq!(read.from_version, "0.6.3");
+        assert_eq!(read.source_path, "/Applications/Gorgonetics.app");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -337,7 +337,7 @@ async fn backup_before_update(
         let source = install_artifact_for(&exe)?;
         let name = source
             .file_name()
-            .ok_or("install artifact has no file name")?;
+            .ok_or_else(|| "install artifact has no file name".to_string())?;
 
         // Clear any stale backup (e.g. from an earlier failed update).
         if dir.exists() {

--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -87,18 +87,10 @@ async function installUpdate() {
   updateStatus = 'downloading';
   downloadProgress = 0;
   try {
-    let totalSize = 0;
-    let downloaded = 0;
-    await pendingUpdate.downloadAndInstall((event) => {
-      if (event.event === 'Started') {
-        totalSize = event.data.contentLength ?? 0;
-      } else if (event.event === 'Progress') {
-        downloaded += event.data.chunkLength ?? 0;
-        downloadProgress = totalSize > 0 ? Math.round((downloaded / totalSize) * 100) : 0;
-      }
+    const { installUpdateWithBackup } = await import('$lib/services/updateService.js');
+    await installUpdateWithBackup(pendingUpdate, (percent) => {
+      downloadProgress = percent;
     });
-    const { relaunch } = await import('@tauri-apps/plugin-process');
-    await relaunch();
   } catch (err) {
     errorMessage = toErrorMessage(err);
     updateStatus = 'error';

--- a/src/lib/services/updateService.ts
+++ b/src/lib/services/updateService.ts
@@ -1,0 +1,46 @@
+/**
+ * Update install orchestration for the desktop auto-updater.
+ *
+ * The Tauri updater overwrites the install in place with no built-in rollback
+ * (see docs/update-rollback.md). To give a failed update an escape hatch, this
+ * splits the plugin's `download` and `install` steps and snapshots the current
+ * install (via the `backup_before_update` Rust command) in the window between
+ * them — #111. The startup path in src-tauri deletes that snapshot once the new
+ * version launches successfully.
+ */
+
+import type { Update } from '@tauri-apps/plugin-updater';
+
+/** Called with download completion percentage (0–100). */
+export type ProgressCallback = (percent: number) => void;
+
+/**
+ * Download an update, back up the current install, then install and relaunch.
+ *
+ * The backup is best-effort: if it fails, the failure is logged and the install
+ * proceeds. Blocking a user-requested update because the safety net could not be
+ * written is worse than updating without it.
+ */
+export async function installUpdateWithBackup(update: Update, onProgress?: ProgressCallback): Promise<void> {
+  let totalSize = 0;
+  let downloaded = 0;
+  await update.download((event) => {
+    if (event.event === 'Started') {
+      totalSize = event.data.contentLength ?? 0;
+    } else if (event.event === 'Progress') {
+      downloaded += event.data.chunkLength ?? 0;
+      onProgress?.(totalSize > 0 ? Math.round((downloaded / totalSize) * 100) : 0);
+    }
+  });
+
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('backup_before_update', { toVersion: update.version });
+  } catch (err) {
+    console.warn('[updater] pre-update backup failed; continuing with install:', err);
+  }
+
+  await update.install();
+  const { relaunch } = await import('@tauri-apps/plugin-process');
+  await relaunch();
+}

--- a/tests/unit/updateService.test.js
+++ b/tests/unit/updateService.test.js
@@ -7,6 +7,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installUpdateWithBackup } from '$lib/services/updateService.js';
 
+// Shared step log so every actor — the Update, the backup command, and
+// relaunch — records into the same ordering across a run.
+let order = [];
 const invoke = vi.fn();
 const relaunch = vi.fn();
 
@@ -14,7 +17,7 @@ vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args) => invoke(...args) })
 vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: (...args) => relaunch(...args) }));
 
 /** A fake Update that records call order and drives the progress callback. */
-function makeUpdate(order) {
+function makeUpdate() {
   return {
     version: '0.7.0',
     download: vi.fn(async (onEvent) => {
@@ -31,8 +34,13 @@ function makeUpdate(order) {
 
 describe('installUpdateWithBackup', () => {
   beforeEach(() => {
-    invoke.mockReset().mockResolvedValue(undefined);
-    relaunch.mockReset().mockResolvedValue(undefined);
+    order = [];
+    invoke.mockReset().mockImplementation(async () => {
+      order.push('backup');
+    });
+    relaunch.mockReset().mockImplementation(async () => {
+      order.push('relaunch');
+    });
   });
 
   afterEach(() => {
@@ -40,14 +48,15 @@ describe('installUpdateWithBackup', () => {
   });
 
   it('backs up between download and install, then relaunches', async () => {
-    const order = [];
-    const update = makeUpdate(order);
+    const update = makeUpdate();
 
     await installUpdateWithBackup(update);
 
     expect(invoke).toHaveBeenCalledWith('backup_before_update', { toVersion: '0.7.0' });
-    // Backup must land after the download finishes and before the install swap.
-    expect(order).toEqual(['download', 'install']);
+    // The backup must land after the download finishes and before the install
+    // swap; relaunch happens last. The full sequence is asserted so the test
+    // fails if any step is reordered.
+    expect(order).toEqual(['download', 'backup', 'install', 'relaunch']);
     expect(update.download).toHaveBeenCalledOnce();
     expect(update.install).toHaveBeenCalledOnce();
     expect(relaunch).toHaveBeenCalledOnce();
@@ -55,7 +64,7 @@ describe('installUpdateWithBackup', () => {
 
   it('reports download progress as a percentage', async () => {
     const onProgress = vi.fn();
-    await installUpdateWithBackup(makeUpdate([]), onProgress);
+    await installUpdateWithBackup(makeUpdate(), onProgress);
 
     // 200-byte total, two 100-byte chunks → 50% then 100%.
     expect(onProgress).toHaveBeenNthCalledWith(1, 50);
@@ -65,12 +74,13 @@ describe('installUpdateWithBackup', () => {
   it('proceeds with install when the backup fails', async () => {
     invoke.mockRejectedValueOnce(new Error('disk full'));
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const order = [];
-    const update = makeUpdate(order);
+    const update = makeUpdate();
 
     await installUpdateWithBackup(update);
 
     expect(warn).toHaveBeenCalled();
+    // Backup failed (no 'backup' entry) but install and relaunch still ran.
+    expect(order).toEqual(['download', 'install', 'relaunch']);
     expect(update.install).toHaveBeenCalledOnce();
     expect(relaunch).toHaveBeenCalledOnce();
   });

--- a/tests/unit/updateService.test.js
+++ b/tests/unit/updateService.test.js
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for updateService — mocks the Tauri core/process plugins so we can
+ * assert the download → backup → install → relaunch ordering and the
+ * best-effort backup behaviour without a desktop runtime.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { installUpdateWithBackup } from '$lib/services/updateService.js';
+
+const invoke = vi.fn();
+const relaunch = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: (...args) => invoke(...args) }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: (...args) => relaunch(...args) }));
+
+/** A fake Update that records call order and drives the progress callback. */
+function makeUpdate(order) {
+  return {
+    version: '0.7.0',
+    download: vi.fn(async (onEvent) => {
+      order.push('download');
+      onEvent?.({ event: 'Started', data: { contentLength: 200 } });
+      onEvent?.({ event: 'Progress', data: { chunkLength: 100 } });
+      onEvent?.({ event: 'Progress', data: { chunkLength: 100 } });
+    }),
+    install: vi.fn(async () => {
+      order.push('install');
+    }),
+  };
+}
+
+describe('installUpdateWithBackup', () => {
+  beforeEach(() => {
+    invoke.mockReset().mockResolvedValue(undefined);
+    relaunch.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('backs up between download and install, then relaunches', async () => {
+    const order = [];
+    const update = makeUpdate(order);
+
+    await installUpdateWithBackup(update);
+
+    expect(invoke).toHaveBeenCalledWith('backup_before_update', { toVersion: '0.7.0' });
+    // Backup must land after the download finishes and before the install swap.
+    expect(order).toEqual(['download', 'install']);
+    expect(update.download).toHaveBeenCalledOnce();
+    expect(update.install).toHaveBeenCalledOnce();
+    expect(relaunch).toHaveBeenCalledOnce();
+  });
+
+  it('reports download progress as a percentage', async () => {
+    const onProgress = vi.fn();
+    await installUpdateWithBackup(makeUpdate([]), onProgress);
+
+    // 200-byte total, two 100-byte chunks → 50% then 100%.
+    expect(onProgress).toHaveBeenNthCalledWith(1, 50);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 100);
+  });
+
+  it('proceeds with install when the backup fails', async () => {
+    invoke.mockRejectedValueOnce(new Error('disk full'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const order = [];
+    const update = makeUpdate(order);
+
+    await installUpdateWithBackup(update);
+
+    expect(warn).toHaveBeenCalled();
+    expect(update.install).toHaveBeenCalledOnce();
+    expect(relaunch).toHaveBeenCalledOnce();
+  });
+
+  it('aborts without installing when the download fails', async () => {
+    const update = {
+      version: '0.7.0',
+      download: vi.fn(async () => {
+        throw new Error('network');
+      }),
+      install: vi.fn(),
+    };
+
+    await expect(installUpdateWithBackup(update)).rejects.toThrow('network');
+    expect(invoke).not.toHaveBeenCalled();
+    expect(update.install).not.toHaveBeenCalled();
+    expect(relaunch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #111.

The Tauri updater overwrites the install in place with no built-in rollback. This adds a manual-restore safety net: the current install is copied aside before the install step and removed once the new version launches successfully.

## How
- `updateService.installUpdateWithBackup` splits the plugin's `download()` and `install()` and calls the new `backup_before_update` Rust command in the window between them.
- The command copies the current install artifact — `.app` bundle (macOS), AppImage (Linux), or install dir (Windows) — into `<app-data>/update-backup/` with a manifest recording from/to versions and the source path. Symlinks are preserved (macOS bundles need them); heavy I/O runs on the blocking pool.
- On startup, if the running version matches the manifest's `to_version`, the update landed and the backup is deleted. A surviving backup (still on the old version) means the update failed and is kept for manual restore.
- Backup is best-effort: a copy failure logs and proceeds rather than blocking the requested update.

## Scope
Automatic rollback of a build that won't launch is intentionally out of scope — it needs an external watchdog process Tauri doesn't provide (the app can't restore itself if it's the thing that crashed). Manual-restore procedure documented in `docs/update-rollback.md`.

## Tests
- Rust: `copy_tree` (files/symlinks/nesting), manifest roundtrip/absent, obsolescence logic.
- JS: download→backup→install→relaunch ordering, progress %, backup-failure-proceeds, download-failure-aborts.
- Full suite (557) green; lint, cargo test, build clean.

Not covered by automated tests: the real per-platform install swap and on-disk restore (no CI runner installs/relaunches a signed bundle) — covered by the manual doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)