### PR TITLE
build(types): enable checkJs for full type coverage (#306)

### DIFF
--- a/scripts/monitor-spark-usage.mjs
+++ b/scripts/monitor-spark-usage.mjs
@@ -36,6 +36,10 @@ export const SPARK_STORAGE_BYTES = 1 * 1024 * 1024 * 1024; // 1 GiB Firestore st
 export const WARN_THRESHOLD = 0.75;
 export const ERROR_THRESHOLD = 1.0;
 
+/**
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
   console.error(`monitor-spark-usage: ${message}`);
   process.exit(1);
@@ -53,9 +57,8 @@ function loadServiceAccount() {
   try {
     return JSON.parse(readFileSync(abs, 'utf-8'));
   } catch (err) {
-    fail(`service account key at ${abs} is not valid JSON: ${err.message}`);
+    fail(`service account key at ${abs} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`);
   }
-  return null; // unreachable, makes the type-checker happy
 }
 
 /**
@@ -64,6 +67,9 @@ function loadServiceAccount() {
  * server-side overhead per doc is slightly higher (index entries,
  * metadata), but the approximation is within ~10% in practice and
  * good enough for a soft-cap warning.
+ *
+ * @param {any} db  Admin SDK Firestore instance (legacy namespaced API; see main)
+ * @param {string} name
  */
 async function summariseCollection(db, name) {
   const snap = await db.collection(name).get();
@@ -74,6 +80,7 @@ async function summariseCollection(db, name) {
   return { count: snap.size, bytes };
 }
 
+/** @param {number} bytes */
 export function formatBytes(bytes) {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
@@ -81,10 +88,16 @@ export function formatBytes(bytes) {
   return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GiB`;
 }
 
+/**
+ * @param {string} label
+ * @param {string | number} value
+ * @param {number} [width]
+ */
 export function formatRow(label, value, width = 24) {
   return `${label.padEnd(width)}${value}`;
 }
 
+/** @param {number} ratio */
 export function statusFor(ratio) {
   if (ratio >= ERROR_THRESHOLD) return 'OVER';
   if (ratio >= WARN_THRESHOLD) return 'WARN';
@@ -95,7 +108,10 @@ async function main() {
   const serviceAccount = loadServiceAccount();
   // Lazy-load the heavy Admin SDK so the module's pure helpers can be
   // unit-tested without pulling firebase-admin into the test process.
-  const { default: admin } = await import('firebase-admin');
+  // Typed as `any`: this uses the legacy namespaced API (admin.credential /
+  // admin.firestore) which firebase-admin v14 ships at runtime but no longer
+  // exposes through its modular type definitions.
+  const { default: admin } = /** @type {{ default: any }} */ (await import('firebase-admin'));
   admin.initializeApp({ credential: admin.credential.cert(serviceAccount) });
   const db = admin.firestore();
 

--- a/tests/unit/communityPetRow.test.ts
+++ b/tests/unit/communityPetRow.test.ts
@@ -14,13 +14,16 @@ vi.mock('$lib/utils/timestamp.js', () => ({
 }));
 
 import CommunityPetRow from '$lib/components/community/CommunityPetRow.svelte';
+import type { SharedPet } from '$lib/types/index.js';
 
 afterEach(() => {
   cleanup();
   selectPetSpy.mockReset();
 });
 
-function makePet(overrides = {}) {
+// Partial fixture — only the fields the row renders. Cast to satisfy the
+// component's typed `pet` prop without spelling out every SharedPet field.
+function makePet(overrides: Partial<SharedPet> = {}): SharedPet {
   return {
     contentHash: 'abc123',
     name: 'Buzz',
@@ -29,7 +32,7 @@ function makePet(overrides = {}) {
     tags: ['fast'],
     uploadedAt: new Date('2026-05-10T12:00:00Z'),
     ...overrides,
-  };
+  } as unknown as SharedPet;
 }
 
 describe('CommunityPetRow accessibility', () => {

--- a/tests/unit/sharePetDialog.test.ts
+++ b/tests/unit/sharePetDialog.test.ts
@@ -22,6 +22,7 @@ vi.mock('$lib/services/shareService.js', () => ({
 }));
 
 import SharePetDialog from '$lib/components/community/SharePetDialog.svelte';
+import type { Pet } from '$lib/types/index.js';
 
 afterEach(() => {
   cleanup();
@@ -30,7 +31,9 @@ afterEach(() => {
 });
 
 // A pet as it arrives from the list path: full metadata, NO genome_text.
-function listPet(overrides = {}) {
+// Partial fixture cast to satisfy the dialog's typed `pet` prop; the omitted
+// attribute/flag columns are irrelevant to the lazy-genome-fetch behaviour.
+function listPet(overrides: Partial<Pet> = {}): Pet {
   return {
     id: 7,
     name: 'Buzz',
@@ -42,7 +45,7 @@ function listPet(overrides = {}) {
     notes: '',
     tags: ['fast'],
     ...overrides,
-  };
+  } as unknown as Pet;
 }
 
 describe('SharePetDialog lazy genome fetch', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    // Kept on for any incidental .js (config files); no .js remains under
+    // src/ or tests/ after the #306 migration.
     "allowJs": true,
-    // All app components use <script lang="ts"> and every former src/ .js file
-    // is now .ts (#306), so the full app script surface is type-checked
-    // (lang="ts" scripts are checked regardless of this flag). Still false
-    // because the vitest test files under tests/ remain plain JS and aren't
-    // yet annotated; flip to true once those are migrated too.
-    "checkJs": false,
+    // Full type coverage: every component uses <script lang="ts"> and all of
+    // src/ and tests/ is .ts (#306). checkJs catches any stray JS reintroduced
+    // later. CI runs `pnpm run check`, so a regression fails the build.
+    "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Capstone for #306. Now that #315 (src) and #316 (tests) have merged — no `.js` remains under `src/` or `tests/` — flip `checkJs: true` for complete type coverage. CI already runs `pnpm run check`, so any untyped JS reintroduced later fails the build.

## What flipping surfaced
`checkJs: false` relaxes how `.svelte` component props are checked from `.ts` callers and skips plain JS. Turning it on exposed 3 files (23 errors) the relaxed mode had let through:

- **sharePetDialog / communityPetRow tests** — factories build intentionally-partial `Pet` / `SharedPet` fixtures passed to typed component props. Typed the `overrides` param `Partial<T>` and cast the factory return `as unknown as T` (documented partial-fixture pattern).
- **scripts/monitor-spark-usage.mjs** — pulled into the typed program because its unit test imports the pure helpers. JSDoc-typed the helpers (`formatBytes`/`formatRow`/`statusFor`/`summariseCollection`), made `fail()` return `never` (which narrows the env-var guard so the `string | undefined` resolves), and scoped the lazily-imported `firebase-admin` to `any` — v14 ships the legacy namespaced API this script uses (`admin.credential` / `admin.firestore`) at runtime but no longer exposes it through the modular type defs. Runtime behaviour unchanged.

## Verification
`pnpm check` 0/0 · 681 unit tests pass · `pnpm run lint:ci` clean.

Closes #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)