### PR TITLE
feat(comparison): trio genome grid (PR 3/4)

### DIFF
--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -1,0 +1,293 @@
+<script>
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
+import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
+import { getGeneEffectsCached } from '$lib/services/geneService.js';
+import { computeOffspringTrio } from '$lib/services/offspringTrioService.js';
+import { buildAppearanceLookup, createGeneCellBuilder } from '$lib/utils/geneGridCells.js';
+import { capitalize } from '$lib/utils/string.js';
+import { buildTrioGrid } from '$lib/utils/trioGrid.js';
+
+/**
+ * @typedef {Object} Props
+ * @property {any} father
+ * @property {any} mother
+ * @property {string} [offspringBreed]
+ */
+
+/** @type {Props} */
+const { father, mother, offspringBreed = '' } = $props();
+
+let loading = $state(false);
+let error = $state(null);
+let grid = $state(null);
+let summary = $state(null);
+
+const ALLELE_LABEL = { D: 'Dominant', x: 'Mixed', R: 'Recessive', unknown: 'Unknown' };
+const VERDICT_LABEL = { gain: 'Gain', risk: 'Risk', neutral: '' };
+
+$effect(() => {
+  if (father?.id && mother?.id) {
+    load(father, mother, offspringBreed);
+  }
+});
+
+async function load(f, m, breed) {
+  try {
+    loading = true;
+    error = null;
+    const species = normalizeSpecies(f.species);
+    const [result, efData] = await Promise.all([
+      computeOffspringTrio(f, m, { species, offspringBreed: breed }),
+      getGeneEffectsCached(species),
+    ]);
+
+    const effectsDB = efData?.effects ?? {};
+    const attributeNames = getAttributeConfig(species).all_attribute_names.map((n) => capitalize(n));
+    const cellBuilder = createGeneCellBuilder({
+      effectsDB,
+      attributeNames,
+      appearanceLookup: buildAppearanceLookup(species),
+      speciesKey: species,
+    });
+
+    grid = buildTrioGrid(result, cellBuilder);
+    summary = result.summary;
+  } catch (err) {
+    error = err?.message || 'Failed to build the trio view';
+    grid = null;
+    summary = null;
+  } finally {
+    loading = false;
+  }
+}
+
+/** Hover text for the offspring distribution cell. */
+function offspringTitle(cell) {
+  const parts = [`Gene ${cell.geneId}`];
+  if (cell.attribute) parts.push(cell.attribute);
+  if (cell.verdict !== 'neutral') {
+    const via = cell.source === 'both' ? 'both parents' : cell.source ? `the ${cell.source}` : '';
+    const lock = cell.lockedIn ? ' (locked in)' : '';
+    parts.push(`${VERDICT_LABEL[cell.verdict]}${lock}${via ? ` via ${via}` : ''}`);
+  }
+  parts.push(`P(+) ${Math.round(cell.pPositive * 100)}%  P(−) ${Math.round(cell.pNegative * 100)}%`);
+  const dist = cell.segments.map((s) => `${ALLELE_LABEL[s.allele]} ${Math.round(s.pct)}%`).join(', ');
+  parts.push(dist);
+  return parts.join('\n');
+}
+
+function parentTitle(cell, label) {
+  if (!cell) return '';
+  return `${label} · Gene ${cell.id} (${ALLELE_LABEL[cell.type] ?? cell.type})\n${cell.effect || 'No effect'}`;
+}
+</script>
+
+<div class="genome-grid-trio">
+    {#if loading}
+        <StatusPane variant="loading" body="Building offspring projection…" />
+    {:else if error}
+        <StatusPane variant="error" icon="⚠️" body={error} />
+    {:else if grid && summary}
+        <div class="trio-summary">
+            <span class="chip chip-gain">{summary.gains} gains</span>
+            <span class="chip chip-risk">{summary.risks} risks</span>
+            <span class="chip chip-lock">{summary.lockedIn} locked in</span>
+            {#if summary.unknownLoci > 0}
+                <span class="chip chip-unknown">{summary.unknownLoci} unknown</span>
+            {/if}
+            <span class="legend">
+                <span class="legend-item"><span class="swatch swatch-gain"></span>gain</span>
+                <span class="legend-item"><span class="swatch swatch-risk"></span>risk</span>
+            </span>
+        </div>
+
+        <div class="grid-container">
+            <table class="trio-table">
+                <thead>
+                    <tr>
+                        <th class="chr-header">Chr</th>
+                        <th class="role-header">&nbsp;</th>
+                        {#each grid.blocks as block (block)}
+                            {#each grid.positionsByBlock[block] as pos (pos)}
+                                <th class="pos-header {pos === 1 ? 'block-start' : ''}">{pos === 1 ? block : ''}</th>
+                            {/each}
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each grid.rows as row (row.chromosome)}
+                        <tr class="role-row father-row">
+                            <td class="chr-label" rowspan="3">{row.chromosome}</td>
+                            <td class="role-label">♂ Father</td>
+                            {#each grid.blocks as block (block)}
+                                {#each grid.positionsByBlock[block] as pos (pos)}
+                                    {@const cell = row.cells[`${block}${pos}`]}
+                                    <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
+                                        {#if cell?.fatherCell}
+                                            <div class={cell.fatherCell.attributeCls} title={parentTitle(cell.fatherCell, 'Father')}>
+                                                {#if cell.fatherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
+                                            </div>
+                                        {/if}
+                                    </td>
+                                {/each}
+                            {/each}
+                        </tr>
+                        <tr class="role-row offspring-row">
+                            <td class="role-label offspring-label">⚲ Offspring</td>
+                            {#each grid.blocks as block (block)}
+                                {#each grid.positionsByBlock[block] as pos (pos)}
+                                    {@const cell = row.cells[`${block}${pos}`]}
+                                    <td class="grid-cell offspring-cell {pos === 1 ? 'block-start' : ''}">
+                                        {#if cell}
+                                            <div
+                                                class="dist-bar verdict-{cell.verdict}"
+                                                class:locked={cell.lockedIn}
+                                                title={offspringTitle(cell)}
+                                            >
+                                                {#each cell.segments as seg, i (i)}
+                                                    <span class="seg tone-{seg.tone}" style="flex: {seg.pct} 0 0"></span>
+                                                {/each}
+                                            </div>
+                                        {/if}
+                                    </td>
+                                {/each}
+                            {/each}
+                        </tr>
+                        <tr class="role-row mother-row">
+                            <td class="role-label">♀ Mother</td>
+                            {#each grid.blocks as block (block)}
+                                {#each grid.positionsByBlock[block] as pos (pos)}
+                                    {@const cell = row.cells[`${block}${pos}`]}
+                                    <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
+                                        {#if cell?.motherCell}
+                                            <div class={cell.motherCell.attributeCls} title={parentTitle(cell.motherCell, 'Mother')}>
+                                                {#if cell.motherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
+                                            </div>
+                                        {/if}
+                                    </td>
+                                {/each}
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+    {:else}
+        <p class="empty-text">No genome data available for this pair.</p>
+    {/if}
+</div>
+
+<style>
+    .genome-grid-trio { width: 100%; }
+
+    .trio-summary {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 10px;
+        flex-wrap: wrap;
+    }
+    .chip {
+        font-size: 12px;
+        font-weight: 600;
+        padding: 2px 10px;
+        border-radius: 10px;
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
+    }
+    .chip-gain { background: color-mix(in srgb, var(--gene-positive) 18%, transparent); color: var(--gene-positive); }
+    .chip-risk { background: color-mix(in srgb, var(--gene-negative) 18%, transparent); color: var(--gene-negative); }
+    .legend { display: flex; gap: 10px; margin-left: auto; font-size: 11px; color: var(--text-tertiary); }
+    .legend-item { display: inline-flex; align-items: center; gap: 4px; }
+    .swatch { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+    .swatch-gain { border: 2px solid var(--gene-positive); }
+    .swatch-risk { border: 2px solid var(--gene-negative); }
+
+    .grid-container {
+        overflow: auto;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        background: var(--bg-secondary);
+    }
+    .trio-table { width: auto; border-collapse: collapse; table-layout: fixed; }
+
+    thead th {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: var(--bg-secondary);
+        border-bottom: 1px solid var(--border-primary);
+        padding: 2px 4px;
+        font-size: 9px;
+        font-weight: normal;
+        color: var(--text-secondary);
+        text-align: center;
+        white-space: nowrap;
+    }
+    .chr-header { position: sticky; left: 0; z-index: 11; width: 28px; min-width: 28px; font-weight: bold; }
+    .role-header { position: sticky; left: 28px; z-index: 11; width: 72px; min-width: 72px; }
+    .pos-header { width: 22px; min-width: 22px; max-width: 22px; }
+    .pos-header.block-start { font-weight: bold; padding-left: 8px; }
+
+    .chr-label {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+        background: var(--bg-secondary);
+        font-size: 10px;
+        font-weight: 700;
+        color: var(--text-secondary);
+        text-align: center;
+        vertical-align: middle;
+        border-right: 1px solid var(--border-primary);
+    }
+    .role-label {
+        position: sticky;
+        left: 28px;
+        z-index: 1;
+        background: var(--bg-secondary);
+        font-size: 9px;
+        font-weight: 600;
+        padding: 1px 6px;
+        white-space: nowrap;
+        border-right: 1px solid var(--border-primary);
+        color: var(--text-secondary);
+        width: 72px;
+        min-width: 72px;
+    }
+    .offspring-label { color: var(--accent); font-weight: 700; }
+    .mother-row { border-bottom: 2px solid var(--border-primary); }
+
+    .grid-cell { padding: 1px; text-align: center; vertical-align: middle; }
+    .grid-cell.block-start { padding-left: 8px; }
+
+    /* Offspring row is taller and its cells host the distribution bar. */
+    .offspring-cell { height: 26px; }
+    .dist-bar {
+        display: flex;
+        width: 20px;
+        height: 20px;
+        margin: 0 auto;
+        border-radius: 3px;
+        overflow: hidden;
+        border: 2px solid transparent;
+        box-sizing: border-box;
+    }
+    .dist-bar.verdict-gain { border-color: var(--gene-positive); }
+    .dist-bar.verdict-risk { border-color: var(--gene-negative); }
+    .dist-bar.locked { box-shadow: inset 0 0 0 1px var(--bg-secondary); }
+    .seg { display: block; height: 100%; }
+
+    .tone-positive { background: var(--gene-positive); }
+    .tone-negative { background: var(--gene-negative); }
+    .tone-potential-positive { background: var(--gene-potential-positive); }
+    .tone-potential-negative { background: var(--gene-potential-negative); }
+    .tone-neutral { background: var(--gene-neutral); }
+    .tone-unknown {
+        background: repeating-linear-gradient(45deg, var(--gene-neutral) 0 2px, transparent 2px 4px);
+        opacity: 0.6;
+    }
+
+    .unknown-symbol { color: var(--text-muted); font-size: 1em; font-weight: 600; }
+    .empty-text { color: var(--text-muted); font-size: 13px; text-align: center; padding: 40px; }
+</style>

--- a/src/lib/utils/trioGrid.ts
+++ b/src/lib/utils/trioGrid.ts
@@ -1,0 +1,137 @@
+/**
+ * Render-model builder for the trio (Father / Offspring / Mother) genome grid.
+ *
+ * Turns the `OffspringTrioResult` from `offspringTrioService` into a
+ * block/position grid layout plus, per locus, the two parent cells (built
+ * with the shared `geneGridCells` factory) and the offspring's allele
+ * distribution as coloured segments for the taller middle row.
+ *
+ * Pure: no Svelte, no DB. The component owns loading and the DOM; this owns
+ * the shape so it can be unit-tested without rendering.
+ */
+
+import { compareBlockLetters } from '$lib/services/genomeParser.js';
+import type { AlleleDistribution, GeneType, OffspringTrioResult, TrioVerdict } from '$lib/types/index.js';
+import type { GeneCell } from '$lib/utils/geneGridCells.js';
+
+/** Effect tone of an offspring allele outcome — drives the segment colour. */
+export type TrioTone = 'positive' | 'negative' | 'potential-positive' | 'potential-negative' | 'neutral' | 'unknown';
+
+/** One slice of the offspring distribution bar. */
+export interface TrioSegment {
+  allele: 'D' | 'x' | 'R' | 'unknown';
+  /** Probability as a percentage (0–100) — the segment's flex width. */
+  pct: number;
+  tone: TrioTone;
+}
+
+/** A fully-resolved locus ready to render across the three rows. */
+export interface TrioLocusCell {
+  geneId: string;
+  block: string;
+  position: number;
+  fatherType: GeneType | null;
+  motherType: GeneType | null;
+  fatherCell: GeneCell | null;
+  motherCell: GeneCell | null;
+  segments: TrioSegment[];
+  verdict: TrioVerdict;
+  source: 'father' | 'mother' | 'both' | null;
+  lockedIn: boolean;
+  attribute?: string;
+  pPositive: number;
+  pNegative: number;
+  fatherEffect?: string;
+  motherEffect?: string;
+}
+
+export interface TrioGridRow {
+  chromosome: string;
+  /** Keyed by `${block}${position}`. Absent key → empty grid cell. */
+  cells: Record<string, TrioLocusCell>;
+}
+
+export interface TrioGrid {
+  blocks: string[];
+  /** 1-based positions present for each block, ascending. */
+  positionsByBlock: Record<string, number[]>;
+  rows: TrioGridRow[];
+}
+
+/** Minimal slice of the `geneGridCells` factory this module needs. */
+interface CellBuilderLike {
+  makeCell(gene: { id: string; type: string }): GeneCell;
+  analyzeGene(geneId: string, geneType: string): { effectType: string };
+}
+
+const ALLELE_ORDER: readonly (keyof AlleleDistribution)[] = ['D', 'x', 'R', 'unknown'];
+
+function toneFor(geneId: string, allele: keyof AlleleDistribution, cellBuilder: CellBuilderLike): TrioTone {
+  if (allele === 'unknown') return 'unknown';
+  // `D`/`x` express the dominant effect, `R` the recessive — `analyzeGene`
+  // resolves the right one from the allele it's given.
+  return cellBuilder.analyzeGene(geneId, allele).effectType as TrioTone;
+}
+
+function buildSegments(geneId: string, dist: AlleleDistribution, cellBuilder: CellBuilderLike): TrioSegment[] {
+  const segments: TrioSegment[] = [];
+  for (const allele of ALLELE_ORDER) {
+    const mass = dist[allele];
+    if (mass > 0) {
+      segments.push({
+        allele: allele as TrioSegment['allele'],
+        pct: mass * 100,
+        tone: toneFor(geneId, allele, cellBuilder),
+      });
+    }
+  }
+  return segments;
+}
+
+/**
+ * Build the full grid render-model. Column layout (blocks × positions) is the
+ * union across all chromosomes so every chromosome row aligns, matching the
+ * 2-pet genome diff.
+ */
+export function buildTrioGrid(result: OffspringTrioResult, cellBuilder: CellBuilderLike): TrioGrid {
+  const maxPosByBlock = new Map<string, number>();
+  for (const chr of result.chromosomes) {
+    for (const g of chr.genes) {
+      maxPosByBlock.set(g.block, Math.max(maxPosByBlock.get(g.block) ?? 0, g.position));
+    }
+  }
+
+  const blocks = [...maxPosByBlock.keys()].sort(compareBlockLetters);
+  const positionsByBlock: Record<string, number[]> = {};
+  for (const block of blocks) {
+    const max = maxPosByBlock.get(block) ?? 0;
+    positionsByBlock[block] = Array.from({ length: max }, (_, i) => i + 1);
+  }
+
+  const rows: TrioGridRow[] = result.chromosomes.map((chr) => {
+    const cells: Record<string, TrioLocusCell> = {};
+    for (const g of chr.genes) {
+      cells[`${g.block}${g.position}`] = {
+        geneId: g.geneId,
+        block: g.block,
+        position: g.position,
+        fatherType: g.fatherType,
+        motherType: g.motherType,
+        fatherCell: g.fatherType ? cellBuilder.makeCell({ id: g.geneId, type: g.fatherType }) : null,
+        motherCell: g.motherType ? cellBuilder.makeCell({ id: g.geneId, type: g.motherType }) : null,
+        segments: buildSegments(g.geneId, g.dist, cellBuilder),
+        verdict: g.verdict,
+        source: g.source,
+        lockedIn: g.lockedIn,
+        attribute: g.attribute,
+        pPositive: g.pPositive,
+        pNegative: g.pNegative,
+        fatherEffect: g.fatherEffect,
+        motherEffect: g.motherEffect,
+      };
+    }
+    return { chromosome: chr.chromosome, cells };
+  });
+
+  return { blocks, positionsByBlock, rows };
+}

--- a/src/lib/utils/trioGrid.ts
+++ b/src/lib/utils/trioGrid.ts
@@ -66,11 +66,17 @@ interface CellBuilderLike {
 
 const ALLELE_ORDER: readonly (keyof AlleleDistribution)[] = ['D', 'x', 'R', 'unknown'];
 
+/** Effect-type strings that map to a defined `tone-*` style. */
+const KNOWN_TONES = new Set<TrioTone>(['positive', 'negative', 'potential-positive', 'potential-negative', 'neutral']);
+
 function toneFor(geneId: string, allele: keyof AlleleDistribution, cellBuilder: CellBuilderLike): TrioTone {
   if (allele === 'unknown') return 'unknown';
   // `D`/`x` express the dominant effect, `R` the recessive — `analyzeGene`
-  // resolves the right one from the allele it's given.
-  return cellBuilder.analyzeGene(geneId, allele).effectType as TrioTone;
+  // resolves the right one from the allele it's given. Normalise to the known
+  // tone set so an unexpected/expanded effectType can't emit an undefined
+  // `tone-*` class; `neutral` is the safe default for a known allele.
+  const effectType = cellBuilder.analyzeGene(geneId, allele).effectType;
+  return KNOWN_TONES.has(effectType as TrioTone) ? (effectType as TrioTone) : 'neutral';
 }
 
 function buildSegments(geneId: string, dist: AlleleDistribution, cellBuilder: CellBuilderLike): TrioSegment[] {

--- a/tests/unit/trioGrid.test.js
+++ b/tests/unit/trioGrid.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { createGeneCellBuilder } from '$lib/utils/geneGridCells.js';
+import { buildTrioGrid } from '$lib/utils/trioGrid.js';
+
+const effectsDB = {
+  // carrier gene: harmful dominant, beneficial recessive
+  '01A1': { effectDominant: 'Speed-', effectRecessive: 'Speed+', breed: '', appearance: '', notes: '' },
+  '01A2': { effectDominant: 'Toughness+', effectRecessive: 'None', breed: '', appearance: '', notes: '' },
+};
+
+const cellBuilder = createGeneCellBuilder({
+  effectsDB,
+  attributeNames: ['Speed', 'Toughness'],
+  appearanceLookup: new Map(),
+  speciesKey: 'beewasp',
+});
+
+const entry = (over) => ({
+  geneId: '01A1',
+  block: 'A',
+  position: 1,
+  fatherType: 'x',
+  motherType: 'x',
+  dist: { D: 0.25, x: 0.5, R: 0.25, unknown: 0 },
+  verdict: 'gain',
+  source: 'both',
+  lockedIn: false,
+  attribute: 'Speed',
+  pPositive: 0.25,
+  pNegative: 0.75,
+  fatherEffect: 'Speed-',
+  motherEffect: 'Speed-',
+  ...over,
+});
+
+const result = {
+  chromosomes: [
+    {
+      chromosome: '01',
+      totalGenes: 2,
+      gains: 1,
+      risks: 0,
+      genes: [
+        entry({}),
+        entry({
+          geneId: '01A2',
+          position: 2,
+          fatherType: 'D',
+          motherType: null,
+          dist: { D: 0, x: 0, R: 0, unknown: 1 },
+          verdict: 'neutral',
+          source: null,
+          attribute: 'Toughness',
+          pPositive: 0,
+          pNegative: 0,
+          motherEffect: undefined,
+        }),
+      ],
+    },
+    {
+      chromosome: '02',
+      totalGenes: 1,
+      gains: 0,
+      risks: 0,
+      genes: [
+        entry({ geneId: '02B1', block: 'B', position: 1, dist: { D: 1, x: 0, R: 0, unknown: 0 }, verdict: 'neutral' }),
+      ],
+    },
+  ],
+  summary: { totalGenes: 3, gains: 1, risks: 0, lockedIn: 0, unknownLoci: 1 },
+};
+
+describe('buildTrioGrid', () => {
+  const grid = buildTrioGrid(result, cellBuilder);
+
+  it('builds the block/position column layout as the union across chromosomes', () => {
+    expect(grid.blocks).toEqual(['A', 'B']);
+    expect(grid.positionsByBlock.A).toEqual([1, 2]);
+    expect(grid.positionsByBlock.B).toEqual([1]);
+  });
+
+  it('keys each chromosome row by block+position', () => {
+    expect(grid.rows.map((r) => r.chromosome)).toEqual(['01', '02']);
+    expect(Object.keys(grid.rows[0].cells).sort()).toEqual(['A1', 'A2']);
+    expect(grid.rows[1].cells.B1).toBeDefined();
+  });
+
+  it('builds parent cells with the shared gene-cell classes, null when a parent lacks the locus', () => {
+    const a1 = grid.rows[0].cells.A1;
+    // father x → expresses the harmful dominant (Speed-) as mixed zygosity
+    expect(a1.fatherCell.attributeCls).toBe('gene-cell gene-negative gene-mixed');
+    expect(a1.motherCell.attributeCls).toBe('gene-cell gene-negative gene-mixed');
+
+    const a2 = grid.rows[0].cells.A2;
+    expect(a2.fatherCell).not.toBeNull();
+    expect(a2.motherCell).toBeNull(); // motherType null → no cell
+  });
+
+  it('builds offspring segments, omitting zero-mass alleles and toning by expressed effect', () => {
+    const segs = grid.rows[0].cells.A1.segments;
+    expect(segs).toEqual([
+      { allele: 'D', pct: 25, tone: 'negative' }, // D expresses the dominant Speed-
+      { allele: 'x', pct: 50, tone: 'negative' }, // x also expresses dominant
+      { allele: 'R', pct: 25, tone: 'positive' }, // R expresses the recessive Speed+
+    ]);
+  });
+
+  it('represents an all-unknown offspring as a single unknown segment', () => {
+    expect(grid.rows[0].cells.A2.segments).toEqual([{ allele: 'unknown', pct: 100, tone: 'unknown' }]);
+  });
+
+  it('carries the verdict metadata through to the cell', () => {
+    const a1 = grid.rows[0].cells.A1;
+    expect(a1.verdict).toBe('gain');
+    expect(a1.source).toBe('both');
+    expect(a1.pPositive).toBe(0.25);
+    expect(a1.attribute).toBe('Speed');
+  });
+
+  it('returns an empty layout for an empty result', () => {
+    const empty = buildTrioGrid({ chromosomes: [], summary: {} }, cellBuilder);
+    expect(empty.blocks).toEqual([]);
+    expect(empty.rows).toEqual([]);
+  });
+});

--- a/tests/unit/trioGrid.test.js
+++ b/tests/unit/trioGrid.test.js
@@ -117,6 +117,36 @@ describe('buildTrioGrid', () => {
     expect(a1.attribute).toBe('Speed');
   });
 
+  it('normalises an unexpected effectType to a neutral tone (no undefined tone-* class)', () => {
+    const stubBuilder = {
+      makeCell: () => ({
+        id: '01A1',
+        type: 'D',
+        attributeCls: '',
+        appearanceCls: '',
+        attribute: '',
+        appearance: '',
+        breed: '',
+        effect: '',
+      }),
+      analyzeGene: () => ({ effectType: 'totally-made-up' }),
+    };
+    const stubResult = {
+      chromosomes: [
+        {
+          chromosome: '01',
+          totalGenes: 1,
+          gains: 0,
+          risks: 0,
+          genes: [entry({ dist: { D: 1, x: 0, R: 0, unknown: 0 } })],
+        },
+      ],
+      summary: {},
+    };
+    const g = buildTrioGrid(stubResult, stubBuilder);
+    expect(g.rows[0].cells.A1.segments).toEqual([{ allele: 'D', pct: 100, tone: 'neutral' }]);
+  });
+
   it('returns an empty layout for an empty result', () => {
     const empty = buildTrioGrid({ chromosomes: [], summary: {} }, cellBuilder);
     expect(empty.blocks).toEqual([]);


### PR DESCRIPTION
PR 3 of 4 for #299. Branches from `main` (#300 + #301 merged).

The trio genome grid component — three rows per chromosome with the offspring **centered and taller**.

- New `GenomeGridTrio.svelte`: loads a pair via `computeOffspringTrio`, builds the shared cell context, renders Father / Offspring / Mother. Parent rows reuse `createGeneCellBuilder` (PR 2). The offspring row renders the full allele distribution as a segmented bar (D/x/R/unknown, widths = probability) coloured by the expressed effect, with a green/amber **verdict ring** for gain/risk and a summary strip (gains / risks / locked-in / unknown) + legend. Hover gives per-cell detail via `title`.
- New `trioGrid.ts`: pure render-model builder (block/position column layout as the union across chromosomes; per-locus parent cells + offspring segments). Unit-tested.

Tests: 7 new unit tests for `buildTrioGrid` (layout union, parent-cell classes, null parent locus, segment toning, all-unknown, empty result). Full unit suite 597 green; biome clean; `svelte-check` clean for the new files.

**Verification scope:** the component is not yet mounted anywhere — it's wired into the Breeding tab in PR 4, which is where the Playwright E2E (and visual confirmation) lands. PR 3 is verified at the data/layout layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)