### PR TITLE
feat(breeding): trio view entry from the pair table (PR 4/4)

### DIFF
--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -94,6 +94,7 @@ function fmt(n) {
                 <tr>
                     <td class="action-cell">
                         <button
+                            type="button"
                             class="inspect-btn"
                             onclick={() => openTrio(pair)}
                             title="View offspring trio"

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -57,6 +57,10 @@ function openPet(pet) {
   appState.switchTab('pets');
 }
 
+function openTrio(pair) {
+  breedingView.selectedPair = { male: pair.male, female: pair.female };
+}
+
 function fmt(n) {
   return n.toFixed(1);
 }
@@ -66,6 +70,7 @@ function fmt(n) {
     <table>
         <thead>
             <tr>
+                <th class="action-col" aria-label="Inspect"></th>
                 {#each columns as col (col.id)}
                     {@const isActive = breedingView.sortCol === col.id}
                     <th
@@ -87,6 +92,15 @@ function fmt(n) {
         <tbody>
             {#each sortedResults as pair (`${pair.male.id}-${pair.female.id}`)}
                 <tr>
+                    <td class="action-cell">
+                        <button
+                            class="inspect-btn"
+                            onclick={() => openTrio(pair)}
+                            title="View offspring trio"
+                            aria-label={`View offspring trio for ${pair.male.name} × ${pair.female.name}`}
+                            data-testid="inspect-pair"
+                        >🔬</button>
+                    </td>
                     <td><button class="parent-link" onclick={() => openPet(pair.male)}>{pair.male.name}</button></td>
                     <td><button class="parent-link" onclick={() => openPet(pair.female)}>{pair.female.name}</button></td>
                     <td class="numeric">{fmt(pair.evMixed)}</td>
@@ -182,5 +196,32 @@ function fmt(n) {
 
     .parent-link:hover {
         text-decoration: underline;
+    }
+
+    .action-col {
+        width: 32px;
+        min-width: 32px;
+    }
+
+    .action-cell {
+        text-align: center;
+        padding: 2px 4px;
+    }
+
+    .inspect-btn {
+        background: none;
+        border: none;
+        cursor: pointer;
+        font-size: 14px;
+        line-height: 1;
+        padding: 4px;
+        border-radius: 4px;
+        opacity: 0.65;
+        transition: opacity 0.15s ease, background 0.15s ease;
+    }
+
+    .inspect-btn:hover {
+        opacity: 1;
+        background: var(--bg-tertiary);
     }
 </style>

--- a/src/lib/components/breeding/BreedingTab.svelte
+++ b/src/lib/components/breeding/BreedingTab.svelte
@@ -7,6 +7,7 @@ import { pets } from '$lib/stores/pets.js';
 import { Gender, HORSE_BREEDS } from '$lib/types/index.js';
 import { capitalize } from '$lib/utils/string.js';
 import BreedingPairTable from './BreedingPairTable.svelte';
+import TrioView from './TrioView.svelte';
 
 const species = getSupportedSpecies();
 
@@ -153,6 +154,14 @@ const horseBreedOptions = Object.keys(HORSE_BREEDS);
             <BreedingPairTable results={pairs} {attrNames} />
         {/if}
     </section>
+
+    {#if breedingView.selectedPair}
+        <TrioView
+            pair={breedingView.selectedPair}
+            offspringBreed={breedingView.offspringBreed}
+            onClose={() => { breedingView.selectedPair = null; }}
+        />
+    {/if}
 </div>
 
 <style>

--- a/src/lib/components/breeding/TrioView.svelte
+++ b/src/lib/components/breeding/TrioView.svelte
@@ -1,0 +1,100 @@
+<script>
+import GenomeGridTrio from '$lib/components/comparison/GenomeGridTrio.svelte';
+import { normalizeSpecies } from '$lib/services/configService.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
+
+/**
+ * @typedef {Object} Props
+ * @property {{ male: any, female: any }} pair
+ * @property {string} [offspringBreed]
+ * @property {() => void} onClose
+ */
+
+/** @type {Props} */
+const { pair, offspringBreed = '', onClose } = $props();
+
+const father = $derived(pair.male);
+const mother = $derived(pair.female);
+const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+    class="modal-backdrop"
+    onclick={onClose}
+    onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}
+    role="presentation"
+>
+    <div
+        class="dialog trio-dialog"
+        role="dialog"
+        aria-label="Offspring trio"
+        aria-modal="true"
+        tabindex="-1"
+        use:focusTrap
+        data-testid="trio-view"
+        onclick={(e) => e.stopPropagation()}
+        onkeydown={(e) => { if (e.key === 'Escape') onClose(); }}
+    >
+        <div class="dialog-header">
+            <h3 class="trio-title">
+                <span class="parent-name father">♂ {father?.name}</span>
+                <span class="cross">×</span>
+                <span class="parent-name mother">♀ {mother?.name}</span>
+                {#if speciesLabel}
+                    <span class="species-badge">{getSpeciesEmoji(father?.species)} {speciesLabel}</span>
+                {/if}
+                {#if offspringBreed}
+                    <span class="breed-badge">{offspringBreed}</span>
+                {/if}
+            </h3>
+            <button class="close-btn" onclick={onClose} aria-label="Close trio view">×</button>
+        </div>
+
+        <div class="dialog-body trio-body">
+            <GenomeGridTrio {father} {mother} {offspringBreed} />
+        </div>
+    </div>
+</div>
+
+<style>
+    .trio-dialog {
+        width: 92%;
+        max-width: 1100px;
+        max-height: 88vh;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .trio-title {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin: 0;
+    }
+
+    .parent-name { font-weight: 700; }
+    .parent-name.father { color: var(--accent); }
+    .parent-name.mother { color: #a855f7; }
+    .cross { color: var(--text-muted); font-weight: 500; }
+
+    .species-badge,
+    .breed-badge {
+        font-size: 12px;
+        font-weight: 500;
+        padding: 2px 8px;
+        background: var(--bg-tertiary);
+        border-radius: 10px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    /* Body scrolls on its own so the wide grid never pushes the page. */
+    .trio-body {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+    }
+</style>

--- a/src/lib/components/breeding/TrioView.svelte
+++ b/src/lib/components/breeding/TrioView.svelte
@@ -6,7 +6,7 @@ import { getSpeciesEmoji } from '$lib/utils/species.js';
 
 /**
  * @typedef {Object} Props
- * @property {{ male: any, female: any }} pair
+ * @property {import('$lib/stores/breeding.svelte.js').SelectedBreedingPair} pair
  * @property {string} [offspringBreed]
  * @property {() => void} onClose
  */
@@ -49,7 +49,7 @@ const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
                     <span class="breed-badge">{offspringBreed}</span>
                 {/if}
             </h3>
-            <button class="close-btn" onclick={onClose} aria-label="Close trio view">×</button>
+            <button type="button" class="close-btn" onclick={onClose} aria-label="Close trio view">×</button>
         </div>
 
         <div class="dialog-body trio-body">

--- a/src/lib/stores/breeding.svelte.ts
+++ b/src/lib/stores/breeding.svelte.ts
@@ -12,6 +12,13 @@
  */
 
 import { getSupportedSpecies } from '$lib/services/configService.js';
+import type { Pet } from '$lib/types/index.js';
+
+/** The (father, mother) pair currently open in the trio detail view. */
+export interface SelectedBreedingPair {
+  male: Pet;
+  female: Pet;
+}
 
 /**
  * Sort columns the breeding pair table will support in PR 4. The
@@ -32,4 +39,6 @@ export const breedingView = $state({
   sortCol: 'evPositiveTotal' as BreedingSortColumn,
   /** Sort direction. Most useful columns are descending by default. */
   sortDir: 'desc' as 'asc' | 'desc',
+  /** Pair open in the trio detail view; null when the view is closed. */
+  selectedPair: null as SelectedBreedingPair | null,
 });

--- a/tests/e2e/breeding.spec.js
+++ b/tests/e2e/breeding.spec.js
@@ -103,4 +103,26 @@ test.describe('Breeding Assistant — ranking UI (PR 4)', () => {
     // pass even if no pet were actually selected.
     await expect(page.locator('.detail-content').getByText(name, { exact: false }).first()).toBeVisible();
   });
+
+  test('inspecting a pair opens the trio view with father / offspring / mother rows', async ({ page }) => {
+    await openBreedingTab(page);
+    const found = await pickSpeciesWithPairs(page);
+    expect(found).toBe(true);
+
+    await page.locator('[data-testid="inspect-pair"]').first().click();
+
+    const trio = page.getByTestId('trio-view');
+    await expect(trio).toBeVisible();
+
+    // The grid loads asynchronously; waiting on the role labels rides out the
+    // loading state. There is one role label per chromosome, so scope to the
+    // first. Offspring sits between the two parents.
+    await expect(trio.getByText('Father', { exact: false }).first()).toBeVisible();
+    await expect(trio.getByText('Offspring', { exact: false }).first()).toBeVisible();
+    await expect(trio.getByText('Mother', { exact: false }).first()).toBeVisible();
+    await expect(trio.locator('.offspring-row').first()).toBeVisible();
+
+    await trio.getByRole('button', { name: 'Close trio view' }).click();
+    await expect(page.getByTestId('trio-view')).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
PR 4 of 4 for #299. **Stacked on #302** (base is `feat/trio-genome-grid-299`).

Wires the trio grid into the Breeding Assistant and closes the feature.

- Each ranked pair row gets a 🔬 **inspect** action (leading column) that opens a `TrioView` modal for that Father × Mother, reusing the shared `.modal-backdrop`/`.dialog` styles and `focusTrap`. Parent-name links still navigate to the pet (separate control).
- `TrioView.svelte`: header (`♂ Father × ♀ Mother` + species/breed badge), scrollable body hosting `GenomeGridTrio`, close via button / Escape / backdrop.
- `breeding.svelte.ts`: `selectedPair` state drives the modal; the selected offspring breed is passed through so the trio filters loci the same way the ranking did.

Tests: new Playwright E2E — inspect a ranked pair → trio modal shows Father / Offspring / Mother rows → close. Full breeding E2E (5) green, comparison E2E green, unit suite 597 green, biome clean.

Notes:
- Confirmed in the running app: opening a real demo pair (Sample Horse × Roach, 48 chromosomes) renders the three-row grid with the centered offspring distribution row.
- The DOM-count `console.warn` seen in the E2E log is from `GeneVisualizer` (the single-pet view opened by the parent-name test), not the trio grid.

Merge order: #302 then this.

Closes #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)