### PR TITLE
fix(release): prevent dev-server teardown from hanging

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -103,10 +103,12 @@ echo "Updating screenshots (starting dev server)..."
 # Kill whatever is listening on the Vite port. `pnpm dev` spawns vite as a
 # child, so signalling only the pnpm wrapper leaves vite holding the port;
 # targeting the port listener catches the process that actually matters.
+# Restrict to the TCP LISTEN socket so we only kill the server bound to the
+# port, never browser/Playwright clients that merely have a connection open.
 free_dev_port() {
   if command -v lsof >/dev/null 2>&1; then
     local pids
-    pids=$(lsof -ti:5174 2>/dev/null || true)
+    pids=$(lsof -ti:5174 -sTCP:LISTEN 2>/dev/null || true)
     if [[ -n "$pids" ]]; then
       # shellcheck disable=SC2086
       kill $pids 2>/dev/null || true
@@ -120,14 +122,15 @@ free_dev_port() {
 # reap the wrapper.
 stop_dev_server() {
   local pid="${1:-}"
-  if [[ -n "$pid" ]]; then
-    pkill -P "$pid" 2>/dev/null || true   # vite (and any other children)
-    kill "$pid" 2>/dev/null || true       # the pnpm wrapper
+  # No PID means we never started a server (e.g. the EXIT trap firing before
+  # `pnpm dev`). Do nothing rather than freeing a port we don't own.
+  if [[ -z "$pid" ]]; then
+    return
   fi
+  pkill -P "$pid" 2>/dev/null || true   # vite (and any other children)
+  kill "$pid" 2>/dev/null || true       # the pnpm wrapper
   free_dev_port
-  if [[ -n "$pid" ]]; then
-    wait "$pid" 2>/dev/null || true
-  fi
+  wait "$pid" 2>/dev/null || true
 }
 
 # Free a leftover dev server from a previous run before starting our own.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -100,14 +100,42 @@ echo "Version bumped to $NEW_VERSION in package.json, tauri.conf.json, Cargo.tom
 # --- Update screenshots ---
 echo "Updating screenshots (starting dev server)..."
 
-# Kill any existing dev server on the port
-if command -v lsof >/dev/null 2>&1; then
-  EXISTING_PID=$(lsof -ti:5174 2>/dev/null || true)
-  if [[ -n "$EXISTING_PID" ]]; then
-    kill "$EXISTING_PID" 2>/dev/null || true
-    sleep 1
+# Kill whatever is listening on the Vite port. `pnpm dev` spawns vite as a
+# child, so signalling only the pnpm wrapper leaves vite holding the port;
+# targeting the port listener catches the process that actually matters.
+free_dev_port() {
+  if command -v lsof >/dev/null 2>&1; then
+    local pids
+    pids=$(lsof -ti:5174 2>/dev/null || true)
+    if [[ -n "$pids" ]]; then
+      # shellcheck disable=SC2086
+      kill $pids 2>/dev/null || true
+    fi
   fi
-fi
+}
+
+# Tear down the dev server started for screenshots. Killing only $DEV_PID (the
+# pnpm wrapper) leaves vite alive and pnpm blocked waiting on it, so a plain
+# `wait $DEV_PID` hangs forever. Kill the child subtree and free the port, then
+# reap the wrapper.
+stop_dev_server() {
+  local pid="${1:-}"
+  if [[ -n "$pid" ]]; then
+    pkill -P "$pid" 2>/dev/null || true   # vite (and any other children)
+    kill "$pid" 2>/dev/null || true       # the pnpm wrapper
+  fi
+  free_dev_port
+  if [[ -n "$pid" ]]; then
+    wait "$pid" 2>/dev/null || true
+  fi
+}
+
+# Free a leftover dev server from a previous run before starting our own.
+free_dev_port
+sleep 1
+
+# Always tear the dev server down on exit, even if a later step fails.
+trap 'stop_dev_server "${DEV_PID:-}"' EXIT
 
 pnpm dev &
 DEV_PID=$!
@@ -129,8 +157,8 @@ else
   echo "Warning: dev server not responding after 20s, skipping screenshots"
 fi
 
-kill $DEV_PID 2>/dev/null || true
-wait $DEV_PID 2>/dev/null || true
+stop_dev_server "$DEV_PID"
+DEV_PID=""
 
 # --- Lint and test ---
 echo "Running lint..."


### PR DESCRIPTION
## Problem

During the v0.7.0 release, `scripts/release.sh` stalled for ~28 minutes after the screenshot step. `pnpm dev &` spawns `vite` as a child; the teardown only signalled `$DEV_PID` (the `pnpm` wrapper), leaving `vite` holding port 5174 and `pnpm` blocked waiting on it — so `wait $DEV_PID` never returned.

## Fix

- `stop_dev_server()` kills the child subtree (`pkill -P`) and frees the port listener (`lsof -ti:5174 | kill`) before reaping the wrapper, so `wait` returns promptly.
- Reuse the same port-freeing helper for the pre-existing-server cleanup at startup.
- Add an `EXIT` trap so a failure in a later step (lint/e2e) also tears the dev server down instead of orphaning it.

## Test

Verified against a real `pnpm dev`: teardown returns in 0s and port 5174 is freed, with no hang. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)