### PR TITLE
feat(breeding): filter trio view by offspring breed and attribute

### DIFF
--- a/src/lib/components/breeding/TrioView.svelte
+++ b/src/lib/components/breeding/TrioView.svelte
@@ -44,9 +44,6 @@ const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
                 {#if speciesLabel}
                     <span class="species-badge">{getSpeciesEmoji(father?.species)} {speciesLabel}</span>
                 {/if}
-                {#if offspringBreed}
-                    <span class="breed-badge">{offspringBreed}</span>
-                {/if}
             </h3>
             <button type="button" class="close-btn" onclick={onClose} aria-label="Close trio view">×</button>
         </div>
@@ -79,8 +76,7 @@ const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
     .parent-name.mother { color: #a855f7; }
     .cross { color: var(--text-muted); font-weight: 500; }
 
-    .species-badge,
-    .breed-badge {
+    .species-badge {
         font-size: 12px;
         font-weight: 500;
         padding: 2px 8px;

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+import { onDestroy, onMount, untrack } from 'svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { computeOffspringTrio } from '$lib/services/offspringTrioService.js';
-import type { OffspringTrioResult, Pet } from '$lib/types/index.js';
+import { type AttributeInfo, HORSE_BREEDS, type OffspringTrioResult, type Pet } from '$lib/types/index.js';
+import { attributeFilterCSS } from '$lib/utils/filterCSS.js';
+import { triStateToggle } from '$lib/utils/filterToggle.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
 import { capitalize } from '$lib/utils/string.js';
 import { buildTrioGrid, type TrioGrid, type TrioLocusCell } from '$lib/utils/trioGrid.js';
@@ -16,37 +19,83 @@ interface Props {
 
 const { father, mother, offspringBreed = '' }: Props = $props();
 
+const isHorse = $derived(normalizeSpecies(father.species) === 'horse');
+const horseBreeds = Object.entries(HORSE_BREEDS);
+
 let loading = $state(false);
 let error = $state<string | null>(null);
 let grid = $state<TrioGrid | null>(null);
 let summary = $state<OffspringTrioResult['summary'] | null>(null);
+let attributeDisplayInfo = $state<AttributeInfo[]>([]);
+
+// Breed re-runs the projection (the service drops loci locked to other breeds,
+// keeping the trio consistent with the breeding ranking). Attribute is a visual
+// focus filter applied as CSS over the rendered grid — the same engine the
+// 2-pet diff grid uses (select dims everything else, alt-click hides).
+let selectedBreed = $state(untrack(() => offspringBreed));
+let selectedAttributes = $state<string[]>([]);
+let hiddenAttributes = $state<string[]>([]);
 
 const ALLELE_LABEL: Record<string, string> = { D: 'Dominant', x: 'Mixed', R: 'Recessive', unknown: 'Unknown' };
 const VERDICT_LABEL: Record<string, string> = { gain: 'Gain', risk: 'Risk', neutral: '' };
 
 $effect(() => {
   if (father?.id && mother?.id) {
-    load(father, mother, offspringBreed);
+    load(father, mother, selectedBreed);
   }
 });
+
+// Dynamic filter stylesheet — the zero-rerender pattern from GenomeGridDiff,
+// scoped to this modal's grid so it can't leak into the diff grid.
+let filterStyleEl: HTMLStyleElement | null = null;
+onMount(() => {
+  filterStyleEl = document.createElement('style');
+  filterStyleEl.id = 'trio-grid-filters';
+  document.head.appendChild(filterStyleEl);
+});
+onDestroy(() => {
+  filterStyleEl?.remove();
+  filterStyleEl = null;
+});
+$effect(() => {
+  if (!filterStyleEl) return;
+  // `*` cell selector: the trio's three rows use different cell classes
+  // (`.gene-cell` parents, `.dist-bar` offspring); all carry `data-attr`.
+  filterStyleEl.textContent = attributeFilterCSS('.trio-grid-container', '*', selectedAttributes, hiddenAttributes);
+});
+
+function toggleAttributeFilter(attrKey: string, ctrlKey: boolean, altKey: boolean) {
+  ({ selected: selectedAttributes, hidden: hiddenAttributes } = triStateToggle(
+    attrKey,
+    selectedAttributes,
+    hiddenAttributes,
+    ctrlKey,
+    altKey,
+  ));
+}
 
 async function load(f: Pet, m: Pet, breed: string) {
   try {
     loading = true;
     error = null;
-    const species = normalizeSpecies(f.species);
+    // A new pair or breed changes which loci exist; a focus carried over from
+    // the previous set could dim the whole grid, so start unfiltered.
+    selectedAttributes = [];
+    hiddenAttributes = [];
+    const sp = normalizeSpecies(f.species);
     const [result, efData] = await Promise.all([
-      computeOffspringTrio(f, m, { species, offspringBreed: breed }),
-      getGeneEffectsCached(species),
+      computeOffspringTrio(f, m, { species: sp, offspringBreed: breed }),
+      getGeneEffectsCached(sp),
     ]);
 
     const effectsDB = efData?.effects ?? {};
-    const attributeNames = getAttributeConfig(species).all_attribute_names.map((n) => capitalize(n));
+    const config = getAttributeConfig(sp);
+    attributeDisplayInfo = config.attributes;
     const cellBuilder = createGeneCellBuilder({
       effectsDB,
-      attributeNames,
-      appearanceLookup: buildAppearanceLookup(species),
-      speciesKey: species,
+      attributeNames: config.all_attribute_names.map((n) => capitalize(n)),
+      appearanceLookup: buildAppearanceLookup(sp),
+      speciesKey: sp,
     });
 
     grid = buildTrioGrid(result, cellBuilder);
@@ -82,11 +131,58 @@ function parentTitle(cell: GeneCell | null, label: string) {
 </script>
 
 <div class="genome-grid-trio">
+    {#if !error}
+        <div class="trio-filters">
+            {#if isHorse}
+                <div class="breed-filter" data-testid="trio-breed-filter">
+                    <span class="breed-label">Breed:</span>
+                    <button
+                        type="button"
+                        class="breed-btn"
+                        class:active={selectedBreed === ''}
+                        onclick={() => { selectedBreed = ''; }}
+                    >All</button>
+                    {#each horseBreeds as [name, abbrev] (name)}
+                        <button
+                            type="button"
+                            class="breed-btn"
+                            class:active={selectedBreed === name}
+                            onclick={() => { selectedBreed = name; }}
+                            title={name}
+                        >{abbrev}</button>
+                    {/each}
+                </div>
+            {/if}
+            {#if attributeDisplayInfo.length > 0}
+                <div class="attribute-filter" data-testid="trio-attribute-filter">
+                    <span class="attr-filter-label">Attribute:</span>
+                    <button
+                        type="button"
+                        class="attr-filter-btn"
+                        class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0}
+                        onclick={() => { selectedAttributes = []; hiddenAttributes = []; }}
+                    >All</button>
+                    {#each attributeDisplayInfo as attr (attr.key)}
+                        <button
+                            type="button"
+                            class="attr-filter-btn"
+                            class:active={selectedAttributes.includes(attr.key)}
+                            class:hidden-attr={hiddenAttributes.includes(attr.key)}
+                            onclick={(e) => toggleAttributeFilter(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
+                            title={attr.name}
+                        >{attr.icon} {attr.name}</button>
+                    {/each}
+                </div>
+                <span class="filter-hint">Click to focus · Ctrl+click multi-select · Alt+click hide</span>
+            {/if}
+        </div>
+    {/if}
+
     {#if loading}
         <StatusPane variant="loading" body="Building offspring projection…" />
     {:else if error}
         <StatusPane variant="error" icon="⚠️" body={error} />
-    {:else if grid && summary}
+    {:else if grid && summary && grid.rows.length > 0}
         <div class="trio-summary">
             <span class="chip chip-gain">{summary.gains} gains</span>
             <span class="chip chip-risk">{summary.risks} risks</span>
@@ -100,7 +196,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
             </span>
         </div>
 
-        <div class="grid-container">
+        <div class="grid-container trio-grid-container">
             <table class="trio-table">
                 <thead>
                     <tr>
@@ -123,7 +219,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                     {@const cell = row.cells[`${block}${pos}`]}
                                     <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
                                         {#if cell?.fatherCell}
-                                            <div class={cell.fatherCell.attributeCls} title={parentTitle(cell.fatherCell, 'Father')}>
+                                            <div class={cell.fatherCell.attributeCls} data-attr={cell.fatherCell.attribute} title={parentTitle(cell.fatherCell, 'Father')}>
                                                 {#if cell.fatherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
                                             </div>
                                         {/if}
@@ -141,6 +237,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                             <div
                                                 class="dist-bar verdict-{cell.verdict}"
                                                 class:locked={cell.lockedIn}
+                                                data-attr={cell.attribute ?? ''}
                                                 title={offspringTitle(cell)}
                                             >
                                                 {#each cell.segments as seg, i (i)}
@@ -159,7 +256,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                     {@const cell = row.cells[`${block}${pos}`]}
                                     <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
                                         {#if cell?.motherCell}
-                                            <div class={cell.motherCell.attributeCls} title={parentTitle(cell.motherCell, 'Mother')}>
+                                            <div class={cell.motherCell.attributeCls} data-attr={cell.motherCell.attribute} title={parentTitle(cell.motherCell, 'Mother')}>
                                                 {#if cell.motherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
                                             </div>
                                         {/if}
@@ -171,6 +268,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
                 </tbody>
             </table>
         </div>
+    {:else if selectedBreed}
+        <p class="empty-text">No loci for the {selectedBreed} breed in this pair.</p>
     {:else}
         <p class="empty-text">No genome data available for this pair.</p>
     {/if}
@@ -178,6 +277,52 @@ function parentTitle(cell: GeneCell | null, label: string) {
 
 <style>
     .genome-grid-trio { width: 100%; }
+
+    .trio-filters {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        margin-bottom: 12px;
+    }
+    .breed-filter,
+    .attribute-filter {
+        display: flex;
+        align-items: center;
+        gap: 3px;
+        flex-wrap: wrap;
+        padding: 0 4px;
+    }
+    .breed-label,
+    .attr-filter-label {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--text-tertiary);
+        margin-right: 4px;
+    }
+    .breed-btn,
+    .attr-filter-btn {
+        padding: 3px 8px;
+        border: 1px solid var(--border-primary);
+        border-radius: 4px;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
+        font-size: 11px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.15s;
+        white-space: nowrap;
+    }
+    .breed-btn:hover,
+    .attr-filter-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
+    .breed-btn.active,
+    .attr-filter-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
+    .attr-filter-btn.hidden-attr {
+        background: var(--error-bg);
+        border-color: var(--error-border);
+        color: var(--error-text);
+        text-decoration: line-through;
+    }
+    .filter-hint { font-size: 11px; color: var(--text-tertiary); font-style: italic; padding: 0 4px; }
 
     .trio-summary {
         display: flex;

--- a/src/lib/utils/filterCSS.ts
+++ b/src/lib/utils/filterCSS.ts
@@ -33,8 +33,9 @@ function pushInclusionRules(
  * and cell selectors. Selected attributes dim everything else; hidden
  * attributes dim themselves. Shares the exact dimming declaration the 2-pet
  * diff grid uses so the trio grid filters identically. `cellSelector` is the
- * element carrying `data-attr` (the diff grid uses `.gene-cell`; grids whose
- * cells aren't `.gene-cell` can pass `[data-attr]`).
+ * element selector that *carries* `data-attr` — `[data-attr]` is appended
+ * internally, so pass the element only (the diff grid uses `.gene-cell`; the
+ * trio grid uses `*` because its rows mix `.gene-cell` and `.dist-bar` cells).
  */
 export function attributeFilterCSS(
   gridSelector: string,

--- a/src/lib/utils/filterCSS.ts
+++ b/src/lib/utils/filterCSS.ts
@@ -16,15 +16,35 @@ function pushInclusionRules(
   selected: string[],
   hidden: string[],
   declaration: string,
+  gridSelector: string = G,
 ): void {
   if (selected.length > 0) {
     let not = '';
     for (const v of selected) not += `:not([${attr}="${v}"])`;
-    rules.push(`${G} ${baseSelector}[${attr}]${not} ${declaration}`);
+    rules.push(`${gridSelector} ${baseSelector}[${attr}]${not} ${declaration}`);
   }
   for (const v of hidden) {
-    rules.push(`${G} ${baseSelector}[${attr}="${v}"] ${declaration}`);
+    rules.push(`${gridSelector} ${baseSelector}[${attr}="${v}"] ${declaration}`);
   }
+}
+
+/**
+ * Attribute select/hide rules for any genome grid, parameterised by the grid
+ * and cell selectors. Selected attributes dim everything else; hidden
+ * attributes dim themselves. Shares the exact dimming declaration the 2-pet
+ * diff grid uses so the trio grid filters identically. `cellSelector` is the
+ * element carrying `data-attr` (the diff grid uses `.gene-cell`; grids whose
+ * cells aren't `.gene-cell` can pass `[data-attr]`).
+ */
+export function attributeFilterCSS(
+  gridSelector: string,
+  cellSelector: string,
+  selectedAttributes: string[],
+  hiddenAttributes: string[],
+): string {
+  const rules: string[] = [];
+  pushInclusionRules(rules, cellSelector, 'data-attr', selectedAttributes, hiddenAttributes, FILTERED, gridSelector);
+  return rules.join('\n');
 }
 
 /** Per-chromosome breed relevance: `generic` rows apply to all breeds. */

--- a/tests/e2e/breeding.spec.ts
+++ b/tests/e2e/breeding.spec.ts
@@ -125,4 +125,65 @@ test.describe('Breeding Assistant — ranking UI (PR 4)', () => {
     await trio.getByRole('button', { name: 'Close trio view' }).click();
     await expect(page.getByTestId('trio-view')).toHaveCount(0);
   });
+
+  test('trio view filters offspring loci by attribute', async ({ page }) => {
+    await openBreedingTab(page);
+    const found = await pickSpeciesWithPairs(page);
+    expect(found).toBe(true);
+
+    await page.locator('[data-testid="inspect-pair"]').first().click();
+    const trio = page.getByTestId('trio-view');
+    await expect(trio).toBeVisible();
+
+    // The attribute filter renders once the projection loads.
+    const attrFilter = trio.getByTestId('trio-attribute-filter');
+    await expect(attrFilter).toBeVisible();
+
+    // Clicking a specific attribute marks it active and clears "All".
+    const firstAttr = attrFilter.locator('.attr-filter-btn').nth(1);
+    await firstAttr.click();
+    await expect(firstAttr).toHaveClass(/active/);
+    await expect(attrFilter.locator('.attr-filter-btn').first()).not.toHaveClass(/active/);
+
+    // Clicking it again resets back to "All".
+    await firstAttr.click();
+    await expect(attrFilter.locator('.attr-filter-btn').first()).toHaveClass(/active/);
+  });
+
+  test('trio view shows the offspring-breed filter only for horses', async ({ page }) => {
+    await openBreedingTab(page);
+    const horseBtn = page.locator('.species-btn').filter({ hasText: /horse/i });
+    if ((await horseBtn.count()) === 0) test.skip(true, 'no horse species supported in this build');
+    await horseBtn.click();
+
+    const inspect = page.locator('[data-testid="inspect-pair"]');
+    if ((await inspect.count()) === 0) test.skip(true, 'no horse pairs in demo data');
+    await inspect.first().click();
+
+    const trio = page.getByTestId('trio-view');
+    await expect(trio).toBeVisible();
+    await expect(trio.getByTestId('trio-breed-filter')).toBeVisible();
+  });
+
+  test('changing the offspring breed clears an active attribute focus', async ({ page }) => {
+    await openBreedingTab(page);
+    const horseBtn = page.locator('.species-btn').filter({ hasText: /horse/i });
+    if ((await horseBtn.count()) === 0) test.skip(true, 'no horse species supported in this build');
+    await horseBtn.click();
+
+    const inspect = page.locator('[data-testid="inspect-pair"]');
+    if ((await inspect.count()) === 0) test.skip(true, 'no horse pairs in demo data');
+    await inspect.first().click();
+
+    const trio = page.getByTestId('trio-view');
+    await expect(trio).toBeVisible();
+
+    // Focus an attribute, then switch breed — the focus must reset to "All".
+    const attrFilter = trio.getByTestId('trio-attribute-filter');
+    await attrFilter.locator('.attr-filter-btn').nth(1).click();
+    await expect(attrFilter.locator('.attr-filter-btn').first()).not.toHaveClass(/active/);
+
+    await trio.getByTestId('trio-breed-filter').locator('.breed-btn').nth(1).click();
+    await expect(attrFilter.locator('.attr-filter-btn').first()).toHaveClass(/active/);
+  });
 });

--- a/tests/unit/filterCSS.test.ts
+++ b/tests/unit/filterCSS.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { attributeFilterCSS, buildFilterCSS } from '$lib/utils/filterCSS.js';
 
 const FILTERED = '{ opacity: 0.15 !important; filter: grayscale(1) !important; pointer-events: none !important; }';
 const HIDDEN = '{ display: none !important; }';
@@ -80,5 +80,21 @@ describe('buildFilterCSS', () => {
     const css = buildFilterCSS({ ...base, showDiffsOnly: true });
     expect(css).toContain(`.grid-container td[data-isdiff="false"][data-hascell="true"] ${DIMMED}`);
     expect(css).toContain(`.grid-container tr[data-hasdiffs="false"] ${HIDDEN}`);
+  });
+});
+
+describe('attributeFilterCSS', () => {
+  it('returns an empty string when nothing is selected or hidden', () => {
+    expect(attributeFilterCSS('.trio-grid-container', '*', [], [])).toBe('');
+  });
+
+  it('dims everything but the selected attributes, scoped to the given grid/cell selectors', () => {
+    const css = attributeFilterCSS('.trio-grid-container', '*', ['Speed'], []);
+    expect(css).toBe(`.trio-grid-container *[data-attr]:not([data-attr="Speed"]) ${FILTERED}`);
+  });
+
+  it('dims a hidden attribute directly', () => {
+    const css = attributeFilterCSS('.trio-grid-container', '*', [], ['Toughness']);
+    expect(css).toBe(`.trio-grid-container *[data-attr="Toughness"] ${FILTERED}`);
   });
 });


### PR DESCRIPTION
## What

Two filters in the offspring trio view:

- **Offspring breed** (horse-only): button row (All + breed abbreviations). Re-runs `computeOffspringTrio`, so breed-locked loci are dropped from the grid and the gain/risk/locked-in summary chips recompute.
- **Attribute focus**: button row from `getAttributeConfig().attributes` (icon + name). Click to focus a single stat (dims everything else), Ctrl+click to multi-select, Alt+click to hide.

## How

Reuses the existing comparison/diff-grid filter machinery rather than new code:
- `triStateToggle` (filterToggle.ts) for select/hide state.
- `attributeFilterCSS()` — extracted from `buildFilterCSS()` and parameterised by grid/cell selector — applied via the same zero-rerender injected `<style>` pattern `GenomeGridDiff` uses. Cells carry `data-attr`; the trio passes `*` as the cell selector since its three rows use different cell classes.

Breed and attribute differ deliberately: attribute is a visual focus (summary stays global, like the diff view's similarity badge); breed changes which loci count toward offspring gains, so it goes through the service.

`load()` clears any attribute focus on pair/breed change so a stale focus can't blank the grid. Removed the now-redundant static breed badge from the trio header.

## Tests

- `attributeFilterCSS` unit tests (filterCSS.test.ts).
- 3 new e2e tests: attribute focus toggling, horse-only breed filter, and focus-reset-on-breed-change.
- svelte-check 0 errors, lint clean, 8/8 breeding e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)