### PR TITLE
feat(community): bulk-share selected pets from the Stable table

### DIFF
--- a/src/lib/components/community/BulkSharePetDialog.svelte
+++ b/src/lib/components/community/BulkSharePetDialog.svelte
@@ -62,6 +62,10 @@ function finish() {
     if (failed) parts.push(`${failed} failed`);
     const msg = `Bulk share complete — ${parts.join(', ')}.`;
     onResult({ type: failed > 0 ? 'error' : created > 0 ? 'success' : 'info', message: msg });
+  } else if (runError) {
+    // Batch-wide failure (no per-pet summary). Surface it to the parent so the
+    // error survives the dialog closing as a StatusBanner, not just in-dialog.
+    onResult({ type: 'error', message: `Bulk share failed: ${runError}` });
   }
   onClose();
 }

--- a/src/lib/components/community/BulkSharePetDialog.svelte
+++ b/src/lib/components/community/BulkSharePetDialog.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
+import { isPlaceholderConfig } from '$lib/firebase.js';
+import { type BulkUploadSummary, uploadPets } from '$lib/services/shareService.js';
+import type { DialogResult, Pet } from '$lib/types/index.js';
+import { errorMessage } from '$lib/utils/error.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
+
+interface Props {
+  pets: Pet[];
+  onClose: () => void;
+  onResult: (result: DialogResult) => void;
+}
+
+const { pets, onClose, onResult }: Props = $props();
+
+type Phase = 'confirm' | 'running' | 'done';
+let phase = $state<Phase>('confirm');
+let done = $state(0);
+let summary = $state<BulkUploadSummary | null>(null);
+let runError = $state('');
+let cancelRequested = $state(false);
+
+const total = $derived(pets.length);
+const percent = $derived(total > 0 ? Math.round((done / total) * 100) : 0);
+
+// Pets whose problems (skipped/failed) are worth listing back to the user.
+const problems = $derived((summary?.items ?? []).filter((i) => i.status === 'skipped' || i.status === 'failed'));
+
+async function handleShare() {
+  if (isPlaceholderConfig || phase === 'running') return;
+  phase = 'running';
+  done = 0;
+  runError = '';
+  cancelRequested = false;
+  try {
+    // Notes are intentionally excluded from bulk shares: there's no per-pet
+    // review step, so we never publish the local notes field. Per-pet sharing
+    // remains the way to opt notes in.
+    const petsToShare = pets.map((p) => ({ ...p, notes: '' }));
+    summary = await uploadPets(petsToShare, {
+      onProgress: (d) => {
+        done = d;
+      },
+      shouldCancel: () => cancelRequested,
+    });
+    phase = 'done';
+  } catch (err) {
+    // uploadPets captures per-pet errors itself; reaching here means a
+    // batch-wide failure (e.g. the genome loader threw unexpectedly).
+    runError = errorMessage(err);
+    phase = 'done';
+  }
+}
+
+function finish() {
+  if (summary) {
+    const { created, alreadyShared, skipped, failed } = summary;
+    const parts = [`${created} shared`];
+    if (alreadyShared) parts.push(`${alreadyShared} already in catalogue`);
+    if (skipped) parts.push(`${skipped} skipped`);
+    if (failed) parts.push(`${failed} failed`);
+    const msg = `Bulk share complete — ${parts.join(', ')}.`;
+    onResult({ type: failed > 0 ? 'error' : created > 0 ? 'success' : 'info', message: msg });
+  }
+  onClose();
+}
+
+function handleClose() {
+  // Don't let a backdrop/Escape close abandon an in-flight run silently.
+  if (phase === 'running') {
+    cancelRequested = true;
+    return;
+  }
+  if (phase === 'done') finish();
+  else onClose();
+}
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+<div
+  class="modal-backdrop"
+  onclick={handleClose}
+  onkeydown={(e) => {
+    if (e.key === 'Escape') handleClose();
+  }}
+  role="presentation"
+  data-testid="bulk-share-backdrop"
+>
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="dialog bulk-share-dialog"
+    role="dialog"
+    aria-label="Share pets to community"
+    aria-modal="true"
+    tabindex="-1"
+    use:focusTrap
+    data-testid="bulk-share-dialog"
+    onclick={(e) => e.stopPropagation()}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') handleClose();
+    }}
+  >
+    <div class="dialog-header">
+      <h3>Share {total} {total === 1 ? 'pet' : 'pets'} to the community</h3>
+      <button class="close-btn" onclick={handleClose}>×</button>
+    </div>
+
+    <div class="dialog-body">
+      {#if isPlaceholderConfig}
+        <div class="banner banner-warn" data-testid="bulk-share-not-configured">
+          The community catalogue isn't configured for this build of Gorgonetics yet, so
+          uploads are disabled. See <code>docs/firebase-setup.md</code>.
+        </div>
+      {/if}
+
+      {#if phase === 'confirm'}
+        <p class="dialog-desc">
+          The genome and public fields (name, character, species, gender, breed, tags) of
+          each selected pet will be uploaded to the public catalogue, where other players
+          can import them. Uploads cannot be edited or deleted from within the app.
+        </p>
+        <ul class="confirm-notes">
+          <li><strong>Notes stay local</strong> — bulk share never uploads the notes field.</li>
+          <li>Pets already in the catalogue are detected and skipped automatically.</li>
+          <li>Pets imported before genome-text was stored will be skipped (re-import to share).</li>
+        </ul>
+      {:else if phase === 'running'}
+        <p class="dialog-desc">Sharing pets… you can cancel; pets already uploaded stay shared.</p>
+        <div
+          class="progress"
+          role="progressbar"
+          aria-valuemin="0"
+          aria-valuemax={total}
+          aria-valuenow={done}
+          data-testid="bulk-share-progress"
+        >
+          <div class="progress-fill" style="width: {percent}%"></div>
+        </div>
+        <p class="progress-label">{done} / {total}{cancelRequested ? ' (finishing current…)' : ''}</p>
+      {:else if phase === 'done'}
+        {#if runError}
+          <StatusBanner type="error" message={runError} />
+        {/if}
+        {#if summary}
+          <div class="summary" data-testid="bulk-share-summary">
+            <div class="summary-row"><span class="pill pill-ok">{summary.created}</span> shared</div>
+            {#if summary.alreadyShared > 0}
+              <div class="summary-row"><span class="pill">{summary.alreadyShared}</span> already in catalogue</div>
+            {/if}
+            {#if summary.skipped > 0}
+              <div class="summary-row"><span class="pill pill-warn">{summary.skipped}</span> skipped</div>
+            {/if}
+            {#if summary.failed > 0}
+              <div class="summary-row"><span class="pill pill-err">{summary.failed}</span> failed</div>
+            {/if}
+          </div>
+          {#if problems.length > 0}
+            <details class="problems">
+              <summary>Details ({problems.length})</summary>
+              <ul>
+                {#each problems as p (p.petId)}
+                  <li><strong>{p.petName}</strong> — {p.status}: {p.error}</li>
+                {/each}
+              </ul>
+            </details>
+          {/if}
+        {/if}
+      {/if}
+    </div>
+
+    <div class="dialog-footer">
+      {#if phase === 'confirm'}
+        <button class="btn btn-secondary" onclick={onClose}>Cancel</button>
+        <button
+          class="btn btn-primary"
+          data-testid="bulk-share-confirm"
+          onclick={handleShare}
+          disabled={isPlaceholderConfig || total === 0}
+        >
+          Share {total} {total === 1 ? 'pet' : 'pets'}
+        </button>
+      {:else if phase === 'running'}
+        <button class="btn btn-secondary" data-testid="bulk-share-cancel" onclick={() => { cancelRequested = true; }} disabled={cancelRequested}>
+          {cancelRequested ? 'Cancelling…' : 'Cancel'}
+        </button>
+      {:else}
+        <button class="btn btn-primary" data-testid="bulk-share-done" onclick={finish}>Done</button>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .bulk-share-dialog {
+    max-width: 480px;
+  }
+
+  .dialog-desc {
+    font-size: 14px;
+    color: var(--text-tertiary);
+    margin: 0 0 12px;
+  }
+
+  .confirm-notes {
+    margin: 0 0 8px;
+    padding-left: 18px;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .confirm-notes li {
+    margin-bottom: 4px;
+  }
+
+  .progress {
+    height: 10px;
+    background: var(--bg-tertiary);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .progress-fill {
+    height: 100%;
+    background: var(--accent);
+    transition: width 0.2s ease;
+  }
+  .progress-label {
+    margin: 8px 0 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .summary {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 14px;
+    margin-bottom: 12px;
+  }
+  .summary-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-secondary);
+  }
+  .pill {
+    display: inline-flex;
+    min-width: 22px;
+    justify-content: center;
+    padding: 1px 8px;
+    border-radius: 10px;
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .pill-ok {
+    background: color-mix(in srgb, var(--gene-positive) 20%, transparent);
+    color: var(--gene-positive);
+  }
+  .pill-warn {
+    background: color-mix(in srgb, var(--warning-text, #d97706) 20%, transparent);
+    color: var(--warning-text, #d97706);
+  }
+  .pill-err {
+    background: color-mix(in srgb, var(--gene-negative) 20%, transparent);
+    color: var(--gene-negative);
+  }
+
+  .problems {
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+  .problems summary {
+    cursor: pointer;
+    color: var(--text-tertiary);
+  }
+  .problems ul {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    max-height: 180px;
+    overflow: auto;
+  }
+  .problems li {
+    margin-bottom: 4px;
+    word-break: break-word;
+  }
+</style>

--- a/src/lib/components/stable/StableTable.svelte
+++ b/src/lib/components/stable/StableTable.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+import BulkSharePetDialog from '$lib/components/community/BulkSharePetDialog.svelte';
 import PetEditor from '$lib/components/pet/PetEditor.svelte';
+import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import {
   getAllAttributeNames,
   getAllAttributes,
@@ -9,7 +11,7 @@ import {
 import { comparisonActions, comparisonPets, comparisonReady } from '$lib/stores/comparison.js';
 import { allTags as allTagsStore, appState, pets } from '$lib/stores/pets.js';
 import { stableView } from '$lib/stores/stable.svelte.js';
-import { HORSE_BREEDS, type Pet } from '$lib/types/index.js';
+import { type DialogResult, HORSE_BREEDS, type Pet } from '$lib/types/index.js';
 
 interface Column {
   id: string;
@@ -30,6 +32,13 @@ const BREEDS_BY_SPECIES: Record<string, string[]> = {
 
 let editingPet = $state<Pet | null>(null);
 let editorOpen = $state(false);
+
+// Bulk-share selection. Keyed by pet id so it survives re-sorts and filter
+// narrowing; "select all" operates on the full filtered set (`sortedPets`),
+// not the rendered rows, so it covers every match regardless of scroll.
+let selectedIds = $state<Set<number>>(new Set());
+let bulkShareOpen = $state(false);
+let shareStatus = $state<DialogResult | null>(null);
 
 function isInComparison(id: number): boolean {
   return $comparisonPets[0]?.id === id || $comparisonPets[1]?.id === id;
@@ -181,6 +190,54 @@ $effect(() => {
   }
 });
 
+// --- Bulk-share selection ---
+
+// How many of the currently-visible (filtered) pets are selected drives the
+// header checkbox's checked/indeterminate state.
+const selectedInView = $derived(sortedPets.reduce((n, p) => n + (selectedIds.has(p.id) ? 1 : 0), 0));
+const allSelected = $derived(sortedPets.length > 0 && selectedInView === sortedPets.length);
+const someSelected = $derived(selectedInView > 0 && !allSelected);
+
+// Switching species changes the pet universe entirely; carrying a selection
+// across would let "Share selected" include pets you can no longer see.
+$effect(() => {
+  stableView.species; // track
+  selectedIds = new Set();
+});
+
+function toggleRow(id: number): void {
+  const next = new Set(selectedIds);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  selectedIds = next;
+}
+
+function toggleSelectAll(): void {
+  if (allSelected) {
+    // Clear only the in-view pets, preserving any selected-but-now-filtered.
+    const next = new Set(selectedIds);
+    for (const p of sortedPets) next.delete(p.id);
+    selectedIds = next;
+  } else {
+    const next = new Set(selectedIds);
+    for (const p of sortedPets) next.add(p.id);
+    selectedIds = next;
+  }
+}
+
+function clearSelection(): void {
+  selectedIds = new Set();
+}
+
+const selectedPets = $derived($pets.filter((p) => selectedIds.has(p.id)));
+
+function handleBulkShareResult(result: DialogResult): void {
+  shareStatus = result;
+  // A run that shared or skipped is "done" with these pets; clear so the user
+  // isn't left with a stale selection that re-shares on a second click.
+  if (result.type !== 'error') clearSelection();
+}
+
 function toggleSort(colId: string): void {
   const col = columns.find((c) => c.id === colId);
   if (!col || col.sortable === false) return;
@@ -215,12 +272,35 @@ function sortIndicator(colId: string): string {
             {/each}
         </div>
         <span class="count">{sortedPets.length} stabled</span>
+        {#if selectedIds.size > 0}
+            <div class="bulk-actions" data-testid="bulk-actions">
+                <span class="bulk-count">{selectedIds.size} selected</span>
+                <button
+                    class="bulk-share-btn"
+                    data-testid="bulk-share-open"
+                    onclick={() => { bulkShareOpen = true; }}
+                    title="Share the selected pets to the community catalogue"
+                >🌐 Share selected</button>
+                <button class="bulk-clear-btn" onclick={clearSelection} title="Clear selection">Clear</button>
+            </div>
+        {/if}
         {#if $comparisonReady}
             <button class="compare-now-btn" onclick={startCompare} title="Open comparison view">
                 ⚖️ Compare ({[$comparisonPets[0]?.name, $comparisonPets[1]?.name].filter(Boolean).join(' vs ')})
             </button>
         {/if}
     </header>
+
+    {#if shareStatus}
+        <div class="share-status">
+            <StatusBanner
+                type={shareStatus.type}
+                message={shareStatus.message}
+                autoDismissMs={8000}
+                onDismiss={() => { shareStatus = null; }}
+            />
+        </div>
+    {/if}
 
     <div class="filter-bar">
         <input
@@ -278,6 +358,18 @@ function sortIndicator(colId: string): string {
         <table class="stable-table">
             <thead>
                 <tr>
+                    <th class="select-col">
+                        <input
+                            type="checkbox"
+                            class="row-select"
+                            data-testid="bulk-select-all"
+                            checked={allSelected}
+                            indeterminate={someSelected}
+                            onchange={toggleSelectAll}
+                            aria-label="Select all {sortedPets.length} pets matching the current filters"
+                            title="Select all {sortedPets.length} matching"
+                        />
+                    </th>
                     {#each columns as col (col.id)}
                         <th
                             class="header-cell"
@@ -306,13 +398,23 @@ function sortIndicator(colId: string): string {
             <tbody>
                 {#if sortedPets.length === 0}
                     <tr>
-                        <td class="empty" colspan={columns.length}>
+                        <td class="empty" colspan={columns.length + 1}>
                             No stabled {stableView.species} pets.
                         </td>
                     </tr>
                 {:else}
                     {#each sortedPets as pet (pet.id)}
-                        <tr data-pet-id={pet.id}>
+                        <tr data-pet-id={pet.id} class:row-selected={selectedIds.has(pet.id)}>
+                            <td class="select-col">
+                                <input
+                                    type="checkbox"
+                                    class="row-select"
+                                    data-testid="bulk-select-row"
+                                    checked={selectedIds.has(pet.id)}
+                                    onchange={() => toggleRow(pet.id)}
+                                    aria-label="Select {pet.name}"
+                                />
+                            </td>
                             {#each columns as col (col.id)}
                                 <td class:numeric={col.numeric} class:compact={col.compact} data-col={col.id}>
                                     {#if col.id === 'actions'}
@@ -360,6 +462,14 @@ function sortIndicator(colId: string): string {
         bind:open={editorOpen}
         onClose={closeEditor}
         onSave={() => {}}
+    />
+{/if}
+
+{#if bulkShareOpen}
+    <BulkSharePetDialog
+        pets={selectedPets}
+        onClose={() => { bulkShareOpen = false; }}
+        onResult={handleBulkShareResult}
     />
 {/if}
 
@@ -547,6 +657,77 @@ function sortIndicator(colId: string): string {
         background: var(--accent);
         border-color: var(--accent);
         color: var(--bg-primary);
+    }
+
+    .bulk-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-left: auto;
+    }
+
+    .bulk-count {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text-secondary);
+    }
+
+    .bulk-share-btn {
+        padding: 6px 14px;
+        background: var(--accent);
+        border: none;
+        border-radius: 6px;
+        color: white;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s ease;
+    }
+
+    .bulk-share-btn:hover {
+        background: var(--accent-hover);
+    }
+
+    .bulk-clear-btn {
+        padding: 6px 10px;
+        background: transparent;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        color: var(--text-tertiary);
+        font-size: 12px;
+        cursor: pointer;
+    }
+
+    .bulk-clear-btn:hover {
+        color: var(--text-secondary);
+        border-color: var(--border-secondary);
+    }
+
+    /* When bulk-actions takes the right slot, Compare follows it rather than
+       grabbing the auto margin. */
+    .bulk-actions ~ .compare-now-btn {
+        margin-left: 0;
+    }
+
+    .share-status {
+        padding: 8px 16px 0;
+        flex-shrink: 0;
+    }
+
+    .select-col {
+        width: 1%;
+        text-align: center;
+        padding-left: 10px;
+        padding-right: 4px;
+    }
+
+    .row-select {
+        cursor: pointer;
+        margin: 0;
+    }
+
+    .stable-table tbody tr.row-selected {
+        background: var(--bg-selected);
     }
 
     .compare-now-btn {

--- a/src/lib/components/stable/StableTable.svelte
+++ b/src/lib/components/stable/StableTable.svelte
@@ -272,9 +272,9 @@ function sortIndicator(colId: string): string {
             {/each}
         </div>
         <span class="count">{sortedPets.length} stabled</span>
-        {#if selectedIds.size > 0}
+        {#if selectedPets.length > 0}
             <div class="bulk-actions" data-testid="bulk-actions">
-                <span class="bulk-count">{selectedIds.size} selected</span>
+                <span class="bulk-count">{selectedPets.length} selected</span>
                 <button
                     class="bulk-share-btn"
                     data-testid="bulk-share-open"

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -42,7 +42,13 @@ import {
 
 import { firestore as defaultFirestore } from '$lib/firebase.js';
 import { CURRENT_SCHEMA_VERSION } from '$lib/services/migrationService.js';
-import { findPetByHash, getPet, updatePet, uploadPet as uploadPetLocally } from '$lib/services/petService.js';
+import {
+  findPetByHash,
+  getPet,
+  getPetGenomeText,
+  updatePet,
+  uploadPet as uploadPetLocally,
+} from '$lib/services/petService.js';
 import { Gender, type ListPetsOpts, type Pet, type SharedPet, type SharedPetsPage } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
 
@@ -173,6 +179,99 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
     }
     throw err;
   }
+}
+
+/** Per-pet outcome of a bulk share. `skipped` = no shareable genome (legacy). */
+export type BulkUploadItemStatus = 'created' | 'already-shared' | 'skipped' | 'failed';
+
+export interface BulkUploadItemResult {
+  petId: number;
+  petName: string;
+  status: BulkUploadItemStatus;
+  contentHash?: string;
+  /** Present for `failed`/`skipped` — a human-readable reason. */
+  error?: string;
+}
+
+export interface BulkUploadSummary {
+  created: number;
+  alreadyShared: number;
+  skipped: number;
+  failed: number;
+  items: BulkUploadItemResult[];
+}
+
+export interface UploadPetsOptions {
+  /** Reports progress after each pet completes (0…total). */
+  onProgress?: (done: number, total: number) => void;
+  /** Abort early when this returns true (e.g. a user-cancelled dialog). */
+  shouldCancel?: () => boolean;
+  db?: Firestore;
+  /** Injectable seams for testing. */
+  upload?: (pet: Pet, db?: Firestore) => Promise<UploadResult>;
+  loadGenomeText?: (petId: number) => Promise<string | null>;
+}
+
+/**
+ * Share many local pets to the public catalogue, one at a time.
+ *
+ * Sequential by design: each pet is two Firestore writes, and a burst of
+ * hundreds of parallel writes risks tripping Spark-plan quotas and gives no
+ * usable progress signal. A single pet failing (network, corruption) never
+ * aborts the batch — its error is captured in `items` and the rest proceed.
+ *
+ * The in-memory pet list drops `genome_text` (see petService LIST_PET_COLUMNS),
+ * so the raw genome is loaded per pet here. A pet with no stored genome text
+ * (imported before migration v13) can't be shared and is reported as
+ * `skipped` rather than `failed` — it needs re-importing, not retrying.
+ */
+export async function uploadPets(pets: Pet[], options: UploadPetsOptions = {}): Promise<BulkUploadSummary> {
+  const upload = options.upload ?? uploadPet;
+  const loadGenomeText = options.loadGenomeText ?? getPetGenomeText;
+  const items: BulkUploadItemResult[] = [];
+  let done = 0;
+
+  for (const pet of pets) {
+    if (options.shouldCancel?.()) break;
+    const petName = pet.name ?? `Pet ${pet.id}`;
+    try {
+      // `genome_text` isn't on the list-projected pet; load it on demand.
+      const genomeText = pet.genome_text ?? (await loadGenomeText(pet.id)) ?? undefined;
+      if (!genomeText) {
+        items.push({
+          petId: pet.id,
+          petName,
+          status: 'skipped',
+          error: 'No stored genome text — re-import this pet before sharing.',
+        });
+        continue;
+      }
+      const result = await upload({ ...pet, genome_text: genomeText }, options.db);
+      items.push({
+        petId: pet.id,
+        petName,
+        status: result.status === 'created' ? 'created' : 'already-shared',
+        contentHash: result.contentHash,
+      });
+    } catch (err) {
+      items.push({ petId: pet.id, petName, status: 'failed', error: errorText(err) });
+    } finally {
+      done++;
+      options.onProgress?.(done, pets.length);
+    }
+  }
+
+  return {
+    created: items.filter((i) => i.status === 'created').length,
+    alreadyShared: items.filter((i) => i.status === 'already-shared').length,
+    skipped: items.filter((i) => i.status === 'skipped').length,
+    failed: items.filter((i) => i.status === 'failed').length,
+    items,
+  };
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 /**

--- a/tests/e2e/stable-table.spec.ts
+++ b/tests/e2e/stable-table.spec.ts
@@ -1,5 +1,5 @@
 import { expect, type Page, test } from '@playwright/test';
-import { waitForAppReady } from './helpers.js';
+import { blockFirestore, waitForAppReady } from './helpers.js';
 
 async function openStable(page: Page) {
   await page.goto('/');
@@ -152,5 +152,65 @@ test.describe('Stable Table', () => {
     await horseCompare.click();
 
     await expect(page.locator('.compare-now-btn')).toBeVisible();
+  });
+});
+
+test.describe('Stable Table — bulk share', () => {
+  test('select-all checks every filtered row and shows the bulk action bar', async ({ page }) => {
+    await openStable(page);
+    const rows = page.locator('.stable-table tbody tr[data-pet-id]');
+    const rowCount = await rows.count();
+    expect(rowCount).toBeGreaterThan(0);
+
+    // No selection → no bulk action bar.
+    await expect(page.getByTestId('bulk-actions')).toHaveCount(0);
+
+    await page.getByTestId('bulk-select-all').check();
+
+    // Every row checkbox is checked and the bar reports the full count.
+    const rowBoxes = page.getByTestId('bulk-select-row');
+    for (let i = 0; i < rowCount; i++) {
+      await expect(rowBoxes.nth(i)).toBeChecked();
+    }
+    await expect(page.getByTestId('bulk-actions')).toContainText(`${rowCount} selected`);
+
+    // Clear resets selection and hides the bar.
+    await page.locator('.bulk-clear-btn').click();
+    await expect(page.getByTestId('bulk-actions')).toHaveCount(0);
+    await expect(rowBoxes.first()).not.toBeChecked();
+  });
+
+  test('a single row selection opens the bulk dialog with the right count, and cancel closes it', async ({ page }) => {
+    await openStable(page);
+    await page.getByTestId('bulk-select-row').first().check();
+    await expect(page.getByTestId('bulk-actions')).toContainText('1 selected');
+
+    await page.getByTestId('bulk-share-open').click();
+    const dialog = page.getByTestId('bulk-share-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Share 1 pet to the community');
+    // Notes-excluded guarantee is stated up front.
+    await expect(dialog).toContainText('Notes stay local');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByTestId('bulk-share-dialog')).toHaveCount(0);
+  });
+
+  test('confirming starts the batch run (progress UI appears)', async ({ page }) => {
+    // Block Firestore so the run never touches the live catalogue. We assert
+    // the run *starts* (progress phase) rather than waiting for completion —
+    // the Firestore client queues writes when offline instead of failing fast,
+    // so the terminal summary is non-deterministic here. The created/skipped/
+    // failed accounting is covered by the uploadPets unit tests.
+    await blockFirestore(page);
+    await openStable(page);
+
+    await page.getByTestId('bulk-select-all').check();
+    await page.getByTestId('bulk-share-open').click();
+    await page.getByTestId('bulk-share-confirm').click();
+
+    // Confirm flips the dialog into the running phase with a progress bar.
+    await expect(page.getByTestId('bulk-share-progress')).toBeVisible();
+    await expect(page.getByTestId('bulk-share-cancel')).toBeVisible();
   });
 });

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -54,21 +54,24 @@ vi.mock('$lib/firebase.js', () => ({
 vi.mock('$lib/services/petService.js', () => ({
   findPetByHash: vi.fn(),
   getPet: vi.fn(),
+  getPetGenomeText: vi.fn(),
   updatePet: vi.fn(),
   uploadPet: vi.fn(),
 }));
 
 import { getDoc, getDocs, orderBy, startAfter, Timestamp, writeBatch } from 'firebase/firestore';
 import { findPetByHash, getPet, updatePet, uploadPet as uploadPetLocally } from '$lib/services/petService.js';
+import type { UploadResult } from '$lib/services/shareService.js';
 import {
   getSharedPet,
   importCommunityPet,
   listPets,
   sanitizeTags,
   uploadPet,
+  uploadPets,
   verifySharedPet,
 } from '$lib/services/shareService.js';
-import { Gender, type SharedPet } from '$lib/types/index.js';
+import { Gender, type Pet, type SharedPet } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
 import { makePet, DEFAULT_RAW_TEXT as RAW_TEXT, DEFAULT_RAW_TEXT_HASH as RAW_TEXT_HASH } from '../fixtures/sharePet.js';
 
@@ -814,5 +817,75 @@ describe('shareService.importCommunityPet', () => {
     expect(result.status).toBe('error');
     expect(result.message).toMatch(/Invalid genome file format/);
     expect(updatePet).not.toHaveBeenCalled();
+  });
+});
+
+describe('shareService.uploadPets', () => {
+  // uploadPets is exercised through its injectable `upload` / `loadGenomeText`
+  // seams so these stay pure — no Firestore, no real petService.
+  const pet = (id: number, over: Record<string, unknown> = {}) =>
+    ({ id, name: `Pet ${id}`, genome_text: `genome-${id}`, content_hash: `h${id}`, ...over }) as unknown as Pet;
+
+  function fakeUpload(byHash: Record<string, UploadResult['status'] | 'throw'>) {
+    return vi.fn(async (p: Pet): Promise<UploadResult> => {
+      const outcome = byHash[p.content_hash ?? ''] ?? 'created';
+      if (outcome === 'throw') throw new Error(`network failure for ${p.content_hash}`);
+      return { status: outcome, contentHash: p.content_hash ?? '' };
+    });
+  }
+
+  it('partitions outcomes into created / already-shared / skipped / failed', async () => {
+    const pets = [pet(1), pet(2), pet(3, { genome_text: null }), pet(4)];
+    const upload = fakeUpload({ h1: 'created', h2: 'already-shared', h4: 'throw' });
+    // Pet 3 has no in-memory genome_text and the loader also returns null → skipped.
+    const loadGenomeText = vi.fn().mockResolvedValue(null);
+
+    const summary = await uploadPets(pets, { upload, loadGenomeText });
+
+    expect(summary.created).toBe(1);
+    expect(summary.alreadyShared).toBe(1);
+    expect(summary.skipped).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.items.map((i) => i.status)).toEqual(['created', 'already-shared', 'skipped', 'failed']);
+    // A single failure never aborts the batch — pet 4 was still attempted.
+    expect(upload).toHaveBeenCalledTimes(3); // pets 1, 2, 4 (3 was skipped before upload)
+    expect(summary.items[3].error).toMatch(/network failure/);
+  });
+
+  it('reports progress once per pet, in order', async () => {
+    const pets = [pet(1), pet(2), pet(3)];
+    const onProgress = vi.fn();
+    await uploadPets(pets, { upload: fakeUpload({}), loadGenomeText: vi.fn(), onProgress });
+    expect(onProgress.mock.calls).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
+
+  it('lazy-loads genome_text only when the pet lacks it', async () => {
+    const pets = [pet(1, { genome_text: 'inline' }), pet(2, { genome_text: undefined })];
+    const upload = fakeUpload({});
+    const loadGenomeText = vi.fn().mockResolvedValue('loaded-text');
+
+    await uploadPets(pets, { upload, loadGenomeText });
+
+    // Pet 1 carried its text; only pet 2 triggers a load.
+    expect(loadGenomeText).toHaveBeenCalledTimes(1);
+    expect(loadGenomeText).toHaveBeenCalledWith(2);
+    expect(upload.mock.calls[0][0].genome_text).toBe('inline');
+    expect(upload.mock.calls[1][0].genome_text).toBe('loaded-text');
+  });
+
+  it('stops early when shouldCancel returns true', async () => {
+    const pets = [pet(1), pet(2), pet(3)];
+    const upload = fakeUpload({});
+    let calls = 0;
+    const shouldCancel = () => ++calls > 2; // allow pets 1 and 2, cancel before 3
+
+    const summary = await uploadPets(pets, { upload, loadGenomeText: vi.fn(), shouldCancel });
+
+    expect(summary.items).toHaveLength(2);
+    expect(upload).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -835,10 +835,12 @@ describe('shareService.uploadPets', () => {
   }
 
   it('partitions outcomes into created / already-shared / skipped / failed', async () => {
-    const pets = [pet(1), pet(2), pet(3, { genome_text: null }), pet(4)];
+    const pets = [pet(1), pet(2), pet(3, { genome_text: undefined }), pet(4)];
     const upload = fakeUpload({ h1: 'created', h2: 'already-shared', h4: 'throw' });
-    // Pet 3 has no in-memory genome_text and the loader also returns null → skipped.
-    const loadGenomeText = vi.fn().mockResolvedValue(null);
+    // Mirror production legacy semantics: the list projection drops genome_text
+    // (so the pet field is `undefined`), and getPetGenomeText returns '' for a
+    // pre-v13 row with no stored raw text. Both → skipped.
+    const loadGenomeText = vi.fn().mockResolvedValue('');
 
     const summary = await uploadPets(pets, { upload, loadGenomeText });
 


### PR DESCRIPTION
## What

Adds bulk sharing to the community catalogue. Previously pets could only be shared one at a time via the per-pet Share button; with large stables that's impractical.

- **Stable table**: row checkboxes + a header **select-all**. Select-all operates on the *entire filtered result set* (`sortedPets`), not the rendered rows — so it covers every pet matching the current filters regardless of scroll position (and stays correct if pagination/virtualization is ever added). Narrow with the existing filter bar (species, gender, breed, starred, tags), then select-all.
- A **"N selected · Share selected · Clear"** action bar appears in the header when anything is selected.
- **BulkSharePetDialog**: confirms the count, uploads sequentially with a progress bar + cancel, and reports a `created / already-shared / skipped / failed` summary with per-pet detail for problems.

## Decisions (per discussion)

- **Select-all = all filtered, not just the visible page.** Selection is keyed by pet id over the data array.
- **Notes are never uploaded in a bulk share** — there's no per-pet review step, so publishing notes would be too easy to do by accident. Per-pet sharing still allows opting notes in.
- **Sequential uploads**, not parallel: each pet is two Firestore writes; a burst of hundreds risks Spark-plan quota and gives no usable progress. One pet failing never aborts the batch.

## Implementation

- `shareService.uploadPets(pets, opts)` wraps `uploadPet` per pet, loads `genome_text` on demand (the list projection drops it for payload size), and captures per-pet outcomes. Injectable `upload`/`loadGenomeText` seams keep it unit-testable. Legacy pets without stored genome text are reported as `skipped` (need re-import), not `failed`.
- Selection clears on species switch (different pet universe).

## Tests

- Unit (`shareService.test.ts`): partitioning of created/already-shared/skipped/failed, progress callbacks, lazy genome load, and early cancel.
- E2E (`stable-table.spec.ts`): select-all checks every filtered row + shows the bar; single-select opens the dialog with the right count; confirm starts the run (progress UI). Firestore is network-blocked in the run test; terminal accounting is covered by the unit tests since the offline Firestore client queues writes rather than failing fast.

svelte-check 0 errors, lint clean, 688 unit + 15 stable-table e2e pass. Verified the selection UI and dialog in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)