### PR TITLE
feat(ui): FilterBar primitive (redesign step 5)

### DIFF
--- a/src/lib/components/shared/FilterBar.svelte
+++ b/src/lib/components/shared/FilterBar.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+/**
+ * One filter bar for the Library. Unifies the divergent filter vocabularies
+ * the app uses today — per-card text, segmented species toggles, breed
+ * dropdowns vs. button rows, and a mix of pills and `<select>`s — into a
+ * single control language: a search box, a segmented species toggle, the
+ * shared BreedSelector, and toggle pills for boolean flags.
+ * See docs/design/redesign-library-workspace-v1.md.
+ *
+ * Fully controlled: the parent owns the filter state and gets a callback per
+ * change. Every section is optional — omit a prop and that control disappears,
+ * so the same bar serves species-scoped and species-agnostic surfaces.
+ */
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
+
+interface FlagSpec {
+  key: string;
+  label: string;
+  active: boolean;
+}
+
+interface Props {
+  search: string;
+  onSearch: (value: string) => void;
+  searchPlaceholder?: string;
+  /** Species options (e.g. ['beewasp','horse']); omit to hide the toggle. */
+  species?: string[];
+  /** Active species; '' means "all". */
+  activeSpecies?: string;
+  onSpecies?: (value: string) => void;
+  allSpeciesLabel?: string;
+  /** Breed name→abbreviation map; omit to hide the breed control. */
+  breeds?: Record<string, string>;
+  breed?: string;
+  onBreed?: (value: string) => void;
+  /** Toggle pills (starred, stabled, pet-quality, tags…). */
+  flags?: FlagSpec[];
+  onToggleFlag?: (key: string) => void;
+}
+
+const {
+  search,
+  onSearch,
+  searchPlaceholder = 'Search pets…',
+  species,
+  activeSpecies = '',
+  onSpecies,
+  allSpeciesLabel = 'All',
+  breeds,
+  breed = '',
+  onBreed,
+  flags,
+  onToggleFlag,
+}: Props = $props();
+</script>
+
+<div class="filter-bar" data-testid="filter-bar">
+  <input
+    type="search"
+    class="fb-search"
+    data-testid="filter-search"
+    placeholder={searchPlaceholder}
+    value={search}
+    oninput={(e) => onSearch(e.currentTarget.value)}
+  />
+
+  {#if species && species.length > 0}
+    <div class="fb-seg" role="group" aria-label="Species" data-testid="filter-species">
+      <button
+        type="button"
+        class="fb-seg-btn"
+        class:active={activeSpecies === ''}
+        aria-pressed={activeSpecies === ''}
+        data-species=""
+        onclick={() => onSpecies?.('')}
+      >{allSpeciesLabel}</button>
+      {#each species as sp (sp)}
+        <button
+          type="button"
+          class="fb-seg-btn"
+          class:active={activeSpecies === sp}
+          aria-pressed={activeSpecies === sp}
+          data-species={sp}
+          onclick={() => onSpecies?.(sp)}
+        >{sp}</button>
+      {/each}
+    </div>
+  {/if}
+
+  {#if breeds}
+    <BreedSelector value={breed} {breeds} onChange={(v) => onBreed?.(v)} />
+  {/if}
+
+  {#if flags && flags.length > 0}
+    <div class="fb-flags" data-testid="filter-flags">
+      {#each flags as flag (flag.key)}
+        <button
+          type="button"
+          class="fb-pill"
+          class:active={flag.active}
+          aria-pressed={flag.active}
+          data-flag={flag.key}
+          onclick={() => onToggleFlag?.(flag.key)}
+        >{flag.label}</button>
+      {/each}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .fb-search {
+    flex: 0 1 220px;
+    min-width: 140px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-primary);
+    border-radius: 7px;
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-size: 12px;
+  }
+  .fb-search::placeholder { color: var(--text-muted); }
+  .fb-search:focus { outline: none; border-color: var(--accent); background: var(--bg-primary); }
+
+  .fb-seg { display: inline-flex; background: var(--bg-tertiary); border-radius: 7px; padding: 2px; }
+  .fb-seg-btn {
+    border: none;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    text-transform: capitalize;
+  }
+  .fb-seg-btn:hover { color: var(--text-secondary); }
+  .fb-seg-btn.active { background: var(--bg-primary); color: var(--text-primary); box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.06)); }
+
+  .fb-flags { display: flex; flex-wrap: wrap; gap: 4px; }
+  .fb-pill {
+    border: 1px solid var(--border-primary);
+    background: var(--bg-primary);
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-weight: 600;
+    padding: 4px 9px;
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  .fb-pill:hover { border-color: var(--accent); color: var(--accent); }
+  .fb-pill.active { background: var(--accent); border-color: var(--accent); color: #fff; }
+</style>

--- a/tests/unit/filterBar.test.ts
+++ b/tests/unit/filterBar.test.ts
@@ -1,0 +1,79 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import type { ComponentProps } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import FilterBar from '$lib/components/shared/FilterBar.svelte';
+
+type Props = ComponentProps<typeof FilterBar>;
+
+function mount(over: Partial<Props> = {}) {
+  const onSearch = vi.fn();
+  const utils = render(FilterBar, { search: '', onSearch, ...over } as unknown as Props);
+  return { ...utils, onSearch };
+}
+
+const q = (c: HTMLElement, sel: string) => c.querySelector(sel);
+const search = (c: HTMLElement) => c.querySelector('[data-testid="filter-search"]') as HTMLInputElement;
+
+afterEach(cleanup);
+
+describe('FilterBar', () => {
+  it('renders the search box with placeholder and value, and fires onSearch on input', async () => {
+    const { container, onSearch } = mount({ search: 'roach', searchPlaceholder: 'Find…' });
+    expect(search(container).value).toBe('roach');
+    expect(search(container).placeholder).toBe('Find…');
+    await fireEvent.input(search(container), { target: { value: 'bee' } });
+    expect(onSearch).toHaveBeenCalledWith('bee');
+  });
+
+  it('hides optional sections when their props are omitted', () => {
+    const { container } = mount();
+    expect(q(container, '[data-testid="filter-species"]')).toBeNull();
+    expect(q(container, '[data-testid="breed-selector"]')).toBeNull();
+    expect(q(container, '[data-testid="filter-flags"]')).toBeNull();
+  });
+
+  it('renders the species toggle with All + each option and reflects the active one', () => {
+    const { container } = mount({ species: ['beewasp', 'horse'], activeSpecies: 'horse' });
+    const seg = q(container, '[data-testid="filter-species"]') as HTMLElement;
+    const btns = seg.querySelectorAll('.fb-seg-btn');
+    expect([...btns].map((b) => b.getAttribute('data-species'))).toEqual(['', 'beewasp', 'horse']);
+    expect(seg.querySelector('[data-species="horse"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(seg.querySelector('[data-species=""]')?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('fires onSpecies with the species value, and "" for All', async () => {
+    const onSpecies = vi.fn();
+    const { container } = mount({ species: ['beewasp', 'horse'], activeSpecies: 'horse', onSpecies });
+    await fireEvent.click(container.querySelector('[data-species="beewasp"]') as HTMLButtonElement);
+    await fireEvent.click(container.querySelector('[data-species=""]') as HTMLButtonElement);
+    expect(onSpecies).toHaveBeenNthCalledWith(1, 'beewasp');
+    expect(onSpecies).toHaveBeenNthCalledWith(2, '');
+  });
+
+  it('renders the shared BreedSelector when breeds are provided and forwards selection', async () => {
+    const onBreed = vi.fn();
+    const { container } = mount({ breeds: { Standardbred: 'Sb', Kurbone: 'Kb' }, breed: '', onBreed });
+    const trigger = container.querySelector('[data-testid="breed-selector-trigger"]') as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    await fireEvent.click(trigger);
+    await fireEvent.click(container.querySelector('.bs-opt[data-breed="Kurbone"]') as HTMLButtonElement);
+    expect(onBreed).toHaveBeenCalledWith('Kurbone');
+  });
+
+  it('renders flag pills reflecting active state and toggles them', async () => {
+    const onToggleFlag = vi.fn();
+    const { container } = mount({
+      flags: [
+        { key: 'starred', label: '★ Starred', active: false },
+        { key: 'stabled', label: '🏠 Stabled', active: true },
+      ],
+      onToggleFlag,
+    });
+    const pills = container.querySelectorAll('.fb-pill');
+    expect(pills).toHaveLength(2);
+    expect(container.querySelector('[data-flag="stabled"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-flag="starred"]')?.getAttribute('aria-pressed')).toBe('false');
+    await fireEvent.click(container.querySelector('[data-flag="starred"]') as HTMLButtonElement);
+    expect(onToggleFlag).toHaveBeenCalledExactlyOnceWith('starred');
+  });
+});


### PR DESCRIPTION
Redesign primitive 5 — the Library's filter row. Targets the epic `redesign/library-workspace` (`docs/design/redesign-library-workspace-v1.md`, §5 step 1).

## What
One **filter bar** unifying the divergent filter vocabularies today (per-card text, segmented species toggles, breed dropdown vs. button row, a mix of pills and `<select>`s) into a single control language:
- a **search** box,
- a segmented **species** toggle (All + each species),
- the shared **BreedSelector** (composed, only when `breeds` provided),
- **toggle pills** for boolean flags (starred / stabled / pet-quality / tags).

Fully controlled — the parent owns filter state and gets a callback per change. Every section is optional, so the same bar serves species-scoped and species-agnostic surfaces.

## Scope
Lands behind the current UI; per-call-site adoption follows.

## Tests
`filterBar.test.ts` (6) — search value/placeholder + input callback, optional sections hidden when omitted, species toggle (All + options, active state, `''` for All), composed BreedSelector forwarding selection, flag pills active-state + toggle. svelte-check 0 errors/0 warnings, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)