### PR TITLE
refactor(utils): extract testable decision logic from grid components (#310)

### DIFF
--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -2,18 +2,17 @@
 import { breedingView } from '$lib/stores/breeding.svelte.js';
 import { appState } from '$lib/stores/pets.js';
 import type { BreedingPairResult, Pet } from '$lib/types/index.js';
+import { type SortableColumn, sortByColumn } from '$lib/utils/sortColumn.js';
 
 interface Props {
   results: BreedingPairResult[];
   attrNames: string[];
 }
 
-// Discriminated on `numeric` so the accessor's return type is tied to the flag:
-// a numeric column sorts by subtraction, a text column by localeCompare, and a
-// mismatch is a compile error rather than a silent cast.
-type Column =
-  | { id: string; label: string; numeric: true; accessor: (r: BreedingPairResult) => number }
-  | { id: string; label: string; numeric: false; accessor: (r: BreedingPairResult) => string };
+// `SortableColumn` is discriminated on `numeric` so the accessor's return type
+// is tied to the flag: a numeric column sorts by subtraction, a text column by
+// localeCompare, and a mismatch is a compile error rather than a silent cast.
+type Column = { id: string; label: string } & SortableColumn<BreedingPairResult>;
 
 const { results, attrNames }: Props = $props();
 
@@ -44,12 +43,7 @@ const sortedResults = $derived.by(() => {
   // the column list later won't silently change the default sort.
   const col =
     columns.find((c) => c.id === breedingView.sortCol) ?? columns.find((c) => c.id === 'evPositiveTotal') ?? columns[0];
-  const dir = breedingView.sortDir === 'asc' ? 1 : -1;
-  return [...results].sort((a, b) => {
-    // `col.numeric` narrows the accessor's return type, so no cast is needed.
-    const cmp = col.numeric ? col.accessor(a) - col.accessor(b) : col.accessor(a).localeCompare(col.accessor(b));
-    return cmp * dir;
-  });
+  return sortByColumn(results, col, breedingView.sortDir);
 });
 
 function setSort(colId: string) {

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -10,6 +10,7 @@ import { settings } from '$lib/stores/settings.js';
 import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { triStateToggle } from '$lib/utils/filterToggle.js';
 import { breedFor, effectFor, type GeneEffectData, isNoEffect } from '$lib/utils/geneAnalysis.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
 import { capitalize } from '$lib/utils/string.js';
@@ -285,27 +286,6 @@ async function loadData() {
 }
 
 // --- Filter UI actions ---
-
-function triStateToggle(
-  key: string,
-  selected: string[],
-  hidden: string[],
-  ctrlKey: boolean,
-  altKey: boolean,
-): { selected: string[]; hidden: string[] } {
-  if (altKey) {
-    const nextHidden = hidden.includes(key)
-      ? hidden.filter((k) => k !== key)
-      : [...hidden.filter((k) => k !== key), key];
-    return { selected: selected.filter((k) => k !== key), hidden: nextHidden };
-  }
-  if (ctrlKey) {
-    const nextSelected = selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
-    return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
-  }
-  const nextSelected = selected.length === 1 && selected[0] === key ? [] : [key];
-  return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
-}
 
 function toggleChromosomeFilter(chr: string, ctrlKey: boolean, altKey: boolean) {
   ({ selected: selectedChromosomes, hidden: hiddenChromosomes } = triStateToggle(

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -14,6 +14,7 @@ import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { EFFECT_COLORS } from '$lib/theme/gene-colors.js';
 import type { AppearanceInfo, Pet } from '$lib/types/index.js';
+import { resolveFilterClick } from '$lib/utils/filterToggle.js';
 import {
   breedFor,
   effectFor,
@@ -22,6 +23,12 @@ import {
   type ParsedChromosome,
   type ParsedGene,
 } from '$lib/utils/geneAnalysis.js';
+import { type GeneEffectLookup, type GeneFilterState, isGeneVisible } from '$lib/utils/geneFilter.js';
+import {
+  updateStats as accumulateStats,
+  initializeStats as buildEmptyStats,
+  type StatsMap,
+} from '$lib/utils/geneStats.js';
 import { handleGridNavigation } from '$lib/utils/keyboard.js';
 import { capitalize } from '$lib/utils/string.js';
 import GeneCell from './GeneCell.svelte';
@@ -94,17 +101,6 @@ interface ChromosomeRow {
   data: ParsedChromosome;
   processedBlocks: Record<string, (ProcessedGene | null)[]>;
 }
-
-// Stats types
-interface AttrStatEntry {
-  positive: number;
-  negative: number;
-  dominant: number;
-  recessive: number;
-  mixed: number;
-}
-
-type StatsMap = Record<string, AttrStatEntry | number>;
 
 const { pet, onStatsUpdated }: Props = $props();
 
@@ -310,22 +306,12 @@ function loadAppearanceConfigForSpecies(species: string) {
   appearanceList = config.appearance_attributes || [];
 }
 
+// Resolve the per-view attribute names then delegate to the pure stats builder.
+// Kept async (awaited by the caller) so the heavy synchronous state writes in
+// createGeneVisualization stay on a later microtask — collapsing that boundary
+// reintroduces an effect_update_depth_exceeded loop.
 async function initializeStats(): Promise<StatsMap> {
   if (currentView === 'attribute') {
-    const emptyAttr = () => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
-    const stats: StatsMap = {
-      positive: 0,
-      negative: 0,
-      neutral: 0,
-      'potential-positive': 0,
-      'potential-negative': 0,
-      'inactive-breed': 0,
-      // Global gene-type counters (unique genes, not per-attribute)
-      _dominant: 0,
-      _recessive: 0,
-      _mixed: 0,
-    };
-
     let attrNames = ALL_ATTRIBUTES.map((a) => a.key);
     if (currentPet?.species) {
       const config = getAttributeConfig(normalizeSpecies(currentPet.species));
@@ -333,71 +319,17 @@ async function initializeStats(): Promise<StatsMap> {
         attrNames = config.all_attribute_names.map((name) => capitalize(name));
       }
     }
-    for (const attr of attrNames) {
-      stats[attr] = emptyAttr();
-    }
-
-    return stats;
-  } else {
-    const stats: StatsMap = { 'appearance-neutral': 0, 'inactive-breed': 0 };
-
-    let attrNames = FALLBACK_APPEARANCE_KEYS;
-    if (currentPet?.species) {
-      const config = getAppearanceConfig(normalizeSpecies(currentPet.species));
-      if (config) {
-        attrNames = config.appearance_attribute_names;
-      }
-    }
-
-    attrNames.forEach((attr) => {
-      stats[attr] = 0;
-    });
-
-    return stats;
-  }
-}
-
-function updateStats(stats: StatsMap, geneAnalysis: GeneAnalysisResult, geneType: string) {
-  // Skip inactive-breed genes from all stats
-  if (geneAnalysis.type === 'inactive-breed') {
-    (stats['inactive-breed'] as number)++;
-    return;
+    return buildEmptyStats('attribute', attrNames);
   }
 
-  if (currentView === 'attribute') {
-    const typeVal = stats[geneAnalysis.type];
-    if (typeof typeVal === 'number') stats[geneAnalysis.type] = typeVal + 1;
-
-    // Global gene-type counters (one per unique gene)
-    if (geneType === 'D') (stats._dominant as number)++;
-    else if (geneType === 'R') (stats._recessive as number)++;
-    else if (geneType === 'x') (stats._mixed as number)++;
-
-    if (geneAnalysis.attribute) {
-      const attrStats = stats[geneAnalysis.attribute];
-      if (attrStats && typeof attrStats === 'object') {
-        const as = attrStats as {
-          dominant: number;
-          recessive: number;
-          mixed: number;
-          positive: number;
-          negative: number;
-        };
-        // Track gene type (D/R/x)
-        if (geneType === 'D') as.dominant++;
-        else if (geneType === 'R') as.recessive++;
-        else if (geneType === 'x') as.mixed++;
-
-        // Only count confirmed positive/negative effects (not potential)
-        if (geneAnalysis.type === 'positive' || geneAnalysis.type === 'negative') {
-          as[geneAnalysis.type]++;
-        }
-      }
+  let attrNames = FALLBACK_APPEARANCE_KEYS;
+  if (currentPet?.species) {
+    const config = getAppearanceConfig(normalizeSpecies(currentPet.species));
+    if (config) {
+      attrNames = config.appearance_attribute_names;
     }
-  } else {
-    const typeVal = stats[geneAnalysis.type];
-    if (typeof typeVal === 'number') stats[geneAnalysis.type] = typeVal + 1;
   }
+  return buildEmptyStats('appearance', attrNames);
 }
 
 function getGeneEffect(speciesKey: string, geneId: string, geneType: string) {
@@ -542,84 +474,6 @@ function analyzePotentialEffectType(species: string, geneId: string) {
   return null;
 }
 
-function isGeneVisible(chromosome: string, gene: ParsedGene, geneAnalysis: GeneAnalysisResult) {
-  const sk = normalizeSpecies(currentPet?.species || '');
-  // Chromosome filter
-  if (selectedChromosomes.length > 0 && !selectedChromosomes.includes(chromosome)) {
-    return false;
-  }
-
-  // Hidden chromosomes
-  if (hiddenChromosomes.includes(chromosome)) {
-    return false;
-  }
-
-  // Attribute filter
-  if (currentView === 'attribute') {
-    if (selectedAttributes.length > 0 && !genePotentiallyAffectsSelectedAttributes(sk, gene.id, selectedAttributes)) {
-      return false;
-    }
-  } else {
-    // Coerce a null attribute to '' (never a selected value) so that, as before,
-    // a gene with no attribute is filtered out when a specific attribute is selected.
-    if (selectedAttributes.length > 0 && !selectedAttributes.includes(geneAnalysis.attribute ?? '')) {
-      return false;
-    }
-  }
-
-  // Hidden attributes
-  if (geneAnalysis.attribute && hiddenAttributes.includes(geneAnalysis.attribute)) {
-    return false;
-  }
-
-  // Effect filter
-  if (currentEffectFilter.length > 0) {
-    let effectType = geneAnalysis.type;
-
-    // Handle potential effects for neutral genes
-    if (geneAnalysis.type === 'neutral' && hasAnyPotentialEffect(sk, gene.id)) {
-      const potentialType = analyzePotentialEffectType(sk, gene.id);
-      if (potentialType) {
-        effectType = potentialType;
-      }
-    }
-
-    const matchesEffect = currentEffectFilter.includes(effectType);
-    if (!matchesEffect) return false;
-  }
-
-  // Hidden effects
-  if (hiddenEffectFilters.length > 0) {
-    let effectType = geneAnalysis.type;
-
-    if (geneAnalysis.type === 'neutral' && hasAnyPotentialEffect(sk, gene.id)) {
-      const potentialType = analyzePotentialEffectType(sk, gene.id);
-      if (potentialType) {
-        effectType = potentialType;
-      }
-    }
-
-    const isHidden = hiddenEffectFilters.includes(effectType);
-    if (isHidden) return false;
-  }
-
-  // Value filter
-  if (currentValueFilter.length > 0) {
-    const geneTypeClass = `gene-${gene.type === 'D' ? 'dominant' : gene.type === 'R' ? 'recessive' : gene.type === 'x' ? 'mixed' : gene.type === '?' ? 'unknown' : 'recessive'}`;
-    const matchesValue = currentValueFilter.some((value) => geneTypeClass.includes(value));
-    if (!matchesValue) return false;
-  }
-
-  // Hidden values
-  if (hiddenValueFilters.length > 0) {
-    const geneTypeClass = `gene-${gene.type === 'D' ? 'dominant' : gene.type === 'R' ? 'recessive' : gene.type === 'x' ? 'mixed' : gene.type === '?' ? 'unknown' : 'recessive'}`;
-    const isHidden = hiddenValueFilters.some((value) => geneTypeClass.includes(value));
-    if (isHidden) return false;
-  }
-
-  return true;
-}
-
 function getContextualAnalysis(species: string, geneId: string, geneAnalysis: GeneAnalysisResult): GeneAnalysisResult {
   if (selectedAttributes.length !== 1 || currentView !== 'attribute' || geneAnalysis.type === 'inactive-breed') {
     return geneAnalysis;
@@ -744,7 +598,7 @@ async function createGeneVisualization() {
           };
 
           geneAnalysisCache.set(cacheKey, processedAnalysis);
-          updateStats(allStats, processedAnalysis, gene.type);
+          accumulateStats(allStats, processedAnalysis, gene.type, currentView as 'attribute' | 'appearance');
         }
       });
 
@@ -809,6 +663,26 @@ async function createGeneVisualization() {
     // Build chromosome data using cached analysis
     const buildTime = isUsingCachedTemplate ? '🔄 Updating chromosome data' : '🏗️ Building chromosome data';
     if (import.meta.env.DEV) console.time(buildTime);
+
+    // Lift component filter state + effect helpers into the pure predicate's inputs.
+    const filterState: GeneFilterState = {
+      selectedChromosomes,
+      hiddenChromosomes,
+      selectedAttributes,
+      hiddenAttributes,
+      currentEffectFilter,
+      hiddenEffectFilters,
+      currentValueFilter,
+      hiddenValueFilters,
+      currentView: currentView as 'attribute' | 'appearance',
+    };
+    const effectLookup: GeneEffectLookup = {
+      affectsSelectedAttributes: (geneId, selected) =>
+        genePotentiallyAffectsSelectedAttributes(speciesKey, geneId, selected),
+      hasAnyPotentialEffect: (geneId) => hasAnyPotentialEffect(speciesKey, geneId),
+      potentialEffectType: (geneId) => analyzePotentialEffectType(speciesKey, geneId),
+    };
+
     chromosomeData = sortedChromosomes.map(([chromosome, data]) => {
       const processedBlocks: Record<string, (ProcessedGene | null)[]> = {};
 
@@ -835,7 +709,7 @@ async function createGeneVisualization() {
             processedBlocks[block][i] = {
               ...gene,
               geneAnalysis: displayAnalysis,
-              isVisible: isGeneVisible(chromosome, gene, geneAnalysis),
+              isVisible: isGeneVisible(chromosome, gene, geneAnalysis, filterState, effectLookup),
             };
           } else {
             processedBlocks[block][i] = null;
@@ -960,82 +834,9 @@ function handleGridKeydown(e: KeyboardEvent) {
   handleGridNavigation(cells, current, e, cols);
 }
 
-function toggleFilterState(
-  selectedArr: string[],
-  hiddenArr: string[],
-  key: string,
-  action: string,
-): { selected: string[]; hidden: string[] } {
-  const isSelected = selectedArr.includes(key);
-  const isHidden = hiddenArr.includes(key);
-
-  if (
-    (action === 'select' && isHidden) ||
-    (action === 'hide' && isSelected) ||
-    (action === 'toggle-select' && isHidden) ||
-    (action === 'toggle-hide' && isSelected)
-  ) {
-    return {
-      selected: selectedArr.filter((k) => k !== key),
-      hidden: hiddenArr.filter((k) => k !== key),
-    };
-  }
-
-  if (action === 'select' || action === 'toggle-select') {
-    if (isSelected) {
-      return {
-        selected: selectedArr.filter((k) => k !== key),
-        hidden: hiddenArr,
-      };
-    } else {
-      return {
-        selected: [...selectedArr, key],
-        hidden: hiddenArr.filter((k) => k !== key),
-      };
-    }
-  }
-
-  if (action === 'hide' || action === 'toggle-hide') {
-    if (isHidden) {
-      return {
-        selected: selectedArr,
-        hidden: hiddenArr.filter((k) => k !== key),
-      };
-    } else {
-      return {
-        selected: selectedArr.filter((k) => k !== key),
-        hidden: [...hiddenArr, key],
-      };
-    }
-  }
-
-  return { selected: selectedArr, hidden: hiddenArr };
-}
-
 export function handleAttributeFilter(event: CustomEvent<{ attribute: string; ctrlKey: boolean; altKey: boolean }>) {
   const { attribute, ctrlKey, altKey } = event.detail;
-
-  let result: { selected: string[]; hidden: string[] };
-  if (altKey) {
-    result = toggleFilterState(selectedAttributes, hiddenAttributes, attribute, 'toggle-hide');
-  } else if (ctrlKey) {
-    result = toggleFilterState(selectedAttributes, hiddenAttributes, attribute, 'toggle-select');
-  } else {
-    if (hiddenAttributes.includes(attribute)) {
-      result = toggleFilterState([], hiddenAttributes, attribute, 'toggle-select');
-    } else if (selectedAttributes.length === 1 && selectedAttributes[0] === attribute) {
-      result = {
-        selected: [],
-        hidden: hiddenAttributes.filter((a) => a !== attribute),
-      };
-    } else {
-      result = {
-        selected: [attribute],
-        hidden: hiddenAttributes.filter((a) => a !== attribute),
-      };
-    }
-  }
-
+  const result = resolveFilterClick(selectedAttributes, hiddenAttributes, attribute, ctrlKey, altKey);
   selectedAttributes = result.selected;
   hiddenAttributes = result.hidden;
   updateVisualization();
@@ -1082,29 +883,7 @@ function handleLegendFilterClick(filterType: string, event: MouseEvent | Keyboar
 }
 
 function handleEffectFilter(effectType: string, isCtrlClick = false, isAltClick = false) {
-  const newFilter = Array.isArray(currentEffectFilter) ? [...currentEffectFilter] : [];
-  const newHidden = Array.isArray(hiddenEffectFilters) ? [...hiddenEffectFilters] : [];
-  let result: { selected: string[]; hidden: string[] };
-
-  if (isAltClick) {
-    result = toggleFilterState(newFilter, newHidden, effectType, 'toggle-hide');
-  } else if (isCtrlClick) {
-    result = toggleFilterState(newFilter, newHidden, effectType, 'toggle-select');
-  } else {
-    if (newHidden.includes(effectType)) {
-      result = toggleFilterState([], newHidden, effectType, 'toggle-select');
-    } else if (newFilter.length === 1 && newFilter[0] === effectType) {
-      result = {
-        selected: [],
-        hidden: newHidden.filter((t) => t !== effectType),
-      };
-    } else {
-      result = {
-        selected: [effectType],
-        hidden: newHidden.filter((t) => t !== effectType),
-      };
-    }
-  }
+  const result = resolveFilterClick(currentEffectFilter, hiddenEffectFilters, effectType, isCtrlClick, isAltClick);
   currentEffectFilter = result.selected;
   hiddenEffectFilters = result.hidden;
   updateVisualization();
@@ -1119,29 +898,7 @@ function handleValueFilter(valueType: string, isCtrlClick = false, isAltClick = 
   };
   const mappedValueType = valueMap[valueType] || valueType;
 
-  const newValueFilter = Array.isArray(currentValueFilter) ? [...currentValueFilter] : [];
-  const newHiddenValues = Array.isArray(hiddenValueFilters) ? [...hiddenValueFilters] : [];
-  let result: { selected: string[]; hidden: string[] };
-
-  if (isAltClick) {
-    result = toggleFilterState(newValueFilter, newHiddenValues, mappedValueType, 'toggle-hide');
-  } else if (isCtrlClick) {
-    result = toggleFilterState(newValueFilter, newHiddenValues, mappedValueType, 'toggle-select');
-  } else {
-    if (newHiddenValues.includes(mappedValueType)) {
-      result = toggleFilterState([], newHiddenValues, mappedValueType, 'toggle-select');
-    } else if (newValueFilter.length === 1 && newValueFilter[0] === mappedValueType) {
-      result = {
-        selected: [],
-        hidden: newHiddenValues.filter((t) => t !== mappedValueType),
-      };
-    } else {
-      result = {
-        selected: [mappedValueType],
-        hidden: newHiddenValues.filter((t) => t !== mappedValueType),
-      };
-    }
-  }
+  const result = resolveFilterClick(currentValueFilter, hiddenValueFilters, mappedValueType, isCtrlClick, isAltClick);
   currentValueFilter = result.selected;
   hiddenValueFilters = result.hidden;
   updateVisualization();

--- a/src/lib/utils/filterToggle.ts
+++ b/src/lib/utils/filterToggle.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure select/hide reducers for the grid filter legends.
+ *
+ * The genome grids drive their filters with click modifiers: a plain click
+ * sets a single selection (or clears it on a second click), Ctrl toggles a
+ * multi-select, Alt toggles a hide. Two distinct reducers exist because the
+ * two grids were written independently and their tri-state semantics differ
+ * (see `triStateToggle` vs `resolveFilterClick`); both are extracted here so
+ * they can be unit-tested rather than living as closures inside components.
+ */
+
+/** A `{ selected, hidden }` filter pair. */
+export interface FilterPair {
+  selected: string[];
+  hidden: string[];
+}
+
+/**
+ * Low-level reducer used by `GeneVisualizer`. Applies one `action` to a key,
+ * keeping the selected/hidden lists mutually exclusive.
+ *
+ * Actions:
+ * - `select` / `toggle-select`: move into (or out of) the selected list
+ * - `hide` / `toggle-hide`: move into (or out of) the hidden list
+ *
+ * `select`/`toggle-select` on a currently-hidden key (and the hide variants on
+ * a currently-selected key) drop it from both lists.
+ */
+export function toggleFilterState(selectedArr: string[], hiddenArr: string[], key: string, action: string): FilterPair {
+  const isSelected = selectedArr.includes(key);
+  const isHidden = hiddenArr.includes(key);
+
+  if (
+    (action === 'select' && isHidden) ||
+    (action === 'hide' && isSelected) ||
+    (action === 'toggle-select' && isHidden) ||
+    (action === 'toggle-hide' && isSelected)
+  ) {
+    return {
+      selected: selectedArr.filter((k) => k !== key),
+      hidden: hiddenArr.filter((k) => k !== key),
+    };
+  }
+
+  if (action === 'select' || action === 'toggle-select') {
+    if (isSelected) {
+      return { selected: selectedArr.filter((k) => k !== key), hidden: hiddenArr };
+    }
+    return { selected: [...selectedArr, key], hidden: hiddenArr.filter((k) => k !== key) };
+  }
+
+  if (action === 'hide' || action === 'toggle-hide') {
+    if (isHidden) {
+      return { selected: selectedArr, hidden: hiddenArr.filter((k) => k !== key) };
+    }
+    return { selected: selectedArr.filter((k) => k !== key), hidden: [...hiddenArr, key] };
+  }
+
+  return { selected: selectedArr, hidden: hiddenArr };
+}
+
+/**
+ * Resolve a legend click into the next filter pair for `GeneVisualizer`. This
+ * is the decision core shared by the attribute / effect / value legend
+ * handlers (the only difference between them was the variable names and a
+ * value-name remap done by the caller).
+ *
+ * - Alt: toggle the key's hidden state
+ * - Ctrl: toggle the key's selected state
+ * - plain click: select the key alone, or clear it if it was the sole
+ *   selection; clicking a hidden key un-hides it
+ */
+export function resolveFilterClick(
+  selectedArr: string[],
+  hiddenArr: string[],
+  key: string,
+  ctrlKey: boolean,
+  altKey: boolean,
+): FilterPair {
+  if (altKey) {
+    return toggleFilterState(selectedArr, hiddenArr, key, 'toggle-hide');
+  }
+  if (ctrlKey) {
+    return toggleFilterState(selectedArr, hiddenArr, key, 'toggle-select');
+  }
+  if (hiddenArr.includes(key)) {
+    return toggleFilterState([], hiddenArr, key, 'toggle-select');
+  }
+  if (selectedArr.length === 1 && selectedArr[0] === key) {
+    return { selected: [], hidden: hiddenArr.filter((k) => k !== key) };
+  }
+  return { selected: [key], hidden: hiddenArr.filter((k) => k !== key) };
+}
+
+/**
+ * Tri-state reducer used by `GenomeGridDiff`. Distinct from `toggleFilterState`
+ * in that Alt toggles hidden *membership* directly (a selected key becomes
+ * hidden), rather than dropping the key from both lists.
+ *
+ * - Alt: toggle the key in the hidden list, always removing it from selected
+ * - Ctrl: toggle the key in the selected list, removing it from hidden
+ * - plain click: select the key alone, or clear it if it was the sole
+ *   selection, removing it from hidden either way
+ */
+export function triStateToggle(
+  key: string,
+  selected: string[],
+  hidden: string[],
+  ctrlKey: boolean,
+  altKey: boolean,
+): FilterPair {
+  if (altKey) {
+    const nextHidden = hidden.includes(key)
+      ? hidden.filter((k) => k !== key)
+      : [...hidden.filter((k) => k !== key), key];
+    return { selected: selected.filter((k) => k !== key), hidden: nextHidden };
+  }
+  if (ctrlKey) {
+    const nextSelected = selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
+    return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
+  }
+  const nextSelected = selected.length === 1 && selected[0] === key ? [] : [key];
+  return { selected: nextSelected, hidden: hidden.filter((k) => k !== key) };
+}

--- a/src/lib/utils/geneFilter.ts
+++ b/src/lib/utils/geneFilter.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure visibility predicate for the gene grid (`GeneVisualizer`).
+ *
+ * `isGeneVisible` used to be a closure inside the component that read its
+ * reactive state and effect helpers directly, so it was unreachable by unit
+ * tests — and the TS migration (#306) silently flipped the appearance-view
+ * attribute filter without any test catching it (fixed in #309). Extracted
+ * here as a pure function taking explicit `state` and an injected
+ * `effectLookup`, so the truth table can be characterised directly.
+ *
+ * Behaviour is byte-for-byte identical to the original closure; only the
+ * inputs are now explicit instead of captured.
+ */
+
+/** The filter state the predicate reads, lifted out of the component. */
+export interface GeneFilterState {
+  selectedChromosomes: string[];
+  hiddenChromosomes: string[];
+  selectedAttributes: string[];
+  hiddenAttributes: string[];
+  currentEffectFilter: string[];
+  hiddenEffectFilters: string[];
+  currentValueFilter: string[];
+  hiddenValueFilters: string[];
+  currentView: 'attribute' | 'appearance';
+}
+
+/**
+ * Effect-database-backed helpers, injected so the predicate stays pure. The
+ * component binds these to the loaded `effectsDB` and the current species; the
+ * tests supply trivial stubs.
+ */
+export interface GeneEffectLookup {
+  /** Whether either allele of `geneId` could affect any of `selectedAttributes` (attribute view). */
+  affectsSelectedAttributes(geneId: string, selectedAttributes: string[]): boolean;
+  /** Whether a `neutral`-typed gene has a latent D/R effect (drives the neutral→potential promotion). */
+  hasAnyPotentialEffect(geneId: string): boolean;
+  /** The promoted potential type for a neutral gene, or null when neither allele is signed. */
+  potentialEffectType(geneId: string): string | null;
+}
+
+interface FilterGene {
+  id: string;
+  type: string;
+}
+
+interface FilterGeneAnalysis {
+  type: string;
+  attribute: string | null;
+}
+
+/** The `gene-<zygosity>` class used by the value filters. */
+function zygosityClass(geneType: string): string {
+  const zygosity =
+    geneType === 'D'
+      ? 'dominant'
+      : geneType === 'R'
+        ? 'recessive'
+        : geneType === 'x'
+          ? 'mixed'
+          : geneType === '?'
+            ? 'unknown'
+            : 'recessive';
+  return `gene-${zygosity}`;
+}
+
+/**
+ * Resolve a gene's effect type for the effect filters, promoting a `neutral`
+ * gene to its latent potential type when it has one.
+ */
+function resolveEffectType(geneId: string, baseType: string, effectLookup: GeneEffectLookup): string {
+  if (baseType === 'neutral' && effectLookup.hasAnyPotentialEffect(geneId)) {
+    const potentialType = effectLookup.potentialEffectType(geneId);
+    if (potentialType) return potentialType;
+  }
+  return baseType;
+}
+
+/** Whether a gene cell should be visible given the active filters. */
+export function isGeneVisible(
+  chromosome: string,
+  gene: FilterGene,
+  geneAnalysis: FilterGeneAnalysis,
+  state: GeneFilterState,
+  effectLookup: GeneEffectLookup,
+): boolean {
+  // Chromosome filter
+  if (state.selectedChromosomes.length > 0 && !state.selectedChromosomes.includes(chromosome)) {
+    return false;
+  }
+
+  // Hidden chromosomes
+  if (state.hiddenChromosomes.includes(chromosome)) {
+    return false;
+  }
+
+  // Attribute filter
+  if (state.currentView === 'attribute') {
+    if (
+      state.selectedAttributes.length > 0 &&
+      !effectLookup.affectsSelectedAttributes(gene.id, state.selectedAttributes)
+    ) {
+      return false;
+    }
+  } else {
+    // Coerce a null attribute to '' (never a selected value) so that a gene
+    // with no attribute is filtered out when a specific attribute is selected.
+    if (state.selectedAttributes.length > 0 && !state.selectedAttributes.includes(geneAnalysis.attribute ?? '')) {
+      return false;
+    }
+  }
+
+  // Hidden attributes
+  if (geneAnalysis.attribute && state.hiddenAttributes.includes(geneAnalysis.attribute)) {
+    return false;
+  }
+
+  // Effect filter
+  if (state.currentEffectFilter.length > 0) {
+    const effectType = resolveEffectType(gene.id, geneAnalysis.type, effectLookup);
+    if (!state.currentEffectFilter.includes(effectType)) return false;
+  }
+
+  // Hidden effects
+  if (state.hiddenEffectFilters.length > 0) {
+    const effectType = resolveEffectType(gene.id, geneAnalysis.type, effectLookup);
+    if (state.hiddenEffectFilters.includes(effectType)) return false;
+  }
+
+  // Value filter
+  if (state.currentValueFilter.length > 0) {
+    const geneTypeClass = zygosityClass(gene.type);
+    if (!state.currentValueFilter.some((value) => geneTypeClass.includes(value))) return false;
+  }
+
+  // Hidden values
+  if (state.hiddenValueFilters.length > 0) {
+    const geneTypeClass = zygosityClass(gene.type);
+    if (state.hiddenValueFilters.some((value) => geneTypeClass.includes(value))) return false;
+  }
+
+  return true;
+}

--- a/src/lib/utils/geneStats.ts
+++ b/src/lib/utils/geneStats.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure stat-accumulation for the gene grid (`GeneVisualizer`).
+ *
+ * `initializeStats` builds the empty per-view stats map and `updateStats`
+ * folds a single analysed gene into it. Both were component methods that read
+ * reactive state directly; lifted here with the view and resolved attribute
+ * names passed in so the accumulation can be characterised by unit tests.
+ */
+
+/** Per-attribute breakdown in the attribute view. */
+export interface AttrStatEntry {
+  positive: number;
+  negative: number;
+  dominant: number;
+  recessive: number;
+  mixed: number;
+}
+
+/** Stats map: scalar counters plus per-attribute entries (attribute view). */
+export type StatsMap = Record<string, AttrStatEntry | number>;
+
+type GeneView = 'attribute' | 'appearance';
+
+interface StatsGeneAnalysis {
+  type: string;
+  attribute: string | null;
+}
+
+/**
+ * Build the empty stats map for a view. `attrNames` is the resolved attribute
+ * list — capitalised attribute names in the attribute view, appearance keys in
+ * the appearance view — so this stays free of config lookups.
+ */
+export function initializeStats(view: GeneView, attrNames: string[]): StatsMap {
+  if (view === 'attribute') {
+    const emptyAttr = (): AttrStatEntry => ({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+    const stats: StatsMap = {
+      positive: 0,
+      negative: 0,
+      neutral: 0,
+      'potential-positive': 0,
+      'potential-negative': 0,
+      'inactive-breed': 0,
+      // Global gene-type counters (unique genes, not per-attribute)
+      _dominant: 0,
+      _recessive: 0,
+      _mixed: 0,
+    };
+    for (const attr of attrNames) {
+      stats[attr] = emptyAttr();
+    }
+    return stats;
+  }
+
+  const stats: StatsMap = { 'appearance-neutral': 0, 'inactive-breed': 0 };
+  for (const attr of attrNames) {
+    stats[attr] = 0;
+  }
+  return stats;
+}
+
+/** Fold a single analysed gene into the stats map (mutates `stats`). */
+export function updateStats(stats: StatsMap, geneAnalysis: StatsGeneAnalysis, geneType: string, view: GeneView): void {
+  // Skip inactive-breed genes from all stats
+  if (geneAnalysis.type === 'inactive-breed') {
+    (stats['inactive-breed'] as number)++;
+    return;
+  }
+
+  if (view === 'attribute') {
+    const typeVal = stats[geneAnalysis.type];
+    if (typeof typeVal === 'number') stats[geneAnalysis.type] = typeVal + 1;
+
+    // Global gene-type counters (one per unique gene)
+    if (geneType === 'D') (stats._dominant as number)++;
+    else if (geneType === 'R') (stats._recessive as number)++;
+    else if (geneType === 'x') (stats._mixed as number)++;
+
+    if (geneAnalysis.attribute) {
+      const attrStats = stats[geneAnalysis.attribute];
+      if (attrStats && typeof attrStats === 'object') {
+        const as = attrStats as AttrStatEntry;
+        // Track gene type (D/R/x)
+        if (geneType === 'D') as.dominant++;
+        else if (geneType === 'R') as.recessive++;
+        else if (geneType === 'x') as.mixed++;
+
+        // Only count confirmed positive/negative effects (not potential)
+        if (geneAnalysis.type === 'positive' || geneAnalysis.type === 'negative') {
+          as[geneAnalysis.type]++;
+        }
+      }
+    }
+  } else {
+    const typeVal = stats[geneAnalysis.type];
+    if (typeof typeVal === 'number') stats[geneAnalysis.type] = typeVal + 1;
+  }
+}

--- a/src/lib/utils/sortColumn.ts
+++ b/src/lib/utils/sortColumn.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure column sort for tabular views (`BreedingPairTable`).
+ *
+ * The comparator was inline in the component's `$derived` sort. The scoring
+ * math behind the numeric columns is covered by `breedingService` tests, but
+ * the string-vs-numeric branch — numeric columns subtract, text columns
+ * `localeCompare` — had no coverage. Extracted as a generic, stable sort so
+ * that branch can be tested directly.
+ */
+
+/**
+ * A sortable column, discriminated on `numeric` so the accessor's return type
+ * is tied to the comparison strategy (subtraction vs `localeCompare`).
+ */
+export type SortableColumn<T> =
+  | { numeric: true; accessor: (r: T) => number }
+  | { numeric: false; accessor: (r: T) => string };
+
+/** Return a new array sorted by `column` in `dir`, leaving `rows` untouched. */
+export function sortByColumn<T>(rows: T[], column: SortableColumn<T>, dir: 'asc' | 'desc'): T[] {
+  const sign = dir === 'asc' ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const cmp = column.numeric
+      ? column.accessor(a) - column.accessor(b)
+      : column.accessor(a).localeCompare(column.accessor(b));
+    return cmp * sign;
+  });
+}

--- a/tests/unit/filterCSS.test.js
+++ b/tests/unit/filterCSS.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+
+const FILTERED = '{ opacity: 0.15 !important; filter: grayscale(1) !important; pointer-events: none !important; }';
+const HIDDEN = '{ display: none !important; }';
+const INACTIVE = '{ background-color: #e8e8ec !important; border-color: #d0d0d6 !important; opacity: 0.5 !important; }';
+const DIMMED = '{ opacity: 0.2 !important; }';
+
+const base = {
+  selectedAttributes: [],
+  hiddenAttributes: [],
+  selectedAppearances: [],
+  hiddenAppearances: [],
+  breedFilter: '',
+  selectedChromosomes: [],
+  hiddenChromosomes: [],
+  showDiffsOnly: false,
+  isHorse: false,
+  currentView: 'attribute',
+  chrBreedRelevance: {},
+};
+
+describe('buildFilterCSS', () => {
+  it('returns an empty string when no filters are active', () => {
+    expect(buildFilterCSS(base)).toBe('');
+  });
+
+  it('dims non-selected attribute cells via a :not() chain', () => {
+    const css = buildFilterCSS({ ...base, selectedAttributes: ['Toughness', 'Speed'] });
+    expect(css).toBe(
+      `.grid-container .gene-cell[data-attr]:not([data-attr="Toughness"]):not([data-attr="Speed"]) ${FILTERED}`,
+    );
+  });
+
+  it('dims a hidden attribute cell directly', () => {
+    const css = buildFilterCSS({ ...base, hiddenAttributes: ['Toughness'] });
+    expect(css).toBe(`.grid-container .gene-cell[data-attr="Toughness"] ${FILTERED}`);
+  });
+
+  it('targets data-appearance in the appearance view', () => {
+    const css = buildFilterCSS({ ...base, currentView: 'appearance', selectedAppearances: ['coat'] });
+    expect(css).toBe(`.grid-container .gene-cell[data-appearance]:not([data-appearance="coat"]) ${FILTERED}`);
+  });
+
+  it('hides chromosomes outside an active selection', () => {
+    const css = buildFilterCSS({ ...base, selectedChromosomes: ['1', '3'] });
+    expect(css).toBe(`.grid-container tr[data-chr]:not([data-chr="1"]):not([data-chr="3"]) ${HIDDEN}`);
+  });
+
+  it('hides explicitly hidden chromosomes', () => {
+    const css = buildFilterCSS({ ...base, hiddenChromosomes: ['2'] });
+    expect(css).toBe(`.grid-container tr[data-chr="2"] ${HIDDEN}`);
+  });
+
+  it('applies breed filtering only for horses', () => {
+    const filters = {
+      ...base,
+      isHorse: true,
+      breedFilter: 'Arabian',
+      chrBreedRelevance: {
+        1: { generic: true, breeds: new Set() },
+        2: { generic: false, breeds: new Set(['Clydesdale']) },
+      },
+    };
+    const css = buildFilterCSS(filters);
+    expect(css).toContain(
+      `.grid-container .gene-cell[data-breed]:not([data-breed=""]):not([data-breed="Arabian"]) ${INACTIVE}`,
+    );
+    // Chromosome 2 is breed-specific and irrelevant to Arabian → hidden; chr 1 is generic → kept.
+    expect(css).toContain(`.grid-container tr[data-chr="2"] ${HIDDEN}`);
+    expect(css).not.toContain('tr[data-chr="1"]');
+  });
+
+  it('ignores the breed filter when not a horse', () => {
+    const css = buildFilterCSS({ ...base, isHorse: false, breedFilter: 'Arabian' });
+    expect(css).toBe('');
+  });
+
+  it('dims non-diff cells and hides diff-free rows in diffs-only mode', () => {
+    const css = buildFilterCSS({ ...base, showDiffsOnly: true });
+    expect(css).toContain(`.grid-container td[data-isdiff="false"][data-hascell="true"] ${DIMMED}`);
+    expect(css).toContain(`.grid-container tr[data-hasdiffs="false"] ${HIDDEN}`);
+  });
+});

--- a/tests/unit/filterToggle.test.js
+++ b/tests/unit/filterToggle.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFilterClick, toggleFilterState, triStateToggle } from '$lib/utils/filterToggle.js';
+
+describe('toggleFilterState', () => {
+  it('selects an unselected key', () => {
+    expect(toggleFilterState([], [], 'a', 'select')).toEqual({ selected: ['a'], hidden: [] });
+  });
+
+  it('toggle-select removes an already-selected key', () => {
+    expect(toggleFilterState(['a'], [], 'a', 'toggle-select')).toEqual({ selected: [], hidden: [] });
+  });
+
+  it('selecting a hidden key drops it from both lists', () => {
+    expect(toggleFilterState([], ['a'], 'a', 'select')).toEqual({ selected: [], hidden: [] });
+  });
+
+  it('hides an un-hidden key, removing it from selected', () => {
+    expect(toggleFilterState(['a'], [], 'a', 'hide')).toEqual({ selected: [], hidden: [] });
+    expect(toggleFilterState([], [], 'a', 'toggle-hide')).toEqual({ selected: [], hidden: ['a'] });
+  });
+
+  it('returns the inputs unchanged for an unknown action', () => {
+    expect(toggleFilterState(['a'], ['b'], 'c', 'bogus')).toEqual({ selected: ['a'], hidden: ['b'] });
+  });
+});
+
+describe('resolveFilterClick', () => {
+  it('plain click selects a key alone', () => {
+    expect(resolveFilterClick(['x'], [], 'a', false, false)).toEqual({ selected: ['a'], hidden: [] });
+  });
+
+  it('plain click on the sole selection clears it', () => {
+    expect(resolveFilterClick(['a'], [], 'a', false, false)).toEqual({ selected: [], hidden: [] });
+  });
+
+  it('plain click on a hidden key un-hides it', () => {
+    expect(resolveFilterClick([], ['a'], 'a', false, false)).toEqual({ selected: [], hidden: [] });
+  });
+
+  it('ctrl click toggles multi-select', () => {
+    expect(resolveFilterClick(['a'], [], 'b', true, false)).toEqual({ selected: ['a', 'b'], hidden: [] });
+  });
+
+  it('alt click toggles hide', () => {
+    expect(resolveFilterClick([], [], 'a', false, true)).toEqual({ selected: [], hidden: ['a'] });
+  });
+});
+
+describe('triStateToggle', () => {
+  it('plain click selects a key alone', () => {
+    expect(triStateToggle('a', ['x'], [], false, false)).toEqual({ selected: ['a'], hidden: [] });
+  });
+
+  it('plain click on the sole selection clears it', () => {
+    expect(triStateToggle('a', ['a'], [], false, false)).toEqual({ selected: [], hidden: [] });
+  });
+
+  it('ctrl click toggles multi-select', () => {
+    expect(triStateToggle('b', ['a'], [], true, false)).toEqual({ selected: ['a', 'b'], hidden: [] });
+    expect(triStateToggle('a', ['a', 'b'], [], true, false)).toEqual({ selected: ['b'], hidden: [] });
+  });
+
+  it('alt click moves a selected key into hidden (unlike toggleFilterState)', () => {
+    // toggleFilterState would drop the key from both lists here; triStateToggle hides it.
+    expect(triStateToggle('a', ['a'], [], false, true)).toEqual({ selected: [], hidden: ['a'] });
+  });
+
+  it('alt click un-hides an already-hidden key', () => {
+    expect(triStateToggle('a', [], ['a'], false, true)).toEqual({ selected: [], hidden: [] });
+  });
+});

--- a/tests/unit/geneFilter.test.js
+++ b/tests/unit/geneFilter.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { isGeneVisible } from '$lib/utils/geneFilter.js';
+
+const empty = {
+  selectedChromosomes: [],
+  hiddenChromosomes: [],
+  selectedAttributes: [],
+  hiddenAttributes: [],
+  currentEffectFilter: [],
+  hiddenEffectFilters: [],
+  currentValueFilter: [],
+  hiddenValueFilters: [],
+  currentView: 'attribute',
+};
+
+// Effect lookup that never matches anything (the common case for filter tests
+// that don't exercise the effect-database-backed branches).
+const noEffects = {
+  affectsSelectedAttributes: () => false,
+  hasAnyPotentialEffect: () => false,
+  potentialEffectType: () => null,
+};
+
+const gene = { id: '01A1', type: 'D' };
+const analysis = { type: 'positive', attribute: 'Toughness' };
+
+describe('isGeneVisible — regression #309', () => {
+  it('appearance view: hides a null-attribute gene when a specific attribute is selected', () => {
+    expect(
+      isGeneVisible(
+        '1',
+        gene,
+        { type: 'inactive-breed', attribute: null },
+        { ...empty, currentView: 'appearance', selectedAttributes: ['Coat'] },
+        noEffects,
+      ),
+    ).toBe(false);
+  });
+
+  it('appearance view: shows a matching-attribute gene when that attribute is selected', () => {
+    expect(
+      isGeneVisible(
+        '1',
+        gene,
+        { type: 'coat', attribute: 'Coat' },
+        { ...empty, currentView: 'appearance', selectedAttributes: ['Coat'] },
+        noEffects,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('isGeneVisible — chromosome filter', () => {
+  it('hides chromosomes outside an active selection', () => {
+    expect(isGeneVisible('2', gene, analysis, { ...empty, selectedChromosomes: ['1'] }, noEffects)).toBe(false);
+  });
+
+  it('shows a chromosome that is in the selection', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, selectedChromosomes: ['1'] }, noEffects)).toBe(true);
+  });
+
+  it('hides an explicitly hidden chromosome', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, hiddenChromosomes: ['1'] }, noEffects)).toBe(false);
+  });
+});
+
+describe('isGeneVisible — attribute filter (attribute view)', () => {
+  it('hides a gene that does not affect any selected attribute', () => {
+    const lookup = { ...noEffects, affectsSelectedAttributes: () => false };
+    expect(isGeneVisible('1', gene, analysis, { ...empty, selectedAttributes: ['Speed'] }, lookup)).toBe(false);
+  });
+
+  it('shows a gene that potentially affects a selected attribute', () => {
+    const lookup = { ...noEffects, affectsSelectedAttributes: () => true };
+    expect(isGeneVisible('1', gene, analysis, { ...empty, selectedAttributes: ['Toughness'] }, lookup)).toBe(true);
+  });
+});
+
+describe('isGeneVisible — hidden attributes', () => {
+  it('hides a gene whose attribute is in the hidden list', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, hiddenAttributes: ['Toughness'] }, noEffects)).toBe(false);
+  });
+
+  it('ignores hidden attributes for a null-attribute gene', () => {
+    const a = { type: 'neutral', attribute: null };
+    expect(isGeneVisible('1', gene, a, { ...empty, hiddenAttributes: ['Toughness'] }, noEffects)).toBe(true);
+  });
+});
+
+describe('isGeneVisible — effect filter', () => {
+  it('shows a gene whose type is in the effect filter', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, currentEffectFilter: ['positive'] }, noEffects)).toBe(true);
+  });
+
+  it('hides a gene whose type is not in the effect filter', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, currentEffectFilter: ['negative'] }, noEffects)).toBe(false);
+  });
+
+  it('promotes a neutral gene to its potential type before matching', () => {
+    const a = { type: 'neutral', attribute: null };
+    const lookup = { ...noEffects, hasAnyPotentialEffect: () => true, potentialEffectType: () => 'potential-positive' };
+    // The neutral gene is promoted to potential-positive and so matches the filter.
+    expect(isGeneVisible('1', gene, a, { ...empty, currentEffectFilter: ['potential-positive'] }, lookup)).toBe(true);
+    // ...and is hidden by a filter that does not include the promoted type.
+    expect(isGeneVisible('1', gene, a, { ...empty, currentEffectFilter: ['neutral'] }, lookup)).toBe(false);
+  });
+
+  it('hides a gene whose type is in the hidden-effects list', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, hiddenEffectFilters: ['positive'] }, noEffects)).toBe(false);
+  });
+});
+
+describe('isGeneVisible — value filter', () => {
+  it('hides a dominant gene when only recessive is selected', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, currentValueFilter: ['gene-recessive'] }, noEffects)).toBe(
+      false,
+    );
+  });
+
+  it('shows a dominant gene when dominant is selected', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, currentValueFilter: ['gene-dominant'] }, noEffects)).toBe(
+      true,
+    );
+  });
+
+  it('hides a dominant gene when dominant is in the hidden-values list', () => {
+    expect(isGeneVisible('1', gene, analysis, { ...empty, hiddenValueFilters: ['gene-dominant'] }, noEffects)).toBe(
+      false,
+    );
+  });
+
+  it('maps an unknown allele (?) to the unknown zygosity class', () => {
+    const unknownGene = { id: '01A1', type: '?' };
+    expect(
+      isGeneVisible('1', unknownGene, analysis, { ...empty, currentValueFilter: ['gene-unknown'] }, noEffects),
+    ).toBe(true);
+  });
+});
+
+describe('isGeneVisible — no filters', () => {
+  it('shows a gene when no filters are active', () => {
+    expect(isGeneVisible('1', gene, analysis, empty, noEffects)).toBe(true);
+  });
+});

