### PR TITLE
feat(ui): shared BreedSelector primitive (redesign step 1)

### DIFF
--- a/src/lib/components/shared/BreedSelector.svelte
+++ b/src/lib/components/shared/BreedSelector.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+/**
+ * One breed control for the whole app. A compact popover trigger
+ * ("Breed: All ▾") that opens a single-select list of breeds (name +
+ * abbreviation). Replaces the dropdowns and 11-wide button rows that
+ * previously diverged across the Stable filter, pet gene grid, comparison
+ * diff controls, and the trio view. See docs/design/redesign-library-workspace-v1.md.
+ *
+ * Generic: `breeds` is a name→abbreviation map passed by the caller, so the
+ * same control serves filters (single-select breed) and lenses (offspring
+ * breed) without knowing about any species.
+ */
+import { onDestroy, onMount } from 'svelte';
+
+interface Props {
+  /** Currently selected breed name; '' means "all / no filter". */
+  value: string;
+  /** Breed name → abbreviation, e.g. `HORSE_BREEDS`. */
+  breeds: Record<string, string>;
+  /** Trigger prefix, e.g. "Breed" or "Offspring breed". */
+  label?: string;
+  /** Label for the "no filter" option. */
+  allLabel?: string;
+  onChange: (value: string) => void;
+}
+
+const { value, breeds, label = 'Breed', allLabel = 'All', onChange }: Props = $props();
+
+let open = $state(false);
+let root = $state<HTMLDivElement | undefined>();
+
+const entries = $derived(Object.entries(breeds));
+const currentLabel = $derived(value === '' ? allLabel : value);
+
+function choose(next: string): void {
+  open = false;
+  if (next !== value) onChange(next);
+}
+
+function onDocClick(e: MouseEvent): void {
+  if (open && root && !root.contains(e.target as Node)) open = false;
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (open && e.key === 'Escape') {
+    open = false;
+    e.stopPropagation();
+  }
+}
+
+onMount(() => {
+  document.addEventListener('click', onDocClick);
+  document.addEventListener('keydown', onKeydown);
+});
+
+onDestroy(() => {
+  document.removeEventListener('click', onDocClick);
+  document.removeEventListener('keydown', onKeydown);
+});
+</script>
+
+<div class="breed-selector" data-testid="breed-selector" bind:this={root}>
+  <button
+    type="button"
+    class="bs-trigger"
+    data-testid="breed-selector-trigger"
+    aria-haspopup="true"
+    aria-expanded={open}
+    onclick={(e) => { e.stopPropagation(); open = !open; }}
+  >
+    <span class="bs-label">{label}:</span>
+    <strong class="bs-value">{currentLabel}</strong>
+    <span class="bs-caret" aria-hidden="true">▾</span>
+  </button>
+
+  {#if open}
+    <div class="bs-pop" data-testid="breed-selector-pop" role="group" aria-label={label}>
+      <button
+        type="button"
+        class="bs-opt"
+        class:sel={value === ''}
+        aria-pressed={value === ''}
+        data-breed=""
+        onclick={() => choose('')}
+      >
+        <span class="bs-tick" aria-hidden="true">{value === '' ? '✓' : ''}</span>
+        <span class="bs-name">{allLabel}</span>
+      </button>
+      {#each entries as [name, abbrev] (name)}
+        <button
+          type="button"
+          class="bs-opt"
+          class:sel={value === name}
+          aria-pressed={value === name}
+          data-breed={name}
+          onclick={() => choose(name)}
+        >
+          <span class="bs-tick" aria-hidden="true">{value === name ? '✓' : ''}</span>
+          <span class="bs-name">{name}</span>
+          <span class="bs-ab">{abbrev}</span>
+        </button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .breed-selector { position: relative; display: inline-block; }
+
+  .bs-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-primary);
+    border-radius: 7px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .bs-trigger:hover { border-color: var(--border-secondary); }
+
+  .bs-label { color: var(--text-tertiary); }
+  .bs-value { color: var(--text-secondary); }
+  .bs-caret { color: var(--text-muted); font-size: 9px; }
+
+  .bs-pop {
+    position: absolute;
+    top: calc(100% + 5px);
+    left: 0;
+    z-index: 30;
+    min-width: 180px;
+    max-height: 260px;
+    overflow: auto;
+    padding: 5px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-primary);
+    border-radius: 9px;
+    box-shadow: var(--shadow-md, 0 4px 14px rgba(0, 0, 0, 0.1));
+  }
+
+  .bs-opt {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 9px;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .bs-opt:hover { background: var(--bg-hover); }
+  .bs-opt.sel { color: var(--accent-text, var(--accent)); font-weight: 600; }
+
+  .bs-tick { width: 12px; flex-shrink: 0; color: var(--accent); }
+  .bs-name { flex: 1; }
+  .bs-ab {
+    color: var(--text-muted);
+    font-size: 10px;
+    font-family: var(--mono, ui-monospace, monospace);
+    margin-left: auto;
+  }
+</style>

--- a/tests/unit/breedSelector.test.ts
+++ b/tests/unit/breedSelector.test.ts
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
+
+type Props = ComponentProps<typeof BreedSelector>;
+
+const BREEDS = { Standardbred: 'Sb', Kurbone: 'Kb', Ilmarian: 'Il' };
+
+function mount(over: Partial<Props> = {}) {
+  const onChange = vi.fn();
+  const utils = render(BreedSelector, {
+    value: '',
+    breeds: BREEDS,
+    onChange,
+    ...over,
+  } as unknown as Props);
+  return { ...utils, onChange };
+}
+
+const trigger = (c: HTMLElement) => c.querySelector('[data-testid="breed-selector-trigger"]') as HTMLButtonElement;
+const pop = (c: HTMLElement) => c.querySelector('[data-testid="breed-selector-pop"]');
+const opt = (c: HTMLElement, breed: string) => c.querySelector(`.bs-opt[data-breed="${breed}"]`) as HTMLButtonElement;
+
+afterEach(cleanup);
+
+describe('BreedSelector', () => {
+  it('shows the all-label on the trigger and keeps the popover closed initially', () => {
+    const { container } = mount();
+    expect(trigger(container).textContent).toContain('Breed:');
+    expect(trigger(container).textContent).toContain('All');
+    expect(trigger(container).getAttribute('aria-expanded')).toBe('false');
+    expect(pop(container)).toBeNull();
+  });
+
+  it('shows the selected breed name on the trigger', () => {
+    const { container } = mount({ value: 'Kurbone' });
+    expect(trigger(container).querySelector('.bs-value')?.textContent).toBe('Kurbone');
+  });
+
+  it('honors a custom label', () => {
+    const { container } = mount({ label: 'Offspring breed' });
+    expect(trigger(container).textContent).toContain('Offspring breed:');
+  });
+
+  it('opens on trigger click and lists All + every breed with its abbreviation', async () => {
+    const { container } = mount();
+    await fireEvent.click(trigger(container));
+    expect(pop(container)).not.toBeNull();
+    expect(trigger(container).getAttribute('aria-expanded')).toBe('true');
+    // All option plus one per breed.
+    expect(container.querySelectorAll('.bs-opt')).toHaveLength(1 + Object.keys(BREEDS).length);
+    const sb = opt(container, 'Standardbred');
+    expect(sb.textContent).toContain('Standardbred');
+    expect(sb.textContent).toContain('Sb');
+  });
+
+  it('selecting a breed calls onChange with its name and closes the popover', async () => {
+    const { container, onChange } = mount();
+    await fireEvent.click(trigger(container));
+    await fireEvent.click(opt(container, 'Ilmarian'));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('Ilmarian');
+    expect(pop(container)).toBeNull();
+  });
+
+  it('selecting All clears the filter (onChange with empty string)', async () => {
+    const { container, onChange } = mount({ value: 'Kurbone' });
+    await fireEvent.click(trigger(container));
+    await fireEvent.click(opt(container, ''));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('');
+  });
+
+  it('does not fire onChange when the already-selected value is re-picked', async () => {
+    const { container, onChange } = mount({ value: 'Kurbone' });
+    await fireEvent.click(trigger(container));
+    await fireEvent.click(opt(container, 'Kurbone'));
+    expect(onChange).not.toHaveBeenCalled();
+    expect(pop(container)).toBeNull(); // still closes
+  });
+
+  it('marks the current value as pressed/selected in the list', async () => {
+    const { container } = mount({ value: 'Standardbred' });
+    await fireEvent.click(trigger(container));
+    expect(opt(container, 'Standardbred').getAttribute('aria-pressed')).toBe('true');
+    expect(opt(container, 'Kurbone').getAttribute('aria-pressed')).toBe('false');
+    expect(opt(container, '').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('closes on Escape', async () => {
+    const { container } = mount();
+    await fireEvent.click(trigger(container));
+    expect(pop(container)).not.toBeNull();
+    await fireEvent.keyDown(document, { key: 'Escape' });
+    expect(pop(container)).toBeNull();
+  });
+
+  it('closes on an outside click', async () => {
+    const { container } = mount();
+    await fireEvent.click(trigger(container));
+    expect(pop(container)).not.toBeNull();
+    await fireEvent.click(document.body);
+    expect(pop(container)).toBeNull();
+  });
+
+  it('stays open when clicking inside the popover chrome (non-option area)', async () => {
+    const { container } = mount();
+    await fireEvent.click(trigger(container));
+    await fireEvent.click(pop(container) as Element);
+    expect(pop(container)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
First shared primitive for the Library + Workspace redesign (`docs/design/redesign-library-workspace-v1.md`, §5 step 1).

## What
One reusable **breed control**: a compact popover trigger ("Breed: All ▾") that opens a single-select list of breeds (name + abbreviation). It's the single control meant to replace the divergent breed selectors today — a `<select>` dropdown in the Stable filter and the Breed tab, and an 11-wide button row in the pet gene grid, comparison diff controls, and trio view.

Generic by design: `breeds` is a name→abbreviation map passed by the caller (e.g. `HORSE_BREEDS`), so the same control serves filters (single-select breed) and lenses (offspring breed) without knowing about any species. Props: `value`, `breeds`, `label?`, `allLabel?`, `onChange`.

## Behaviour
- Single-select; selecting "All" clears to `''`; re-picking the current value is a no-op but still closes.
- Closes on selection, Escape, and outside click.
- Uses the app's existing CSS tokens; `aria-haspopup`/`aria-expanded` on the trigger, `aria-pressed` on the selected option.

## Scope
Lands **behind the current UI** — no call sites migrated yet (per the doc's incremental plan; each call site is converted in a later step, updating its e2e alongside). It's exercised by 11 unit tests via `@testing-library/svelte` rather than e2e, since it isn't wired into a page yet.

## Tests
`tests/unit/breedSelector.test.ts` — trigger label, custom label, open/close, option list + abbreviations, onChange semantics (select / clear / no-op re-pick), selected-state marking, Escape, outside-click, inside-click-stays-open. svelte-check 0 errors, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)