### PR TITLE
refactor(types): migrate comparison/ components to TS (#306, batch 2)

### DIFF
--- a/src/lib/components/comparison/AttributeComparison.svelte
+++ b/src/lib/components/comparison/AttributeComparison.svelte
@@ -1,9 +1,15 @@
-<script>
+<script lang="ts">
 import { compareAttributes } from '$lib/services/comparisonService.js';
+import type { AttributeComparisonResult, Pet } from '$lib/types/index.js';
 
-const { petA, petB } = $props();
+interface Props {
+  petA: Pet;
+  petB: Pet;
+}
 
-const results = $derived(petA && petB ? compareAttributes(petA, petB) : []);
+const { petA, petB }: Props = $props();
+
+const results = $derived<AttributeComparisonResult[]>(petA && petB ? compareAttributes(petA, petB) : []);
 
 const summary = $derived.by(() => {
   let aWins = 0;

--- a/src/lib/components/comparison/ComparisonPetPicker.svelte
+++ b/src/lib/components/comparison/ComparisonPetPicker.svelte
@@ -1,7 +1,8 @@
-<script>
+<script lang="ts">
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { comparisonActions, comparisonPets, speciesMismatch } from '$lib/stores/comparison.js';
 import { pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
 
 let searchQuery = $state('');
@@ -24,7 +25,7 @@ const filteredPets = $derived.by(() => {
   });
 });
 
-function handlePetClick(pet) {
+function handlePetClick(pet: Pet) {
   comparisonActions.addPet(pet);
 }
 </script>

--- a/src/lib/components/comparison/ComparisonView.svelte
+++ b/src/lib/components/comparison/ComparisonView.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import AttributeComparison from '$lib/components/comparison/AttributeComparison.svelte';
 import GeneStatsComparison from '$lib/components/comparison/GeneStatsComparison.svelte';
 import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
@@ -63,11 +63,11 @@ const speciesLabel = $derived($comparisonPets[0] ? normalizeSpecies($comparisonP
 
         <div class="comparison-body">
             {#if activeView === 'attributes'}
-                <AttributeComparison petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+                <AttributeComparison petA={$comparisonPets[0]!} petB={$comparisonPets[1]!} />
             {:else if activeView === 'geneStats'}
-                <GeneStatsComparison petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+                <GeneStatsComparison petA={$comparisonPets[0]!} petB={$comparisonPets[1]!} />
             {:else if activeView === 'genomeDiff'}
-                <GenomeGridDiff petA={$comparisonPets[0]} petB={$comparisonPets[1]} />
+                <GenomeGridDiff petA={$comparisonPets[0]!} petB={$comparisonPets[1]!} />
             {/if}
         </div>
     {:else}

--- a/src/lib/components/comparison/GeneStatsComparison.svelte
+++ b/src/lib/components/comparison/GeneStatsComparison.svelte
@@ -1,12 +1,18 @@
-<script>
+<script lang="ts">
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { compareGeneStats } from '$lib/services/comparisonService.js';
+import type { GeneStatsComparisonResult, GeneStatsEntry, Pet } from '$lib/types/index.js';
 
-const { petA, petB } = $props();
+interface Props {
+  petA: Pet;
+  petB: Pet;
+}
 
-let results = $state([]);
+const { petA, petB }: Props = $props();
+
+let results = $state<GeneStatsComparisonResult[]>([]);
 let loading = $state(false);
-let error = $state(null);
+let error = $state<string | null>(null);
 
 // Reload when pets change
 $effect(() => {
@@ -20,15 +26,15 @@ async function loadStats() {
     loading = true;
     error = null;
     results = await compareGeneStats(petA, petB);
-  } catch (err) {
-    error = err.message || 'Failed to load gene stats';
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : 'Failed to load gene stats';
     results = [];
   } finally {
     loading = false;
   }
 }
 
-function sumEntry(entry) {
+function sumEntry(entry: GeneStatsEntry) {
   return entry.positive + entry.negative;
 }
 

--- a/src/lib/components/comparison/GenomeDiff.svelte
+++ b/src/lib/components/comparison/GenomeDiff.svelte
@@ -1,17 +1,28 @@
-<script>
+<script lang="ts">
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { diffGenomes } from '$lib/services/comparisonService.js';
+import type { ChromosomeDiff, GeneType, Pet } from '$lib/types/index.js';
 
-const { petA, petB } = $props();
+interface Props {
+  petA: Pet;
+  petB: Pet;
+}
 
-let diffs = $state([]);
-let summary = $state(null);
+const { petA, petB }: Props = $props();
+
+let diffs = $state<ChromosomeDiff[]>([]);
+let summary = $state<{
+  totalGenes: number;
+  identicalGenes: number;
+  differentGenes: number;
+  similarityPercent: number;
+} | null>(null);
 let loading = $state(false);
-let error = $state(null);
+let error = $state<string | null>(null);
 let showDiffsOnly = $state(false);
 
 // Track which chromosomes are expanded
-let expandedChromosomes = $state(new Set());
+let expandedChromosomes = $state(new Set<string>());
 
 $effect(() => {
   if (petA?.id && petB?.id) {
@@ -28,13 +39,13 @@ async function loadDiff() {
     summary = result.summary;
 
     // Auto-expand chromosomes with differences
-    const expanded = new Set();
+    const expanded = new Set<string>();
     for (const d of diffs) {
       if (d.differentGenes > 0) expanded.add(d.chromosome);
     }
     expandedChromosomes = expanded;
-  } catch (err) {
-    error = err.message || 'Failed to load genome diff';
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : 'Failed to load genome diff';
     diffs = [];
     summary = null;
   } finally {
@@ -42,7 +53,7 @@ async function loadDiff() {
   }
 }
 
-function toggleChromosome(chr) {
+function toggleChromosome(chr: string) {
   expandedChromosomes = new Set(expandedChromosomes);
   if (expandedChromosomes.has(chr)) {
     expandedChromosomes.delete(chr);
@@ -51,12 +62,12 @@ function toggleChromosome(chr) {
   }
 }
 
-function geneTypeLabel(type) {
+function geneTypeLabel(type: GeneType | null) {
   if (!type) return '·';
   return type;
 }
 
-function geneTypeClass(type) {
+function geneTypeClass(type: GeneType | null) {
   if (type === 'D') return 'dominant';
   if (type === 'R') return 'recessive';
   if (type === 'x') return 'mixed';

--- a/src/lib/components/comparison/GenomeDiff.svelte
+++ b/src/lib/components/comparison/GenomeDiff.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { diffGenomes } from '$lib/services/comparisonService.js';
-import type { ChromosomeDiff, GeneType, Pet } from '$lib/types/index.js';
+import type { ChromosomeDiff, GeneType, GenomeDiffSummary, Pet } from '$lib/types/index.js';
 
 interface Props {
   petA: Pet;
@@ -11,12 +11,7 @@ interface Props {
 const { petA, petB }: Props = $props();
 
 let diffs = $state<ChromosomeDiff[]>([]);
-let summary = $state<{
-  totalGenes: number;
-  identicalGenes: number;
-  differentGenes: number;
-  similarityPercent: number;
-} | null>(null);
+let summary = $state<GenomeDiffSummary | null>(null);
 let loading = $state(false);
 let error = $state<string | null>(null);
 let showDiffsOnly = $state(false);

--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,16 +1,9 @@
 <script lang="ts">
-import type { AppearanceInfo, AttributeInfo } from '$lib/types/index.js';
+import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 
-interface DiffSummary {
-  totalGenes: number;
-  identicalGenes: number;
-  differentGenes: number;
-  similarityPercent: number;
-}
-
 interface Props {
-  summary: DiffSummary;
+  summary: GenomeDiffSummary;
   isHorse: boolean;
   breedFilter: string;
   autoBreed?: boolean;

--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,5 +1,38 @@
-<script>
+<script lang="ts">
+import type { AppearanceInfo, AttributeInfo } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
+
+interface DiffSummary {
+  totalGenes: number;
+  identicalGenes: number;
+  differentGenes: number;
+  similarityPercent: number;
+}
+
+interface Props {
+  summary: DiffSummary;
+  isHorse: boolean;
+  breedFilter: string;
+  autoBreed?: boolean;
+  petsHaveKnownBreed?: boolean;
+  petsShareBreed?: boolean;
+  showDiffsOnly: boolean;
+  selectedAttributes: string[];
+  hiddenAttributes: string[];
+  attributeDisplayInfo: AttributeInfo[];
+  selectedAppearances?: string[];
+  hiddenAppearances?: string[];
+  appearanceDisplayInfo?: AppearanceInfo[];
+  currentView?: 'attribute' | 'appearance';
+  onBreedChange: (name: string) => void;
+  onAutoBreedToggle: () => void;
+  onAttributeToggle: (key: string, ctrlKey: boolean, altKey: boolean) => void;
+  onAppearanceToggle: (key: string, ctrlKey: boolean, altKey: boolean) => void;
+  onDiffsOnlyChange: (val: boolean) => void;
+  onResetAttributes: () => void;
+  onResetAppearances: () => void;
+  onViewChange: (view: 'attribute' | 'appearance') => void;
+}
 
 const {
   summary,
@@ -24,7 +57,7 @@ const {
   onResetAttributes,
   onResetAppearances,
   onViewChange,
-} = $props();
+}: Props = $props();
 </script>
 
 <div class="diff-controls">
@@ -36,7 +69,7 @@ const {
             <button class="view-btn" class:active={currentView === 'appearance'} onclick={() => onViewChange('appearance')}>Appearance</button>
         </div>
         <label class="diff-toggle">
-            <input type="checkbox" checked={showDiffsOnly} onchange={(e) => onDiffsOnlyChange(e.target.checked)} />
+            <input type="checkbox" checked={showDiffsOnly} onchange={(e) => onDiffsOnlyChange((e.target as HTMLInputElement).checked)} />
             Differences only
         </label>
     </div>

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import { onDestroy, onMount } from 'svelte';
 import GenomeDiffControls from '$lib/components/comparison/GenomeDiffControls.svelte';
 import GeneTooltip from '$lib/components/gene/GeneTooltip.svelte';
@@ -7,49 +7,75 @@ import { getAppearanceConfig, getAttributeConfig, normalizeSpecies } from '$lib/
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { settings } from '$lib/stores/settings.js';
+import type { AppearanceInfo, AttributeInfo, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { buildFilterCSS } from '$lib/utils/filterCSS.js';
-import { breedFor, effectFor, isNoEffect } from '$lib/utils/geneAnalysis.js';
-import { buildAppearanceLookup, createGeneCellBuilder } from '$lib/utils/geneGridCells.js';
+import { breedFor, effectFor, type GeneEffectData, isNoEffect } from '$lib/utils/geneAnalysis.js';
+import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
 import { capitalize } from '$lib/utils/string.js';
 
-const { petA, petB } = $props();
+interface DiffSummary {
+  totalGenes: number;
+  identicalGenes: number;
+  differentGenes: number;
+  similarityPercent: number;
+}
+
+interface ChromosomeRow {
+  chr: string;
+  cellsA: Record<string, (GeneCell | null)[]>;
+  cellsB: Record<string, (GeneCell | null)[]>;
+  diffs: Record<string, boolean[]>;
+  hasDiffs: boolean;
+}
+
+interface ChrBreedEntry {
+  generic: boolean;
+  breeds: Set<string>;
+}
+
+interface Props {
+  petA: Pet;
+  petB: Pet;
+}
+
+const { petA, petB }: Props = $props();
 
 let loading = $state(false);
-let error = $state(null);
-let summary = $state(null);
+let error = $state<string | null>(null);
+let summary = $state<DiffSummary | null>(null);
 let showDiffsOnly = $state(false);
-let currentView = $state('attribute');
+let currentView = $state<'attribute' | 'appearance'>('attribute');
 
-let effectsDB = {};
+let effectsDB: Record<string, GeneEffectData> = {};
 let speciesKey = $state('');
 const isHorse = $derived(speciesKey === 'horse');
 
-let sortedBlocks = $state([]);
-let blockMaxGenes = new Map();
-let blockIndices = $state({});
+let sortedBlocks = $state<string[]>([]);
+let blockMaxGenes = new Map<string, number>();
+let blockIndices = $state<Record<string, number[]>>({});
 
-let allAttributeNames = [];
-let attributeDisplayInfo = $state([]);
-let appearanceDisplayInfo = $state([]);
-let appearanceLookup = new Map();
+let allAttributeNames: string[] = [];
+let attributeDisplayInfo = $state<AttributeInfo[]>([]);
+let appearanceDisplayInfo = $state<AppearanceInfo[]>([]);
+let appearanceLookup = new Map<string, string>();
 
-let chromosomeRows = $state([]);
-let chrBreedRelevance = {};
+let chromosomeRows = $state<ChromosomeRow[]>([]);
+let chrBreedRelevance: Record<string, ChrBreedEntry> = {};
 
 // Filters
 let breedFilter = $state('');
 let autoBreed = $state(false);
-let selectedChromosomes = $state([]);
-let hiddenChromosomes = $state([]);
-let selectedAttributes = $state([]);
-let hiddenAttributes = $state([]);
-let selectedAppearances = $state([]);
-let hiddenAppearances = $state([]);
+let selectedChromosomes = $state<string[]>([]);
+let hiddenChromosomes = $state<string[]>([]);
+let selectedAttributes = $state<string[]>([]);
+let hiddenAttributes = $state<string[]>([]);
+let selectedAppearances = $state<string[]>([]);
+let hiddenAppearances = $state<string[]>([]);
 
 // Auto-breed: use the shared setting and detect from pets' breeds
 const petsHaveKnownBreed = $derived(
-  isHorse && petA?.breed && HORSE_BREEDS[petA.breed] && petB?.breed && HORSE_BREEDS[petB.breed],
+  !!(isHorse && petA?.breed && HORSE_BREEDS[petA.breed] && petB?.breed && HORSE_BREEDS[petB.breed]),
 );
 const petsShareBreed = $derived(petsHaveKnownBreed && petA.breed === petB.breed);
 
@@ -89,10 +115,10 @@ let tooltipY = $state(0);
 let tooltipGeneId = $state('');
 let tooltipGeneType = $state('');
 let tooltipEffect = $state('');
-let tooltipPotentialEffects = $state([]);
+let tooltipPotentialEffects = $state<string[]>([]);
 
 // Dynamic filter style element — created programmatically (a Svelte component can't declare a dynamic style block in its markup)
-let filterStyleEl = null;
+let filterStyleEl: HTMLStyleElement | null = null;
 
 onMount(() => {
   filterStyleEl = document.createElement('style');
@@ -170,8 +196,8 @@ async function loadData() {
       speciesKey,
     });
 
-    const allBlks = new Set();
-    const maxGenes = new Map();
+    const allBlks = new Set<string>();
+    const maxGenes = new Map<string, number>();
     for (const parsed of [parsedA, parsedB]) {
       for (const chrData of Object.values(parsed)) {
         for (const block of chrData.blocks) {
@@ -184,7 +210,7 @@ async function loadData() {
     sortedBlocks = [...allBlks].sort();
     blockMaxGenes = maxGenes;
 
-    const indices = {};
+    const indices: Record<string, number[]> = {};
     for (const block of sortedBlocks) {
       indices[block] = Array.from({ length: maxGenes.get(block) || 0 }, (_, i) => i);
     }
@@ -219,14 +245,14 @@ async function loadData() {
       const dataA = parsedA[chr] || { blocks: [] };
       const dataB = parsedB[chr] || { blocks: [] };
 
-      const genesByBlockA = new Map();
-      const genesByBlockB = new Map();
+      const genesByBlockA = new Map<string, { id: string; type: string }[]>();
+      const genesByBlockB = new Map<string, { id: string; type: string }[]>();
       for (const b of dataA.blocks) genesByBlockA.set(b.letter, b.genes);
       for (const b of dataB.blocks) genesByBlockB.set(b.letter, b.genes);
 
-      const cellsA = {};
-      const cellsB = {};
-      const diffs = {};
+      const cellsA: Record<string, (GeneCell | null)[]> = {};
+      const cellsB: Record<string, (GeneCell | null)[]> = {};
+      const diffs: Record<string, boolean[]> = {};
       let chrDiffs = 0;
 
       for (const block of sortedBlocks) {
@@ -256,8 +282,8 @@ async function loadData() {
     const identicalGenes = totalGenes - differentGenes;
     const pct = totalGenes > 0 ? Math.round((identicalGenes / totalGenes) * 100) : 0;
     summary = { totalGenes, identicalGenes, differentGenes, similarityPercent: pct };
-  } catch (err) {
-    error = err.message || 'Failed to load genome data';
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : 'Failed to load genome data';
     chromosomeRows = [];
     summary = null;
   } finally {
@@ -267,7 +293,13 @@ async function loadData() {
 
 // --- Filter UI actions ---
 
-function triStateToggle(key, selected, hidden, ctrlKey, altKey) {
+function triStateToggle(
+  key: string,
+  selected: string[],
+  hidden: string[],
+  ctrlKey: boolean,
+  altKey: boolean,
+): { selected: string[]; hidden: string[] } {
   if (altKey) {
     const nextHidden = hidden.includes(key)
       ? hidden.filter((k) => k !== key)
@@ -282,7 +314,7 @@ function triStateToggle(key, selected, hidden, ctrlKey, altKey) {
   return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
 }
 
-function toggleChromosomeFilter(chr, ctrlKey, altKey) {
+function toggleChromosomeFilter(chr: string, ctrlKey: boolean, altKey: boolean) {
   ({ selected: selectedChromosomes, hidden: hiddenChromosomes } = triStateToggle(
     chr,
     selectedChromosomes,
@@ -292,7 +324,7 @@ function toggleChromosomeFilter(chr, ctrlKey, altKey) {
   ));
 }
 
-function toggleAttributeFilter(attrKey, ctrlKey, altKey) {
+function toggleAttributeFilter(attrKey: string, ctrlKey: boolean, altKey: boolean) {
   ({ selected: selectedAttributes, hidden: hiddenAttributes } = triStateToggle(
     attrKey,
     selectedAttributes,
@@ -302,7 +334,7 @@ function toggleAttributeFilter(attrKey, ctrlKey, altKey) {
   ));
 }
 
-function toggleAppearanceFilter(key, ctrlKey, altKey) {
+function toggleAppearanceFilter(key: string, ctrlKey: boolean, altKey: boolean) {
   ({ selected: selectedAppearances, hidden: hiddenAppearances } = triStateToggle(
     key,
     selectedAppearances,
@@ -314,9 +346,9 @@ function toggleAppearanceFilter(key, ctrlKey, altKey) {
 
 // --- Tooltip ---
 
-function handleCellEnter(event, cell) {
+function handleCellEnter(event: MouseEvent, cell: GeneCell) {
   if (!cell) return;
-  const potentialEffects = [];
+  const potentialEffects: string[] = [];
   const cellData = effectsDB[cell.id];
   const dominantEffect = effectFor(cellData, 'D');
   const recessiveEffect = effectFor(cellData, 'R');

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -7,19 +7,12 @@ import { getAppearanceConfig, getAttributeConfig, normalizeSpecies } from '$lib/
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { settings } from '$lib/stores/settings.js';
-import type { AppearanceInfo, AttributeInfo, Pet } from '$lib/types/index.js';
+import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { buildFilterCSS } from '$lib/utils/filterCSS.js';
 import { breedFor, effectFor, type GeneEffectData, isNoEffect } from '$lib/utils/geneAnalysis.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
 import { capitalize } from '$lib/utils/string.js';
-
-interface DiffSummary {
-  totalGenes: number;
-  identicalGenes: number;
-  differentGenes: number;
-  similarityPercent: number;
-}
 
 interface ChromosomeRow {
   chr: string;
@@ -43,7 +36,7 @@ const { petA, petB }: Props = $props();
 
 let loading = $state(false);
 let error = $state<string | null>(null);
-let summary = $state<DiffSummary | null>(null);
+let summary = $state<GenomeDiffSummary | null>(null);
 let showDiffsOnly = $state(false);
 let currentView = $state<'attribute' | 'appearance'>('attribute');
 

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -1,29 +1,28 @@
-<script>
+<script lang="ts">
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { computeOffspringTrio } from '$lib/services/offspringTrioService.js';
-import { buildAppearanceLookup, createGeneCellBuilder } from '$lib/utils/geneGridCells.js';
+import type { OffspringTrioResult, Pet } from '$lib/types/index.js';
+import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
 import { capitalize } from '$lib/utils/string.js';
-import { buildTrioGrid } from '$lib/utils/trioGrid.js';
+import { buildTrioGrid, type TrioGrid, type TrioLocusCell } from '$lib/utils/trioGrid.js';
 
-/**
- * @typedef {Object} Props
- * @property {any} father
- * @property {any} mother
- * @property {string} [offspringBreed]
- */
+interface Props {
+  father: Pet;
+  mother: Pet;
+  offspringBreed?: string;
+}
 
-/** @type {Props} */
-const { father, mother, offspringBreed = '' } = $props();
+const { father, mother, offspringBreed = '' }: Props = $props();
 
 let loading = $state(false);
-let error = $state(null);
-let grid = $state(null);
-let summary = $state(null);
+let error = $state<string | null>(null);
+let grid = $state<TrioGrid | null>(null);
+let summary = $state<OffspringTrioResult['summary'] | null>(null);
 
-const ALLELE_LABEL = { D: 'Dominant', x: 'Mixed', R: 'Recessive', unknown: 'Unknown' };
-const VERDICT_LABEL = { gain: 'Gain', risk: 'Risk', neutral: '' };
+const ALLELE_LABEL: Record<string, string> = { D: 'Dominant', x: 'Mixed', R: 'Recessive', unknown: 'Unknown' };
+const VERDICT_LABEL: Record<string, string> = { gain: 'Gain', risk: 'Risk', neutral: '' };
 
 $effect(() => {
   if (father?.id && mother?.id) {
@@ -31,7 +30,7 @@ $effect(() => {
   }
 });
 
-async function load(f, m, breed) {
+async function load(f: Pet, m: Pet, breed: string) {
   try {
     loading = true;
     error = null;
@@ -52,8 +51,8 @@ async function load(f, m, breed) {
 
     grid = buildTrioGrid(result, cellBuilder);
     summary = result.summary;
-  } catch (err) {
-    error = err?.message || 'Failed to build the trio view';
+  } catch (err: unknown) {
+    error = err instanceof Error ? err.message : 'Failed to build the trio view';
     grid = null;
     summary = null;
   } finally {
@@ -62,7 +61,7 @@ async function load(f, m, breed) {
 }
 
 /** Hover text for the offspring distribution cell. */
-function offspringTitle(cell) {
+function offspringTitle(cell: TrioLocusCell) {
   const parts = [`Gene ${cell.geneId}`];
   if (cell.attribute) parts.push(cell.attribute);
   if (cell.verdict !== 'neutral') {
@@ -76,7 +75,7 @@ function offspringTitle(cell) {
   return parts.join('\n');
 }
 
-function parentTitle(cell, label) {
+function parentTitle(cell: GeneCell | null, label: string) {
   if (!cell) return '';
   return `${label} · Gene ${cell.id} (${ALLELE_LABEL[cell.type] ?? cell.type})\n${cell.effect || 'No effect'}`;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -332,6 +332,14 @@ export interface ChromosomeDiff {
   genes: GeneDiffEntry[];
 }
 
+/** Aggregate counts for a two-pet genome diff, shared across the comparison UI. */
+export interface GenomeDiffSummary {
+  totalGenes: number;
+  identicalGenes: number;
+  differentGenes: number;
+  similarityPercent: number;
+}
+
 export interface ComparisonResult {
   petA: Pet;
   petB: Pet;
@@ -339,12 +347,7 @@ export interface ComparisonResult {
   attributes: AttributeComparisonResult[];
   geneStats: GeneStatsComparisonResult[];
   genomeDiff: ChromosomeDiff[];
-  summary: {
-    totalGenes: number;
-    identicalGenes: number;
-    differentGenes: number;
-    similarityPercent: number;
-  };
+  summary: GenomeDiffSummary;
 }
 
 // --- Offspring trio types ---


### PR DESCRIPTION
Batch 2 of the #306 svelte-check coverage migration (after #307 breeding/ + StatusPane). Branches from `main`.

Converts all 8 `comparison/` components to `<script lang="ts">` with typed props/state/handlers (~104 type errors resolved), so svelte-check now type-checks the whole folder. Behavior-preserving — only types and idiomatic guards changed.

Files: `ComparisonView`, `ComparisonPetPicker`, `AttributeComparison`, `GeneStatsComparison`, `GenomeDiff`, `GenomeDiffControls`, `GenomeGridTrio`, `GenomeGridDiff` (the largest, ~59 errors).

Notable typing decisions (no runtime change):
- `GenomeGridDiff`/`GenomeGridTrio`: `catch (err: unknown)` → `err instanceof Error ? err.message : fallback` (also handles non-Error throws).
- `ComparisonView`: non-null assertions on `$comparisonPets[0]!/[1]!` — only inside the `{#if $comparisonReady}` guard where both slots are filled.
- `GenomeGridDiff`: `petsHaveKnownBreed` wrapped in `!!()` (the `&&`-chain inferred `string | false`); explicit return type on `triStateToggle` to avoid `never[]` inference.
- `currentView`/`onViewChange` typed `'attribute' | 'appearance'` to match `filterCSS.js`.

`pnpm check` green (0/0), unit 598, comparison E2E 12/12, biome clean.

Part of #306. Remaining: gene/ (GeneVisualizer dominates at ~132), pet/, layout/, stable/, community/, utils/, routes/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)