--- a/tests/unit/geneFilter.test.js
+++ b/tests/unit/geneFilter.test.js
@@ -31,7 +31,7 @@ describe('isGeneVisible — regression #309', () => {
         '1',
         gene,
         { type: 'inactive-breed', attribute: null },
-        { ...empty, currentView: 'appearance', selectedAttributes: ['Coat'] },
+        { ...empty, currentView: 'appearance', selectedAttributes: ['coat'] },
         noEffects,
       ),
     ).toBe(false);
@@ -42,8 +42,8 @@ describe('isGeneVisible — regression #309', () => {
       isGeneVisible(
         '1',
         gene,
-        { type: 'coat', attribute: 'Coat' },
-        { ...empty, currentView: 'appearance', selectedAttributes: ['Coat'] },
+        { type: 'coat', attribute: 'coat' },
+        { ...empty, currentView: 'appearance', selectedAttributes: ['coat'] },
         noEffects,
       ),
     ).toBe(true);

--- a/tests/unit/geneStats.test.js
+++ b/tests/unit/geneStats.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { initializeStats, updateStats } from '$lib/utils/geneStats.js';
+
+describe('initializeStats — attribute view', () => {
+  const stats = initializeStats('attribute', ['Toughness', 'Speed']);
+
+  it('seeds the scalar effect counters and global gene-type counters', () => {
+    expect(stats.positive).toBe(0);
+    expect(stats.neutral).toBe(0);
+    expect(stats['potential-positive']).toBe(0);
+    expect(stats['inactive-breed']).toBe(0);
+    expect(stats._dominant).toBe(0);
+    expect(stats._recessive).toBe(0);
+    expect(stats._mixed).toBe(0);
+  });
+
+  it('seeds a per-attribute entry for each attribute name', () => {
+    expect(stats.Toughness).toEqual({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+    expect(stats.Speed).toEqual({ positive: 0, negative: 0, dominant: 0, recessive: 0, mixed: 0 });
+  });
+});
+
+describe('initializeStats — appearance view', () => {
+  it('seeds appearance-neutral, inactive-breed, and a zero per appearance key', () => {
+    const stats = initializeStats('appearance', ['coat', 'hair']);
+    expect(stats).toEqual({ 'appearance-neutral': 0, 'inactive-breed': 0, coat: 0, hair: 0 });
+  });
+});
+
+describe('updateStats — attribute view', () => {
+  it('counts a confirmed positive on its attribute and the global counters', () => {
+    const stats = initializeStats('attribute', ['Toughness']);
+    updateStats(stats, { type: 'positive', attribute: 'Toughness' }, 'D', 'attribute');
+    expect(stats.positive).toBe(1);
+    expect(stats._dominant).toBe(1);
+    expect(stats.Toughness).toEqual({ positive: 1, negative: 0, dominant: 1, recessive: 0, mixed: 0 });
+  });
+
+  it('counts a potential effect in the scalar bucket but not as positive/negative on the attribute', () => {
+    const stats = initializeStats('attribute', ['Toughness']);
+    updateStats(stats, { type: 'potential-positive', attribute: 'Toughness' }, 'R', 'attribute');
+    expect(stats['potential-positive']).toBe(1);
+    expect(stats._recessive).toBe(1);
+    expect(stats.Toughness).toEqual({ positive: 0, negative: 0, dominant: 0, recessive: 1, mixed: 0 });
+  });
+
+  it('skips inactive-breed genes from every bucket except its own counter', () => {
+    const stats = initializeStats('attribute', ['Toughness']);
+    updateStats(stats, { type: 'inactive-breed', attribute: null }, 'D', 'attribute');
+    expect(stats['inactive-breed']).toBe(1);
+    expect(stats._dominant).toBe(0);
+    expect(stats.positive).toBe(0);
+  });
+});
+
+describe('updateStats — appearance view', () => {
+  it('counts the appearance category and ignores per-attribute breakdown', () => {
+    const stats = initializeStats('appearance', ['coat']);
+    updateStats(stats, { type: 'coat', attribute: 'coat' }, 'D', 'appearance');
+    expect(stats.coat).toBe(1);
+  });
+
+  it('still skips inactive-breed genes', () => {
+    const stats = initializeStats('appearance', ['coat']);
+    updateStats(stats, { type: 'inactive-breed', attribute: null }, 'D', 'appearance');
+    expect(stats['inactive-breed']).toBe(1);
+    expect(stats.coat).toBe(0);
+  });
+});

--- a/tests/unit/sortColumn.test.js
+++ b/tests/unit/sortColumn.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { sortByColumn } from '$lib/utils/sortColumn.js';
+
+const rows = [
+  { name: 'Charlie', score: 2 },
+  { name: 'alice', score: 10 },
+  { name: 'Bob', score: 2 },
+];
+
+describe('sortByColumn — numeric', () => {
+  const col = { numeric: true, accessor: (r) => r.score };
+
+  it('sorts ascending by subtraction', () => {
+    expect(sortByColumn(rows, col, 'asc').map((r) => r.score)).toEqual([2, 2, 10]);
+  });
+
+  it('sorts descending', () => {
+    expect(sortByColumn(rows, col, 'desc').map((r) => r.score)).toEqual([10, 2, 2]);
+  });
+});
+
+describe('sortByColumn — text', () => {
+  const col = { numeric: false, accessor: (r) => r.name };
+
+  it('sorts by localeCompare (case-insensitive ordering, not raw charCode)', () => {
+    // A raw `<` comparison would put 'Charlie' before 'alice' (uppercase first);
+    // localeCompare orders alphabetically regardless of case.
+    expect(sortByColumn(rows, col, 'asc').map((r) => r.name)).toEqual(['alice', 'Bob', 'Charlie']);
+  });
+
+  it('reverses for descending', () => {
+    expect(sortByColumn(rows, col, 'desc').map((r) => r.name)).toEqual(['Charlie', 'Bob', 'alice']);
+  });
+});
+
+describe('sortByColumn — purity', () => {
+  it('does not mutate the input array', () => {
+    const input = [...rows];
+    sortByColumn(input, { numeric: true, accessor: (r) => r.score }, 'asc');
+    expect(input).toEqual(rows);
+  });
+});


### PR DESCRIPTION
Closes #310.

Extracts pure decision logic out of the migrated grid components into `$lib/utils` so it can be unit-tested, then adds truth-table / characterization tests. Behavior-preserving.

## New utils + tests
- `geneFilter.ts` — `isGeneVisible` as a pure predicate over an explicit `GeneFilterState` plus an injected `GeneEffectLookup` (so the effect-DB helpers stay out of the predicate). Tests cover the #309 regression (appearance view hides a null-attribute gene when a specific attribute is selected), chromosome include/exclude, hidden attributes, both views, the effect filter, and the neutral→potential promotion.
- `filterToggle.ts` — `toggleFilterState` + `resolveFilterClick` (GeneVisualizer's legend reducers, which the three filter handlers now share) and `triStateToggle` (GenomeGridDiff). The two reducers differ in Alt semantics; kept separate and tested accordingly.
- `geneStats.ts` — `initializeStats`/`updateStats` accumulation.
- `sortColumn.ts` — generic numeric-vs-text column comparator (the path the `breedingService` tests don't reach).
- Adds a unit test for the already-pure but untested `buildFilterCSS`.

## Wiring
`GeneVisualizer`, `GenomeGridDiff`, and `BreedingPairTable` now import these utils; ~320 lines of in-component logic removed.

## Scope
Covers the migrated components. `pet/`, `layout/`, `stable/` are deferred until their TS migration (#306), per the issue.

## Gotcha
`initializeStats` stays `async` (awaited in `createGeneVisualization`). Collapsing that microtask boundary moves the heavy `$state` writes earlier and reintroduces an `effect_update_depth_exceeded` loop.

## Verification
- `pnpm test` — 708 unit tests pass (55 new)
- `pnpm check` — 0 errors
- `pnpm run lint:ci` — clean
- `pnpm test:e2e` — 135 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)