### PR TITLE
refactor(utils): extract testable computePetChanges from PetEditor (#313)

### DIFF
--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -6,6 +6,7 @@ import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
 import type { AttributeInfo, Gender, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
+import { computePetChanges } from '$lib/utils/petChanges.js';
 import TagInput from './TagInput.svelte';
 
 interface Props {
@@ -63,26 +64,16 @@ const filteredAttributeList: AttributeInfo[] = $derived(
 
 async function handleSave(): Promise<void> {
   try {
-    const updateData: Record<string, unknown> = {};
-    if (editName.trim() !== pet.name) updateData.name = editName.trim();
-    if (editGender !== pet.gender) updateData.gender = editGender;
-    if (editBreed.trim() !== (pet.breed || 'Mixed')) updateData.breed = editBreed.trim();
-
-    const attributeChanges: Record<string, number> = {};
-    for (const [key, value] of Object.entries(editAttributes)) {
-      if ((pet as unknown as Record<string, unknown>)[key] !== value) attributeChanges[key] = value;
-    }
-    if (Object.keys(attributeChanges).length > 0) updateData.attributes = attributeChanges;
-
-    const currentTags = pet.tags ?? [];
-    const tagsChanged = editTags.length !== currentTags.length || editTags.some((t, i) => t !== currentTags[i]);
-    if (tagsChanged) {
-      updateData.tags = editTags;
-    }
-
-    if (editStarred !== !!pet.starred) updateData.starred = editStarred;
-    if (editStabled !== !!pet.stabled) updateData.stabled = editStabled;
-    if (editIsPetQuality !== !!pet.is_pet_quality) updateData.is_pet_quality = editIsPetQuality;
+    const updateData = computePetChanges(pet, {
+      name: editName,
+      gender: editGender,
+      breed: editBreed,
+      attributes: editAttributes,
+      tags: editTags,
+      starred: editStarred,
+      stabled: editStabled,
+      isPetQuality: editIsPetQuality,
+    });
 
     if (Object.keys(updateData).length > 0) {
       await appState.updatePet(pet.id, updateData);

--- a/src/lib/utils/petChanges.ts
+++ b/src/lib/utils/petChanges.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure change-diff for `PetEditor`.
+ *
+ * Extracted from the in-component `handleSave` so the field-by-field
+ * comparison that builds `updateData` can be unit-tested rather than living
+ * inside an async save handler (#313, follow-up to #306 / #310).
+ *
+ * The returned object holds only the keys that actually changed, matching the
+ * `appState.updatePet` partial-update contract. `handleSave` stays a thin
+ * wrapper: it builds the draft from component state, calls this, and persists
+ * when the result is non-empty.
+ */
+
+import type { Gender, Pet } from '$lib/types/index.js';
+
+/** Editable snapshot of a pet, as held by the `PetEditor` form state. */
+export interface PetEditDraft {
+  /** Raw name input; trimmed before comparison/persistence. */
+  name: string;
+  gender: Gender;
+  /** Raw breed input; trimmed before comparison/persistence. */
+  breed: string;
+  /** Attribute values keyed by lowercased attribute name. */
+  attributes: Record<string, number>;
+  tags: string[];
+  starred: boolean;
+  stabled: boolean;
+  isPetQuality: boolean;
+}
+
+/**
+ * Compute the partial update for a pet: only the fields whose draft value
+ * differs from the stored pet. `attributes` and `tags` are nested sub-objects,
+ * present only when something within them changed.
+ *
+ * Returns an empty object when nothing changed — callers use that to skip the
+ * persist call.
+ */
+export function computePetChanges(pet: Pet, draft: PetEditDraft): Record<string, unknown> {
+  const updateData: Record<string, unknown> = {};
+
+  if (draft.name.trim() !== pet.name) updateData.name = draft.name.trim();
+  if (draft.gender !== pet.gender) updateData.gender = draft.gender;
+  if (draft.breed.trim() !== (pet.breed || 'Mixed')) updateData.breed = draft.breed.trim();
+
+  const attributeChanges: Record<string, number> = {};
+  for (const [key, value] of Object.entries(draft.attributes)) {
+    if ((pet as unknown as Record<string, unknown>)[key] !== value) attributeChanges[key] = value;
+  }
+  if (Object.keys(attributeChanges).length > 0) updateData.attributes = attributeChanges;
+
+  const currentTags = pet.tags ?? [];
+  const tagsChanged = draft.tags.length !== currentTags.length || draft.tags.some((t, i) => t !== currentTags[i]);
+  if (tagsChanged) updateData.tags = draft.tags;
+
+  if (draft.starred !== !!pet.starred) updateData.starred = draft.starred;
+  if (draft.stabled !== !!pet.stabled) updateData.stabled = draft.stabled;
+  if (draft.isPetQuality !== !!pet.is_pet_quality) updateData.is_pet_quality = draft.isPetQuality;
+
+  return updateData;
+}

--- a/tests/unit/petChanges.test.js
+++ b/tests/unit/petChanges.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { computePetChanges } from '$lib/utils/petChanges.js';
+
+// Stored pet fixture — only the fields the diff reads.
+const pet = (over = {}) => ({
+  name: 'Bessie',
+  gender: 'Female',
+  breed: 'Standardbred',
+  tags: ['foal'],
+  intelligence: 50,
+  toughness: 60,
+  starred: false,
+  stabled: false,
+  is_pet_quality: false,
+  ...over,
+});
+
+// Draft mirroring the stored pet — overlay deltas per test.
+const draft = (over = {}) => ({
+  name: 'Bessie',
+  gender: 'Female',
+  breed: 'Standardbred',
+  attributes: { intelligence: 50, toughness: 60 },
+  tags: ['foal'],
+  starred: false,
+  stabled: false,
+  isPetQuality: false,
+  ...over,
+});
+
+describe('computePetChanges — no changes', () => {
+  it('returns an empty object when nothing changed', () => {
+    expect(computePetChanges(pet(), draft())).toEqual({});
+  });
+});
+
+describe('computePetChanges — scalar fields', () => {
+  it('trims name before comparing and persisting', () => {
+    expect(computePetChanges(pet(), draft({ name: '  Bessie  ' }))).toEqual({});
+    expect(computePetChanges(pet(), draft({ name: '  Bella  ' }))).toEqual({ name: 'Bella' });
+  });
+
+  it('detects gender change', () => {
+    expect(computePetChanges(pet(), draft({ gender: 'Male' }))).toEqual({ gender: 'Male' });
+  });
+
+  it('trims breed and compares against the stored breed', () => {
+    expect(computePetChanges(pet(), draft({ breed: '  Kurbone  ' }))).toEqual({ breed: 'Kurbone' });
+  });
+
+  it("compares breed against 'Mixed' default when the pet has no breed", () => {
+    // Pet with falsy breed, draft left at the 'Mixed' default → no change.
+    expect(computePetChanges(pet({ breed: '' }), draft({ breed: 'Mixed' }))).toEqual({});
+    // Same pet, draft moved off the default → change.
+    expect(computePetChanges(pet({ breed: '' }), draft({ breed: 'Bee' }))).toEqual({ breed: 'Bee' });
+  });
+});
+
+describe('computePetChanges — attributes', () => {
+  it('includes only changed attributes', () => {
+    const result = computePetChanges(pet(), draft({ attributes: { intelligence: 55, toughness: 60 } }));
+    expect(result).toEqual({ attributes: { intelligence: 55 } });
+  });
+
+  it('includes multiple changed attributes', () => {
+    const result = computePetChanges(pet(), draft({ attributes: { intelligence: 55, toughness: 70 } }));
+    expect(result).toEqual({ attributes: { intelligence: 55, toughness: 70 } });
+  });
+
+  it('omits attributes entirely when none changed', () => {
+    expect(computePetChanges(pet(), draft())).not.toHaveProperty('attributes');
+  });
+});
+
+describe('computePetChanges — tags', () => {
+  it('detects a length change', () => {
+    expect(computePetChanges(pet(), draft({ tags: ['foal', 'fast'] }))).toEqual({ tags: ['foal', 'fast'] });
+    expect(computePetChanges(pet(), draft({ tags: [] }))).toEqual({ tags: [] });
+  });
+
+  it('detects per-index inequality at equal length', () => {
+    expect(computePetChanges(pet(), draft({ tags: ['fast'] }))).toEqual({ tags: ['fast'] });
+  });
+
+  it('treats reordered tags as a change (positional comparison)', () => {
+    const p = pet({ tags: ['a', 'b'] });
+    expect(computePetChanges(p, draft({ tags: ['b', 'a'] }))).toEqual({ tags: ['b', 'a'] });
+  });
+
+  it('tolerates a missing tags array on the pet', () => {
+    const { tags, ...noTags } = pet();
+    expect(computePetChanges(noTags, draft({ tags: [] }))).toEqual({});
+    expect(computePetChanges(noTags, draft({ tags: ['new'] }))).toEqual({ tags: ['new'] });
+  });
+});
+
+describe('computePetChanges — boolean markers', () => {
+  it('detects starred flip', () => {
+    expect(computePetChanges(pet(), draft({ starred: true }))).toEqual({ starred: true });
+  });
+
+  it('detects stabled flip', () => {
+    expect(computePetChanges(pet(), draft({ stabled: true }))).toEqual({ stabled: true });
+  });
+
+  it('detects is_pet_quality flip', () => {
+    expect(computePetChanges(pet(), draft({ isPetQuality: true }))).toEqual({ is_pet_quality: true });
+  });
+
+  it('coerces truthy/falsy stored markers via !! before comparing', () => {
+    // Stored marker is undefined (falsy); draft false → no change.
+    expect(computePetChanges(pet({ starred: undefined }), draft({ starred: false }))).toEqual({});
+    // Stored marker is a truthy non-boolean (1); draft true → no change.
+    expect(computePetChanges(pet({ stabled: 1 }), draft({ stabled: true }))).toEqual({});
+  });
+});
+
+describe('computePetChanges — combined', () => {
+  it('assembles every changed field into one update object', () => {
+    const result = computePetChanges(
+      pet(),
+      draft({
+        name: 'Bella',
+        gender: 'Male',
+        breed: 'Kurbone',
+        attributes: { intelligence: 99, toughness: 60 },
+        tags: ['stud'],
+        starred: true,
+        stabled: true,
+        isPetQuality: true,
+      }),
+    );
+    expect(result).toEqual({
+      name: 'Bella',
+      gender: 'Male',
+      breed: 'Kurbone',
+      attributes: { intelligence: 99 },
+      tags: ['stud'],
+      starred: true,
+      stabled: true,
+      is_pet_quality: true,
+    });
+  });
+});


### PR DESCRIPTION
Closes #313. Follow-up to #306 / #310 (pet/ migration in #312).

## Change
`PetEditor.handleSave` computed the change-diff inline before calling `appState.updatePet`. That decision logic is pure but was untested because it lived inside an async save handler.

Extracted it into `computePetChanges(pet, draft): Record<string, unknown>` in `$lib/utils/petChanges.ts`, returning only the changed keys (`attributes` / `tags` as nested sub-objects when those changed). `handleSave` is now a thin wrapper that builds the draft from component state and persists when the result is non-empty. Behaviour-preserving.

## Tests
`tests/unit/petChanges.test.js` — 17 truth-table cases:
- no changes → `{}` (the `Object.keys(...).length > 0` guard)
- name trim, gender, breed with the `|| 'Mixed'` default
- attribute diff loop (only changed attributes included)
- tag length change + positional inequality + missing tags array
- starred/stabled/is_pet_quality flips incl. `!!` coercion of non-boolean stored markers

`pnpm check` 0/0, `pnpm run lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)