### PR TITLE
feat(ui): EmptyState + PageHeader primitives (redesign steps 2-3)

### DIFF
--- a/src/lib/components/shared/EmptyState.svelte
+++ b/src/lib/components/shared/EmptyState.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+/**
+ * One empty / prompt state for the whole app. Replaces the ad-hoc paw-print
+ * "Select a pet to view details" markup that was copy-pasted across views —
+ * including onto the Genes tab, where it described the wrong thing. Every
+ * caller passes context-appropriate copy, so an empty state always explains
+ * what *this* surface needs. See docs/design/redesign-library-workspace-v1.md.
+ */
+
+interface Props {
+  /** Optional decorative glyph (emoji). Omit for a text-only state. */
+  icon?: string;
+  /** Short, specific headline — what to do, not an apology. */
+  title: string;
+  /** Optional one-line elaboration. */
+  body?: string;
+  /** Optional call to action. Both label and handler are required to show it. */
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const { icon, title, body, actionLabel, onAction }: Props = $props();
+const hasAction = $derived(!!actionLabel && !!onAction);
+</script>
+
+<div class="empty-state" data-testid="empty-state">
+  <div class="es-inner">
+    {#if icon}
+      <div class="es-icon" data-testid="empty-state-icon" aria-hidden="true">{icon}</div>
+    {/if}
+    <h3 class="es-title">{title}</h3>
+    {#if body}
+      <p class="es-body">{body}</p>
+    {/if}
+    {#if hasAction}
+      <button type="button" class="es-action" data-testid="empty-state-action" onclick={onAction}>
+        {actionLabel}
+      </button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .empty-state {
+    height: 100%;
+    display: grid;
+    place-items: center;
+    padding: 32px;
+    text-align: center;
+  }
+  .es-inner { max-width: 380px; display: flex; flex-direction: column; align-items: center; gap: 6px; }
+  .es-icon { font-size: 40px; line-height: 1; opacity: 0.55; margin-bottom: 6px; }
+  .es-title { font-size: 16px; font-weight: 600; color: var(--text-secondary); margin: 0; }
+  .es-body { font-size: 13px; color: var(--text-muted); margin: 0; }
+  .es-action {
+    margin-top: 12px;
+    padding: 7px 16px;
+    border: none;
+    border-radius: 7px;
+    background: var(--accent);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .es-action:hover { background: var(--accent-hover); }
+</style>

--- a/src/lib/components/shared/PageHeader.svelte
+++ b/src/lib/components/shared/PageHeader.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+/**
+ * One page-header pattern for the whole app. Today every view headers itself
+ * differently — Pets/Genes have none, Stable a bare "Stable", Breed a big
+ * "💞 Breeding Assistant" + subtitle, Community "Community catalogue" +
+ * subtitle. This unifies them: an optional icon, a title, an optional
+ * subtitle, and a right-aligned `actions` slot for controls.
+ * See docs/design/redesign-library-workspace-v1.md.
+ */
+import type { Snippet } from 'svelte';
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  /** Optional decorative glyph (emoji) before the title. */
+  icon?: string;
+  /** Right-aligned controls (buttons, toggles, badges). */
+  actions?: Snippet;
+}
+
+const { title, subtitle, icon, actions }: Props = $props();
+</script>
+
+<header class="page-header" data-testid="page-header">
+  <div class="ph-text">
+    <h2 class="ph-title">
+      {#if icon}<span class="ph-icon" aria-hidden="true">{icon}</span>{/if}
+      {title}
+    </h2>
+    {#if subtitle}
+      <p class="ph-subtitle" data-testid="page-header-subtitle">{subtitle}</p>
+    {/if}
+  </div>
+  {#if actions}
+    <div class="ph-actions" data-testid="page-header-actions">
+      {@render actions()}
+    </div>
+  {/if}
+</header>
+
+<style>
+  .page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 22px;
+    border-bottom: 1px solid var(--border-primary);
+    background: var(--bg-primary);
+    flex-shrink: 0;
+  }
+  .ph-text { min-width: 0; }
+  .ph-title {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+  .ph-icon { font-size: 18px; line-height: 1; }
+  .ph-subtitle { margin: 2px 0 0; font-size: 12px; color: var(--text-tertiary); }
+  .ph-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+</style>

--- a/tests/fixtures/PageHeaderHarness.svelte
+++ b/tests/fixtures/PageHeaderHarness.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+/** Test harness: renders PageHeader with an `actions` snippet so the slot
+ * can be asserted without hand-rolling createRawSnippet in the test. */
+import PageHeader from '$lib/components/shared/PageHeader.svelte';
+
+interface Props {
+  title: string;
+  subtitle?: string;
+  icon?: string;
+}
+const { title, subtitle, icon }: Props = $props();
+</script>
+
+<PageHeader {title} {subtitle} {icon}>
+  {#snippet actions()}
+    <button type="button" data-testid="harness-action">Do thing</button>
+  {/snippet}
+</PageHeader>

--- a/tests/unit/emptyState.test.ts
+++ b/tests/unit/emptyState.test.ts
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import EmptyState from '$lib/components/shared/EmptyState.svelte';
+
+type Props = ComponentProps<typeof EmptyState>;
+
+function mount(over: Partial<Props> = {}) {
+  return render(EmptyState, { title: 'Pick a pet', ...over } as unknown as Props);
+}
+
+afterEach(cleanup);
+
+describe('EmptyState', () => {
+  it('renders the title', () => {
+    const { container } = mount();
+    expect(container.querySelector('.es-title')?.textContent).toBe('Pick a pet');
+  });
+
+  it('renders the body when provided', () => {
+    const { container } = mount({ body: 'Choose one from the list.' });
+    expect(container.querySelector('.es-body')?.textContent).toBe('Choose one from the list.');
+  });
+
+  it('omits the body element when not provided', () => {
+    const { container } = mount();
+    expect(container.querySelector('.es-body')).toBeNull();
+  });
+
+  it('renders the icon when provided', () => {
+    const { container } = mount({ icon: '🐾' });
+    expect(container.querySelector('[data-testid="empty-state-icon"]')?.textContent).toBe('🐾');
+  });
+
+  it('omits the icon when not provided', () => {
+    const { container } = mount();
+    expect(container.querySelector('[data-testid="empty-state-icon"]')).toBeNull();
+  });
+
+  it('shows the action and fires onAction only when both label and handler are given', async () => {
+    const onAction = vi.fn();
+    const { container } = mount({ actionLabel: 'Upload genome', onAction });
+    const btn = container.querySelector('[data-testid="empty-state-action"]') as HTMLButtonElement;
+    expect(btn.textContent?.trim()).toBe('Upload genome');
+    await fireEvent.click(btn);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the action when the label is missing even if a handler is passed', () => {
+    const { container } = mount({ onAction: vi.fn() });
+    expect(container.querySelector('[data-testid="empty-state-action"]')).toBeNull();
+  });
+
+  it('hides the action when the handler is missing even if a label is passed', () => {
+    const { container } = mount({ actionLabel: 'Do it' });
+    expect(container.querySelector('[data-testid="empty-state-action"]')).toBeNull();
+  });
+});

--- a/tests/unit/pageHeader.test.ts
+++ b/tests/unit/pageHeader.test.ts
@@ -1,0 +1,48 @@
+import { cleanup, render } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import PageHeader from '$lib/components/shared/PageHeader.svelte';
+import PageHeaderHarness from '../fixtures/PageHeaderHarness.svelte';
+
+type Props = ComponentProps<typeof PageHeader>;
+
+function mount(over: Partial<Props> = {}) {
+  return render(PageHeader, { title: 'Stable', ...over } as unknown as Props);
+}
+
+afterEach(cleanup);
+
+describe('PageHeader', () => {
+  it('renders the title', () => {
+    const { container } = mount();
+    expect(container.querySelector('.ph-title')?.textContent?.trim()).toBe('Stable');
+  });
+
+  it('renders the subtitle when provided', () => {
+    const { container } = mount({ subtitle: 'Rank stabled pairs.' });
+    expect(container.querySelector('[data-testid="page-header-subtitle"]')?.textContent).toBe('Rank stabled pairs.');
+  });
+
+  it('omits the subtitle when not provided', () => {
+    const { container } = mount();
+    expect(container.querySelector('[data-testid="page-header-subtitle"]')).toBeNull();
+  });
+
+  it('renders the icon before the title when provided', () => {
+    const { container } = mount({ icon: '💞', title: 'Breeding' });
+    expect(container.querySelector('.ph-icon')?.textContent).toBe('💞');
+    expect(container.querySelector('.ph-title')?.textContent).toContain('Breeding');
+  });
+
+  it('omits the actions container when no actions snippet is given', () => {
+    const { container } = mount();
+    expect(container.querySelector('[data-testid="page-header-actions"]')).toBeNull();
+  });
+
+  it('renders the actions snippet content when provided', () => {
+    const { container } = render(PageHeaderHarness, { title: 'Stable' } as never);
+    const actions = container.querySelector('[data-testid="page-header-actions"]');
+    expect(actions).not.toBeNull();
+    expect(actions?.querySelector('[data-testid="harness-action"]')?.textContent).toBe('Do thing');
+  });
+});


### PR DESCRIPTION
Redesign primitives 2 and 3, targeting the epic branch `redesign/library-workspace` (`docs/design/redesign-library-workspace-v1.md`, §5 step 1).

## EmptyState
One context-driven empty/prompt state — `icon?`, `title`, `body?`, optional `actionLabel`/`onAction`. Replaces the paw-print "Select a pet to view details" markup that was copy-pasted across views, including onto the **Genes tab** where it described the wrong thing. Callers pass copy that fits the surface, so an empty state always explains what *this* view needs (the action shows only when both label and handler are given).

## PageHeader
One header pattern — `icon?`, `title`, `subtitle?`, and a right-aligned `actions` snippet — to unify the four ad-hoc header styles today (Pets/Genes have none, Stable a bare title, Breed a big icon+subtitle, Community title+subtitle).

## Scope
Both land **behind the current UI**; per-view adoption follows in later steps.

## Tests
- `emptyState.test.ts` — title, body present/absent, icon present/absent, action fires, action hidden unless both label+handler.
- `pageHeader.test.ts` — title, subtitle present/absent, icon, actions-absent, and actions-snippet rendering (via `tests/fixtures/PageHeaderHarness.svelte`).
- 14 tests; svelte-check 0 errors; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)