### PR TITLE
refactor(types): migrate pet/ components to TS (#306)

### DIFF
--- a/src/lib/components/pet/PetCard.svelte
+++ b/src/lib/components/pet/PetCard.svelte
@@ -1,15 +1,25 @@
-<script>
+<script lang="ts">
 import { House, PawPrint, Star } from '@lucide/svelte';
+import type { MarkerKey } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
 
-const { pet, selected = false, onclick, onkeydown, onToggleMarker } = $props();
+interface Props {
+  pet: Pet;
+  selected?: boolean;
+  onclick?: (pet: Pet) => void;
+  onkeydown?: (e: KeyboardEvent) => void;
+  onToggleMarker?: (id: number, key: MarkerKey, value: boolean) => void;
+}
 
-function toggleMarker(e, key, value) {
+const { pet, selected = false, onclick, onkeydown, onToggleMarker }: Props = $props();
+
+function toggleMarker(e: MouseEvent, key: MarkerKey, value: boolean) {
   e.stopPropagation();
   onToggleMarker?.(pet.id, key, value);
 }
 
-function handleKey(e) {
+function handleKey(e: KeyboardEvent) {
   // Ignore keys that bubbled up from inner marker buttons — they handle
   // Space/Enter themselves; otherwise hitting those on a marker would also
   // fire the card's own "select pet" action.

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -1,65 +1,76 @@
-<script>
+<script lang="ts">
 import { House, PawPrint, Star } from '@lucide/svelte';
 import { untrack } from 'svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
 import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
+import type { AttributeInfo, Gender, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import TagInput from './TagInput.svelte';
 
-const ALL_ATTRIBUTES = getAllAttributeDisplayInfo();
+interface Props {
+  pet: Pet;
+  open: boolean;
+  onClose?: () => void;
+  onSave?: (petId: number) => void;
+}
 
-let { pet, open = $bindable(), onClose, onSave } = $props();
+const ALL_ATTRIBUTES: AttributeInfo[] = getAllAttributeDisplayInfo();
 
-const BREED_OPTIONS = {
+let { pet, open = $bindable(), onClose, onSave }: Props = $props();
+
+const BREED_OPTIONS: Record<string, string[]> = {
   BeeWasp: ['Bee', 'Wasp'],
   Horse: Object.keys(HORSE_BREEDS),
   default: ['Mixed'],
 };
 
-const getBreedOptions = (species) => BREED_OPTIONS[species] || BREED_OPTIONS.default;
-const breedOptions = $derived(getBreedOptions(pet.species));
+const getBreedOptions = (species: string): string[] => BREED_OPTIONS[species] ?? BREED_OPTIONS.default;
+const breedOptions: string[] = $derived(getBreedOptions(pet.species));
 
-function initEditState(p) {
+function initEditState(p: Pet): { name: string; gender: Gender; breed: string; attributes: Record<string, number> } {
   const opts = getBreedOptions(p.species);
   return {
     name: p.name || '',
-    gender: p.gender || 'Male',
+    gender: (p.gender || 'Male') as Gender,
     breed: opts.includes(p.breed) ? p.breed : opts[0],
     attributes: Object.fromEntries(
-      ALL_ATTRIBUTES.map((attr) => [attr.key.toLowerCase(), p[attr.key.toLowerCase()] ?? 50]),
+      ALL_ATTRIBUTES.map((attr) => [
+        attr.key.toLowerCase(),
+        ((p as unknown as Record<string, unknown>)[attr.key.toLowerCase()] as number) ?? 50,
+      ]),
     ),
   };
 }
 
 const initial = untrack(() => initEditState(pet));
-let editName = $state(initial.name);
-let editGender = $state(initial.gender);
-let editBreed = $state(initial.breed);
-const editAttributes = $state(initial.attributes);
-let editTags = $state(untrack(() => [...(pet.tags ?? [])]));
-let editStarred = $state(untrack(() => !!pet.starred));
-let editStabled = $state(untrack(() => !!pet.stabled));
-let editIsPetQuality = $state(untrack(() => !!pet.is_pet_quality));
-let saveError = $state('');
+let editName: string = $state(initial.name);
+let editGender: Gender = $state(initial.gender);
+let editBreed: string = $state(initial.breed);
+const editAttributes: Record<string, number> = $state(initial.attributes);
+let editTags: string[] = $state(untrack(() => [...(pet.tags ?? [])]));
+let editStarred: boolean = $state(untrack(() => !!pet.starred));
+let editStabled: boolean = $state(untrack(() => !!pet.stabled));
+let editIsPetQuality: boolean = $state(untrack(() => !!pet.is_pet_quality));
+let saveError: string = $state('');
 
-const allTags = $derived($allTagsStore);
+const allTags: string[] = $derived($allTagsStore);
 
-const availableAttributes = $derived(getAllAttributeNames(pet.species));
-const filteredAttributeList = $derived(
+const availableAttributes: string[] = $derived(getAllAttributeNames(pet.species));
+const filteredAttributeList: AttributeInfo[] = $derived(
   ALL_ATTRIBUTES.filter((attr) => availableAttributes.includes(attr.key.toLowerCase())),
 );
 
-async function handleSave() {
+async function handleSave(): Promise<void> {
   try {
-    const updateData = {};
+    const updateData: Record<string, unknown> = {};
     if (editName.trim() !== pet.name) updateData.name = editName.trim();
     if (editGender !== pet.gender) updateData.gender = editGender;
     if (editBreed.trim() !== (pet.breed || 'Mixed')) updateData.breed = editBreed.trim();
 
-    const attributeChanges = {};
+    const attributeChanges: Record<string, number> = {};
     for (const [key, value] of Object.entries(editAttributes)) {
-      if (pet[key] !== value) attributeChanges[key] = value;
+      if ((pet as unknown as Record<string, unknown>)[key] !== value) attributeChanges[key] = value;
     }
     if (Object.keys(attributeChanges).length > 0) updateData.attributes = attributeChanges;
 
@@ -80,25 +91,25 @@ async function handleSave() {
     open = false;
     onClose?.();
   } catch (err) {
-    saveError = err.message || 'Failed to save changes.';
+    saveError = (err as Error).message || 'Failed to save changes.';
   }
 }
 
-function handleCancel() {
+function handleCancel(): void {
   saveError = '';
   open = false;
   onClose?.();
 }
 
-function handleBackdropClick(e) {
+function handleBackdropClick(e: MouseEvent): void {
   if (e.target === e.currentTarget) handleCancel();
 }
 
-function handleKeydown(e) {
+function handleKeydown(e: KeyboardEvent): void {
   if (e.key === 'Escape') handleCancel();
 }
 
-function updateAttribute(attrKey, value) {
+function updateAttribute(attrKey: string, value: string): void {
   editAttributes[attrKey] = Number.parseInt(value, 10) || 0;
 }
 </script>
@@ -209,7 +220,7 @@ function updateAttribute(attrKey, value) {
                 min="0"
                 max="100"
                 value={editAttributes[attr.key.toLowerCase()] ?? 50}
-                oninput={(e) => updateAttribute(attr.key.toLowerCase(), e.target.value)}
+                oninput={(e) => updateAttribute(attr.key.toLowerCase(), (e.currentTarget as HTMLInputElement).value)}
               />
             </div>
           {/each}

--- a/src/lib/components/pet/PetImageGallery.svelte
+++ b/src/lib/components/pet/PetImageGallery.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 import { onDestroy } from 'svelte';
 import {
   deleteImage,
@@ -7,35 +7,40 @@ import {
   reorderImages,
   uploadImage,
 } from '$lib/services/imageService.js';
+import type { Pet, PetImage } from '$lib/types/index.js';
 import { arrayMove, createDragState, createKeyboardReorder } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getBasename } from '$lib/utils/path.js';
 
-const { pet } = $props();
+interface Props {
+  pet: Pet;
+}
 
-let images = $state([]);
-let uploading = $state(false);
-let uploadProgress = $state(null);
-let lightboxIndex = $state(-1);
-let deleteTarget = $state(null);
-let statusMessage = $state(null);
-let statusTimer = null;
+const { pet }: Props = $props();
+
+let images = $state<PetImage[]>([]);
+let uploading = $state<boolean>(false);
+let uploadProgress = $state<{ current: number; total: number } | null>(null);
+let lightboxIndex = $state<number>(-1);
+let deleteTarget = $state<PetImage | null>(null);
+let statusMessage = $state<string | null>(null);
+let statusTimer: ReturnType<typeof setTimeout> | null = null;
 
 const lightboxImage = $derived(lightboxIndex >= 0 ? images[lightboxIndex] : null);
 
-async function loadImages() {
+async function loadImages(): Promise<void> {
   if (!pet?.id) return;
   images = await getImagesForPet(pet.id);
 }
 
-async function handleUpload() {
+async function handleUpload(): Promise<void> {
   const paths = await pickImageFiles();
   if (paths.length === 0) return;
 
   uploading = true;
   const total = paths.length;
-  const failures = [];
+  const failures: string[] = [];
 
   // Sequential upload — consider parallel with concurrency limit if this becomes a bottleneck
   for (let i = 0; i < paths.length; i++) {
@@ -59,44 +64,44 @@ async function handleUpload() {
     statusMessage = `Uploaded ${total} image${total > 1 ? 's' : ''}`;
   }
   if (statusMessage) {
-    clearTimeout(statusTimer);
+    clearTimeout(statusTimer ?? undefined);
     statusTimer = setTimeout(() => {
       statusMessage = null;
     }, 5000);
   }
 }
 
-function openLightbox(index) {
+function openLightbox(index: number): void {
   lightboxIndex = index;
 }
 
-function closeLightbox() {
+function closeLightbox(): void {
   lightboxIndex = -1;
 }
 
-function prevImage() {
+function prevImage(): void {
   if (lightboxIndex > 0) lightboxIndex--;
 }
 
-function nextImage() {
+function nextImage(): void {
   if (lightboxIndex < images.length - 1) lightboxIndex++;
 }
 
-function handleLightboxKey(e) {
+function handleLightboxKey(e: KeyboardEvent): void {
   if (e.key === 'Escape') closeLightbox();
   else if (e.key === 'ArrowLeft') prevImage();
   else if (e.key === 'ArrowRight') nextImage();
 }
 
-function confirmDelete(img) {
+function confirmDelete(img: PetImage): void {
   deleteTarget = img;
 }
 
-function cancelDelete() {
+function cancelDelete(): void {
   deleteTarget = null;
 }
 
-async function executeDelete() {
+async function executeDelete(): Promise<void> {
   if (!deleteTarget) return;
   try {
     await deleteImage(deleteTarget.id, deleteTarget.pet_id, deleteTarget.filename);
@@ -113,7 +118,7 @@ async function executeDelete() {
 
 const drag = createDragState();
 
-async function handleDrop(e, dropIndex) {
+async function handleDrop(e: DragEvent, dropIndex: number): Promise<void> {
   e.preventDefault();
   drag.dragOverIndex = null;
   if (drag.draggedIndex === null || drag.draggedIndex === dropIndex) return;
@@ -129,7 +134,7 @@ async function handleDrop(e, dropIndex) {
   drag.draggedIndex = null;
 
   try {
-    await reorderImages(reordered.map((img) => img.id));
+    await reorderImages(images.map((img) => img.id));
   } catch {
     images = previous;
   }
@@ -140,27 +145,27 @@ async function handleDrop(e, dropIndex) {
 // the `images` index. If image filtering is ever added, gate the handle (as
 // PetList does with `isDraggable`) and map indices by id, or this will reorder
 // by a misaligned index.
-let reorderAnnouncement = $state('');
+let reorderAnnouncement = $state<string>('');
 const kbReorder = createKeyboardReorder({
   count: () => images.length,
-  reorder: (from, to) => {
+  reorder: (from: number, to: number) => {
     images = arrayMove(images, from, to);
   },
   persist: () => reorderImages(images.map((img) => img.id)),
   snapshot: () => [...images],
-  restore: (snap) => {
-    images = snap;
+  restore: (snap: unknown) => {
+    images = snap as PetImage[];
   },
-  label: (i) => images[i]?.original_name || 'image',
-  announce: (msg) => {
+  label: (i: number) => images[i]?.original_name || 'image',
+  announce: (msg: string) => {
     reorderAnnouncement = msg;
   },
-  focusItem: (i) => {
-    document.querySelectorAll('.thumbnail-grid .reorder-handle')[i]?.focus();
+  focusItem: (i: number) => {
+    document.querySelectorAll<HTMLElement>('.thumbnail-grid .reorder-handle')[i]?.focus();
   },
 });
 
-onDestroy(() => clearTimeout(statusTimer));
+onDestroy(() => clearTimeout(statusTimer ?? undefined));
 
 $effect(() => {
   const _id = pet?.id;

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -14,6 +14,7 @@ import { focusTrap } from '$lib/utils/focusTrap.js';
 import type { UploadSource } from '$lib/utils/genomeUpload.js';
 import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
 import { getBasename } from '$lib/utils/path.js';
+import { filterPets } from '$lib/utils/petFilter.js';
 import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
 
@@ -79,23 +80,9 @@ $effect(() => {
   return () => clearTimeout(timer);
 });
 
-const filteredPets = $derived.by((): Pet[] => {
-  const q = debouncedSearchQuery ? debouncedSearchQuery.toLowerCase() : '';
-  return $pets.filter((pet: Pet) => {
-    if (q) {
-      if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
-        return false;
-      }
-    }
-    if (selectedTags.length > 0) {
-      const petTags = pet.tags ?? [];
-      if (!selectedTags.every((t) => petTags.includes(t))) return false;
-    }
-    if (starredOnly && !pet.starred) return false;
-    if (stabledOnly && !pet.stabled) return false;
-    return true;
-  });
-});
+const filteredPets = $derived.by((): Pet[] =>
+  filterPets($pets, { query: debouncedSearchQuery, tags: selectedTags, starredOnly, stabledOnly }),
+);
 
 function toggleTagFilter(tag: string): void {
   if (selectedTags.includes(tag)) {

--- a/src/lib/components/pet/PetList.svelte
+++ b/src/lib/components/pet/PetList.svelte
@@ -1,24 +1,27 @@
-<script>
+<script lang="ts">
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { compareSelectMode, comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { pendingImportCount, refreshPendingImportCount } from '$lib/stores/gameImport.js';
+import type { MarkerKey } from '$lib/stores/pets.js';
 import { allTags as allTagsStore, appState, error, pets, selectedPet } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
 import { createDragState, createKeyboardReorder, moveByFilteredIndex } from '$lib/utils/dragReorder.svelte.js';
 import { errorMessage } from '$lib/utils/error.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
+import type { UploadSource } from '$lib/utils/genomeUpload.js';
 import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
 import { getBasename } from '$lib/utils/path.js';
 import PetCard from './PetCard.svelte';
 import PetEditor from './PetEditor.svelte';
 
-function isSelectedForComparison(petId) {
+function isSelectedForComparison(petId: number): boolean {
   return $comparisonPets[0]?.id === petId || $comparisonPets[1]?.id === petId;
 }
 
-function toggleComparisonPet(pet) {
+function toggleComparisonPet(pet: Pet): void {
   if (isSelectedForComparison(pet.id)) {
     comparisonActions.removePet(pet.id);
   } else {
@@ -26,7 +29,7 @@ function toggleComparisonPet(pet) {
   }
 }
 
-function isCompareDisabled(pet) {
+function isCompareDisabled(pet: Pet): boolean {
   if (isSelectedForComparison(pet.id)) return false;
   if ($comparisonReady) return true;
   // Disable different species when first pet is selected
@@ -35,7 +38,7 @@ function isCompareDisabled(pet) {
   return false;
 }
 
-function startCompare() {
+function startCompare(): void {
   comparisonActions.toggleSelectMode();
   appState.switchTab('compare');
 }
@@ -45,16 +48,16 @@ let searchQuery = $state('');
 // $derived.by below doesn't replay the whole filter on every keystroke.
 let debouncedSearchQuery = $state('');
 const SEARCH_DEBOUNCE_MS = 150;
-let selectedTags = $state([]);
+let selectedTags = $state<string[]>([]);
 let starredOnly = $state(false);
 let stabledOnly = $state(true);
 let uploading = $state(false);
-let uploadProgress = $state(null);
+let uploadProgress = $state<{ current: number; total: number } | null>(null);
 let autoScanning = $state(false);
-let autoScanProgress = $state(null);
+let autoScanProgress = $state<{ current: number; total: number } | null>(null);
 let showEditor = $state(false);
-let editingPet = $state(null);
-let deletingPet = $state(null);
+let editingPet = $state<Pet | null>(null);
+let deletingPet = $state<Pet | null>(null);
 
 const availableTags = $derived($allTagsStore);
 
@@ -76,9 +79,9 @@ $effect(() => {
   return () => clearTimeout(timer);
 });
 
-const filteredPets = $derived.by(() => {
+const filteredPets = $derived.by((): Pet[] => {
   const q = debouncedSearchQuery ? debouncedSearchQuery.toLowerCase() : '';
-  return $pets.filter((pet) => {
+  return $pets.filter((pet: Pet) => {
     if (q) {
       if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
         return false;
@@ -94,7 +97,7 @@ const filteredPets = $derived.by(() => {
   });
 });
 
-function toggleTagFilter(tag) {
+function toggleTagFilter(tag: string): void {
   if (selectedTags.includes(tag)) {
     selectedTags = selectedTags.filter((t) => t !== tag);
   } else {
@@ -102,12 +105,12 @@ function toggleTagFilter(tag) {
   }
 }
 
-function selectPet(pet) {
+function selectPet(pet: Pet): void {
   appState.selectPet(pet);
 }
 
-async function toggleMarker(petId, key, value) {
-  const pet = $pets.find((p) => p.id === petId);
+async function toggleMarker(petId: number, key: MarkerKey, value: boolean): Promise<void> {
+  const pet = $pets.find((p: Pet) => p.id === petId);
   if (!pet || pet[key] === value) return;
   // Optimistic in-place flip — no full list reload, so the toggle is
   // instant (#275). Errors are surfaced via the shared `error` store.
@@ -117,14 +120,14 @@ async function toggleMarker(petId, key, value) {
 // Upload a batch of genome sources (file paths or dropped files), reusing the
 // shared sequential runner. Reloads the list once and surfaces a per-file
 // failure summary. Guarded so picker and drop uploads can't run concurrently.
-async function uploadSources(sources) {
+async function uploadSources(sources: UploadSource[]): Promise<void> {
   if (sources.length === 0 || uploading || autoScanning) return;
   uploading = true;
   error.set(null);
   try {
     const { total, succeeded, failures } = await runGenomeUpload(sources, {
-      upload: (content) => appState.uploadPetQuiet(content),
-      onProgress: (current, t) => {
+      upload: (content: string) => appState.uploadPetQuiet(content),
+      onProgress: (current: number, t: number) => {
         uploadProgress = { current, total: t };
       },
     });
@@ -140,8 +143,8 @@ async function uploadSources(sources) {
   }
 }
 
-async function handleUpload() {
-  let filePaths;
+async function handleUpload(): Promise<void> {
+  let filePaths: string[];
   try {
     filePaths = await pickGenomeFiles();
   } catch (err) {
@@ -158,22 +161,22 @@ async function handleUpload() {
 // don't — so isFileDrag() tells the two apart.
 let fileDragActive = $state(false);
 
-function handleFileDragOver(e) {
+function handleFileDragOver(e: DragEvent): void {
   if (!isFileDrag(e.dataTransfer)) return;
   e.preventDefault();
   if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
   fileDragActive = true;
 }
 
-function handleFileDragLeave(e) {
+function handleFileDragLeave(e: DragEvent & { currentTarget: EventTarget & Element }): void {
   if (!isFileDrag(e.dataTransfer)) return;
   // Ignore leaves into descendant elements; only clear when the cursor leaves
   // the panel entirely (relatedTarget is null when leaving the window).
-  if (e.currentTarget.contains(e.relatedTarget)) return;
+  if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
   fileDragActive = false;
 }
 
-async function handleFileDrop(e) {
+async function handleFileDrop(e: DragEvent): Promise<void> {
   if (!isFileDrag(e.dataTransfer)) return;
   e.preventDefault();
   fileDragActive = false;
@@ -185,7 +188,7 @@ async function handleFileDrop(e) {
     error.set('No genome files (.txt) in the dropped items.');
     return;
   }
-  await uploadSources(accepted.map((file) => ({ name: file.name, read: () => file.text() })));
+  await uploadSources(accepted.map((file: File) => ({ name: file.name, read: () => file.text() })));
   if (rejected.length > 0 && !$error) {
     error.set(`Skipped ${rejected.length} non-genome file${rejected.length === 1 ? '' : 's'}.`);
   }
@@ -194,17 +197,17 @@ async function handleFileDrop(e) {
 // External file drags also bubble through the per-card reorder handlers. Skip
 // the reorder path for them so they don't show the reorder indicator or fight
 // the panel-level drop handler.
-function handleCardDragOver(e, index) {
+function handleCardDragOver(e: DragEvent, index: number): void {
   if (isFileDrag(e.dataTransfer)) return;
   drag.handleDragOver(e, index);
 }
 
-async function handleAutoScan() {
+async function handleAutoScan(): Promise<void> {
   try {
     autoScanning = true;
     error.set(null);
     const result = await autoScanGameFolder({
-      onProgress: (current, total) => {
+      onProgress: (current: number, total: number) => {
         autoScanProgress = { current, total };
       },
     });
@@ -226,7 +229,7 @@ async function handleAutoScan() {
     const backfillNote = result.backfilled > 0 ? `, ${result.backfilled} unlocked for sharing` : '';
     const summary = `Auto-import: ${result.imported} new, ${result.skipped} already imported${backfillNote} (of ${result.scanned} files).`;
     if (result.failures.length > 0) {
-      const lines = result.failures.map((f) => `${f.file}: ${f.reason}`);
+      const lines = result.failures.map((f: { file: string; reason: string }) => `${f.file}: ${f.reason}`);
       error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);
     } else if (result.imported > 0 || result.backfilled > 0) {
       error.set(summary);
@@ -241,27 +244,27 @@ async function handleAutoScan() {
   }
 }
 
-function closeEditor() {
+function closeEditor(): void {
   showEditor = false;
   editingPet = null;
 }
 
-function handleDelete(pet) {
+function handleDelete(pet: Pet): void {
   deletingPet = pet;
 }
 
-async function confirmDelete() {
+async function confirmDelete(): Promise<void> {
   if (deletingPet) {
     await appState.deletePet(deletingPet.id);
     deletingPet = null;
   }
 }
 
-function cancelDelete() {
+function cancelDelete(): void {
   deletingPet = null;
 }
 
-function handlePetCardKeydown(e, index) {
+function handlePetCardKeydown(e: KeyboardEvent, index: number): void {
   const len = filteredPets.length;
   if (len === 0) return;
 
@@ -281,7 +284,7 @@ function handlePetCardKeydown(e, index) {
   }
 
   if (nextIndex >= 0 && nextIndex !== index) {
-    const cards = document.querySelectorAll('.pet-list-items .pet-card');
+    const cards = document.querySelectorAll<HTMLElement>('.pet-list-items .pet-card');
     cards[nextIndex]?.focus();
   }
 }
@@ -289,7 +292,7 @@ function handlePetCardKeydown(e, index) {
 const drag = createDragState();
 const isDraggable = $derived(!searchQuery && selectedTags.length === 0);
 
-async function handleDrop(e, dropIndex) {
+async function handleDrop(e: DragEvent, dropIndex: number): Promise<void> {
   e.preventDefault();
   drag.dragOverIndex = null;
   if (drag.draggedIndex === null || drag.draggedIndex === dropIndex) return;
@@ -303,7 +306,7 @@ async function handleDrop(e, dropIndex) {
 
   const previous = [...$pets];
   const reordered = [...$pets];
-  const fromIdx = reordered.findIndex((p) => p.id === fromPet.id);
+  const fromIdx = reordered.findIndex((p: Pet) => p.id === fromPet.id);
   if (fromIdx < 0) {
     drag.draggedIndex = null;
     return;
@@ -318,7 +321,7 @@ async function handleDrop(e, dropIndex) {
       drag.draggedIndex = null;
       return;
     }
-    const toIdx = reordered.findIndex((p) => p.id === toPet.id);
+    const toIdx = reordered.findIndex((p: Pet) => p.id === toPet.id);
     if (toIdx < 0) {
       drag.draggedIndex = null;
       return;
@@ -329,7 +332,7 @@ async function handleDrop(e, dropIndex) {
   drag.draggedIndex = null;
 
   try {
-    await appState.reorderPets(reordered.map((p) => p.id));
+    await appState.reorderPets(reordered.map((p: Pet) => p.id));
   } catch {
     pets.set(previous);
   }
@@ -343,16 +346,16 @@ async function handleDrop(e, dropIndex) {
 let reorderAnnouncement = $state('');
 const kbReorder = createKeyboardReorder({
   count: () => filteredPets.length,
-  reorder: (from, to) => pets.set(moveByFilteredIndex($pets, filteredPets, from, to, (p) => p.id)),
-  persist: () => appState.reorderPets($pets.map((p) => p.id)),
+  reorder: (from: number, to: number) => pets.set(moveByFilteredIndex($pets, filteredPets, from, to, (p: Pet) => p.id)),
+  persist: () => appState.reorderPets($pets.map((p: Pet) => p.id)),
   snapshot: () => [...$pets],
-  restore: (snap) => pets.set(snap),
-  label: (i) => filteredPets[i]?.name || 'Unnamed',
-  announce: (msg) => {
+  restore: (snap: unknown) => pets.set(snap as Pet[]),
+  label: (i: number) => filteredPets[i]?.name || 'Unnamed',
+  announce: (msg: string) => {
     reorderAnnouncement = msg;
   },
-  focusItem: (i) => {
-    document.querySelectorAll('.pet-list-items .reorder-handle')[i]?.focus();
+  focusItem: (i: number) => {
+    document.querySelectorAll<HTMLElement>('.pet-list-items .reorder-handle')[i]?.focus();
   },
 });
 </script>

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -1,28 +1,48 @@
-<script>
+<script lang="ts">
 import { onDestroy } from 'svelte';
 import SharePetDialog from '$lib/components/community/SharePetDialog.svelte';
 import GeneStatsTable from '$lib/components/gene/GeneStatsTable.svelte';
 import GeneVisualizer from '$lib/components/gene/GeneVisualizer.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { settings } from '$lib/stores/settings.js';
+import type { DialogResult, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
+import type { StatsMap } from '$lib/utils/geneStats.js';
 import PetImageGallery from './PetImageGallery.svelte';
 
-const { pet } = $props();
+interface GeneVisualizerInstance {
+  getStatsData(): {
+    currentStats: StatsMap | null;
+    currentView: string;
+    selectedAttributes: string[];
+    hiddenAttributes: string[];
+    totalGenes: number;
+    neutralGenes: number;
+    petSpecies: string | undefined;
+  };
+  handleViewChange(view: string): void;
+  handleAttributeFilter(event: CustomEvent<{ attribute: string; ctrlKey: boolean; altKey: boolean }>): void;
+  setBreedFilter(breed: string): void;
+}
 
-let geneVisualizerRef = $state();
+interface Props {
+  pet?: Pet | null;
+}
+
+const { pet }: Props = $props();
+
+let geneVisualizerRef = $state<GeneVisualizerInstance | undefined>(undefined);
 let currentView = $state('attribute');
 let statsOpen = $state(false);
 let galleryOpen = $state(false);
-let drawerWidth = $state(320);
-let stats = $state(null);
+let drawerWidth = $state<number>(320);
+let stats = $state<ReturnType<GeneVisualizerInstance['getStatsData']> | null>(null);
 let breedFilter = $state('');
 let autoBreed = $state(false);
 let showShare = $state(false);
-/** @type {import('$lib/types/index.js').DialogResult | null} */
-let shareStatus = $state(null);
+let shareStatus = $state<DialogResult | null>(null);
 
-function handleShareResult(result) {
+function handleShareResult(result: DialogResult): void {
   shareStatus = result;
 }
 
@@ -37,7 +57,7 @@ $effect(() => {
 
 // Apply the breed filter whenever autoBreed or pet changes
 $effect(() => {
-  if (autoBreed && petHasKnownBreed) {
+  if (autoBreed && petHasKnownBreed && pet) {
     breedFilter = pet.breed;
   }
   if (geneVisualizerRef) {
@@ -45,9 +65,9 @@ $effect(() => {
   }
 });
 
-function toggleAutoBreed() {
+function toggleAutoBreed(): void {
   autoBreed = !autoBreed;
-  if (autoBreed && petHasKnownBreed) {
+  if (autoBreed && petHasKnownBreed && pet) {
     breedFilter = pet.breed;
   } else {
     breedFilter = '';
@@ -57,7 +77,7 @@ function toggleAutoBreed() {
   }
 }
 
-function setBreedFilter(fullName) {
+function setBreedFilter(fullName: string): void {
   breedFilter = breedFilter === fullName ? '' : fullName;
   if (geneVisualizerRef) {
     geneVisualizerRef.setBreedFilter(breedFilter);
@@ -65,9 +85,9 @@ function setBreedFilter(fullName) {
 }
 
 // Cleanup refs for resize listeners
-let cleanupResize = null;
+let cleanupResize = $state<(() => void) | null>(null);
 
-function handleViewChange(view) {
+function handleViewChange(view: string): void {
   currentView = view;
   if (geneVisualizerRef) {
     geneVisualizerRef.handleViewChange(view);
@@ -75,18 +95,18 @@ function handleViewChange(view) {
   refreshStats();
 }
 
-function toggleStats() {
+function toggleStats(): void {
   statsOpen = !statsOpen;
   if (statsOpen) refreshStats();
 }
 
-function refreshStats() {
+function refreshStats(): void {
   if (geneVisualizerRef) {
     stats = geneVisualizerRef.getStatsData();
   }
 }
 
-function handleAttributeFilter(event) {
+function handleAttributeFilter(event: CustomEvent<{ attribute: string; ctrlKey: boolean; altKey: boolean }>): void {
   if (geneVisualizerRef?.handleAttributeFilter) {
     geneVisualizerRef.handleAttributeFilter(event);
     refreshStats();
@@ -94,20 +114,20 @@ function handleAttributeFilter(event) {
 }
 
 // Called by GeneVisualizer when stats data changes
-function handleStatsUpdated() {
+function handleStatsUpdated(): void {
   if (statsOpen) refreshStats();
 }
 
-function startResize(e) {
+function startResize(e: MouseEvent): void {
   e.preventDefault();
   const startX = e.clientX;
   const startWidth = drawerWidth;
 
-  function onMove(e) {
+  function onMove(e: MouseEvent): void {
     drawerWidth = Math.max(240, Math.min(600, startWidth + (startX - e.clientX)));
   }
 
-  function onUp() {
+  function onUp(): void {
     window.removeEventListener('mousemove', onMove);
     window.removeEventListener('mouseup', onUp);
     cleanupResize = null;
@@ -219,7 +239,7 @@ onDestroy(() => {
     {/if}
 
     <div class="content-area">
-      {#if galleryOpen}
+      {#if galleryOpen && pet}
         <div class="gallery-container">
             <PetImageGallery {pet} />
         </div>

--- a/src/lib/components/pet/TagInput.svelte
+++ b/src/lib/components/pet/TagInput.svelte
@@ -1,8 +1,14 @@
-<script>
-let { tags = [], allTags = [], onchange } = $props();
+<script lang="ts">
+interface Props {
+  tags?: string[];
+  allTags?: string[];
+  onchange?: (tags: string[]) => void;
+}
 
-let inputValue = $state('');
-let showSuggestions = $state(false);
+let { tags = [], allTags = [], onchange }: Props = $props();
+
+let inputValue = $state<string>('');
+let showSuggestions = $state<boolean>(false);
 
 const suggestions = $derived(
   inputValue.trim()
@@ -10,7 +16,7 @@ const suggestions = $derived(
     : [],
 );
 
-function addTag(value) {
+function addTag(value: string): void {
   const tag = value.trim().toLowerCase();
   if (!tag || tags.includes(tag)) return;
   const updated = [...tags, tag];
@@ -19,11 +25,11 @@ function addTag(value) {
   showSuggestions = false;
 }
 
-function removeTag(tag) {
+function removeTag(tag: string): void {
   onchange?.(tags.filter((t) => t !== tag));
 }
 
-function handleKeydown(e) {
+function handleKeydown(e: KeyboardEvent): void {
   if (e.key === 'Enter') {
     e.preventDefault();
     if (suggestions.length > 0) {
@@ -36,8 +42,8 @@ function handleKeydown(e) {
   }
 }
 
-function handleInput(e) {
-  inputValue = e.target.value;
+function handleInput(e: Event): void {
+  inputValue = (e.target as HTMLInputElement).value;
   if (inputValue.includes(',')) {
     const parts = inputValue.split(',');
     for (const part of parts.slice(0, -1)) {
@@ -48,15 +54,15 @@ function handleInput(e) {
   showSuggestions = inputValue.trim().length > 0;
 }
 
-function handleFocus() {
+function handleFocus(): void {
   showSuggestions = inputValue.trim().length > 0;
 }
 
-function handleBlur() {
+function handleBlur(): void {
   showSuggestions = false;
 }
 
-function handleSuggestionMousedown(e, suggestion) {
+function handleSuggestionMousedown(e: MouseEvent, suggestion: string): void {
   e.preventDefault();
   addTag(suggestion);
 }

--- a/src/lib/utils/petFilter.ts
+++ b/src/lib/utils/petFilter.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure pet-list filtering for `PetList`.
+ *
+ * Extracted from the in-component `filteredPets` $derived so the
+ * search / tag / starred / stabled predicate can be unit-tested rather than
+ * living as a closure over component reactive state (#306 audit per #310).
+ */
+
+import type { Pet } from '$lib/types/index.js';
+
+export interface PetListFilters {
+  /** Search text, matched case-insensitively against name and species. Empty means "no search". */
+  query: string;
+  /** Tags that must ALL be present on the pet. */
+  tags: string[];
+  starredOnly: boolean;
+  stabledOnly: boolean;
+}
+
+/** Whether a pet passes the active list filters. */
+export function petMatchesFilters(pet: Pet, filters: PetListFilters): boolean {
+  const q = filters.query ? filters.query.toLowerCase() : '';
+  if (q) {
+    if (!(pet.name || '').toLowerCase().includes(q) && !(pet.species || '').toLowerCase().includes(q)) {
+      return false;
+    }
+  }
+  if (filters.tags.length > 0) {
+    const petTags = pet.tags ?? [];
+    if (!filters.tags.every((t) => petTags.includes(t))) return false;
+  }
+  if (filters.starredOnly && !pet.starred) return false;
+  if (filters.stabledOnly && !pet.stabled) return false;
+  return true;
+}
+
+/** Return the pets that pass the active list filters, preserving order. */
+export function filterPets(pets: Pet[], filters: PetListFilters): Pet[] {
+  return pets.filter((pet) => petMatchesFilters(pet, filters));
+}

--- a/tests/unit/petFilter.test.js
+++ b/tests/unit/petFilter.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { filterPets, petMatchesFilters } from '$lib/utils/petFilter.js';
+
+// Minimal pet fixtures — only the fields the filter reads.
+const pet = (over = {}) => ({
+  name: 'Bessie',
+  species: 'Horse',
+  tags: [],
+  starred: false,
+  stabled: false,
+  ...over,
+});
+
+const noFilters = { query: '', tags: [], starredOnly: false, stabledOnly: false };
+
+describe('petMatchesFilters — search', () => {
+  it('matches name case-insensitively', () => {
+    expect(petMatchesFilters(pet({ name: 'Bessie' }), { ...noFilters, query: 'bess' })).toBe(true);
+  });
+
+  it('matches species case-insensitively', () => {
+    expect(petMatchesFilters(pet({ species: 'Beewasp' }), { ...noFilters, query: 'BEE' })).toBe(true);
+  });
+
+  it('rejects when neither name nor species matches', () => {
+    expect(petMatchesFilters(pet({ name: 'Bessie', species: 'Horse' }), { ...noFilters, query: 'wasp' })).toBe(false);
+  });
+
+  it('tolerates missing name/species', () => {
+    expect(petMatchesFilters(pet({ name: '', species: '' }), { ...noFilters, query: 'x' })).toBe(false);
+    expect(petMatchesFilters(pet({ name: '', species: '' }), noFilters)).toBe(true);
+  });
+});
+
+describe('petMatchesFilters — tags', () => {
+  it('requires ALL selected tags to be present (AND semantics)', () => {
+    const p = pet({ tags: ['foal', 'fast'] });
+    expect(petMatchesFilters(p, { ...noFilters, tags: ['foal'] })).toBe(true);
+    expect(petMatchesFilters(p, { ...noFilters, tags: ['foal', 'fast'] })).toBe(true);
+    expect(petMatchesFilters(p, { ...noFilters, tags: ['foal', 'slow'] })).toBe(false);
+  });
+
+  it('treats a tagless pet as failing any tag filter', () => {
+    expect(petMatchesFilters(pet({ tags: undefined }), { ...noFilters, tags: ['foal'] })).toBe(false);
+  });
+});
+
+describe('petMatchesFilters — starred / stabled gates', () => {
+  it('hides non-starred pets when starredOnly is on', () => {
+    expect(petMatchesFilters(pet({ starred: false }), { ...noFilters, starredOnly: true })).toBe(false);
+    expect(petMatchesFilters(pet({ starred: true }), { ...noFilters, starredOnly: true })).toBe(true);
+  });
+
+  it('hides non-stabled pets when stabledOnly is on', () => {
+    expect(petMatchesFilters(pet({ stabled: false }), { ...noFilters, stabledOnly: true })).toBe(false);
+    expect(petMatchesFilters(pet({ stabled: true }), { ...noFilters, stabledOnly: true })).toBe(true);
+  });
+});
+
+describe('petMatchesFilters — combined', () => {
+  it('requires every active filter to pass', () => {
+    const p = pet({ name: 'Bessie', tags: ['foal'], starred: true, stabled: true });
+    expect(petMatchesFilters(p, { query: 'bess', tags: ['foal'], starredOnly: true, stabledOnly: true })).toBe(true);
+    // One failing condition (wrong tag) fails the whole predicate.
+    expect(petMatchesFilters(p, { query: 'bess', tags: ['adult'], starredOnly: true, stabledOnly: true })).toBe(false);
+  });
+
+  it('passes everything when no filters are active', () => {
+    expect(petMatchesFilters(pet(), noFilters)).toBe(true);
+  });
+});
+
+describe('filterPets', () => {
+  it('returns matching pets in original order without mutating the input', () => {
+    const pets = [
+      pet({ name: 'Bessie', stabled: true }),
+      pet({ name: 'Comet', stabled: false }),
+      pet({ name: 'Daisy', stabled: true }),
+    ];
+    const input = [...pets];
+    const result = filterPets(pets, { ...noFilters, stabledOnly: true });
+    expect(result.map((p) => p.name)).toEqual(['Bessie', 'Daisy']);
+    expect(pets).toEqual(input);
+  });
+});


### PR DESCRIPTION
Part of #306 (full svelte-check coverage). Migrates the `pet/` folder — the next batch after gene/, comparison/, breeding/.

## Scope
All 6 `pet/` components converted to `<script lang="ts">` with typed props, state, handlers, and event types:
- `PetCard`, `TagInput`, `PetEditor`, `PetImageGallery`, `PetVisualization`, `PetList`

`PetVisualization` holds a `bind:this` ref to the (already-TS) `GeneVisualizer`; typed via a local structural `GeneVisualizerInstance` interface covering the four methods it calls. `PetCard`'s `onToggleMarker` now uses the `MarkerKey` union from the pets store rather than `string`.

Behavior-preserving (only types added), with one exception below.

## Bug surfaced by the type checker
`PetImageGallery`'s mouse drag-drop persist called `reorderImages(reordered.map(...))` where `reordered` was never defined — a pre-existing bug hidden by `checkJs: false`. At runtime it threw `ReferenceError` on every drag reorder, silently caught by the `catch { images = previous }` block, so drag-drop image reordering never persisted (keyboard reorder was unaffected — it already used `images`). Fixed to persist the reordered `images`. This is the kind of latent defect #306 exists to catch.

## Verification
- `pnpm check` — 0 errors / 0 warnings
- `pnpm run lint:ci` — clean
- `pnpm test` — 653 unit tests pass
- `pnpm test:e2e` — 135 passed / 2 skipped

## Remaining for #306
`layout/` (6), `community/` (5), `stable/` (1), root components (2), routes (2 svelte), and the 5 `.js` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)