### PR TITLE
feat(redesign): Library + Workspace shell behind a flag (adoption slice 1)

### DIFF
--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import ComparisonPetPicker from '$lib/components/comparison/ComparisonPetPicker.svelte';
 import GeneEditor from '$lib/components/gene/GeneEditor.svelte';
+import Library from '$lib/components/library/Library.svelte';
 import PetList from '$lib/components/pet/PetList.svelte';
 import { activeTab } from '$lib/stores/pets.js';
 import {
@@ -83,6 +84,8 @@ function onHandleKeydown(e: KeyboardEvent) {
             </div>
         {:else if $activeTab === "compare"}
             <ComparisonPetPicker />
+        {:else if $activeTab === "library"}
+            <Library />
         {/if}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <!-- svelte-ignore a11y_no_noninteractive_tabindex -->

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ArrowLeft } from '@lucide/svelte';
 import logoImg from '$lib/assets/logo.png';
+import { redesignEnabled } from '$lib/stores/flags.js';
 import { activeTab, appState, canGoBack, type Tab } from '$lib/stores/pets.js';
 import DataMenu from './DataMenu.svelte';
 import SettingsModal from './SettingsModal.svelte';
@@ -46,6 +47,16 @@ function handleMouseUp(e: MouseEvent) {
         <ArrowLeft size={16} />
     </button>
     <nav aria-label="Main navigation" class="top-bar-tabs">
+        {#if redesignEnabled}
+            <button
+                class="tab-btn"
+                class:active={$activeTab === "library"}
+                data-testid="tab-library"
+                onclick={() => switchTab("library")}
+            >
+                ✨ My Pets
+            </button>
+        {/if}
         <button
             class="tab-btn"
             class:active={$activeTab === "pets"}

--- a/src/lib/components/library/Library.svelte
+++ b/src/lib/components/library/Library.svelte
@@ -9,7 +9,7 @@ import FilterBar from '$lib/components/shared/FilterBar.svelte';
 import PetRow from '$lib/components/shared/PetRow.svelte';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { clearLibrarySelection, libraryView, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
-import { allTags as allTagsStore, pets } from '$lib/stores/pets.js';
+import { pets } from '$lib/stores/pets.js';
 import { HORSE_BREEDS, type Pet } from '$lib/types/index.js';
 import { filterPets } from '$lib/utils/petFilter.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
@@ -44,13 +44,22 @@ const flags = $derived([
   { key: 'petQuality', label: '🏆 Pet quality', active: libraryView.petQualityOnly },
 ]);
 
-// Switching species invalidates a breed from another species, and a stale
-// selection from another species shouldn't linger.
+// A breed from another species no longer applies once the species changes.
 $effect(() => {
   libraryView.species;
   if (libraryView.breed && (!breedsForSpecies || !(libraryView.breed in breedsForSpecies))) {
     libraryView.breed = '';
   }
+});
+
+// Clear the multi-selection when the species changes — pets selected under the
+// old species would otherwise linger invisibly and still drive the Workspace
+// (which resolves selection against the full pet list, not the filtered view).
+// Tracks species only, so narrowing other filters (breed/flags) keeps the
+// selection. Runs once on mount against an empty set (a no-op).
+$effect(() => {
+  libraryView.species;
+  clearLibrarySelection();
 });
 
 function toggleFlag(key: string): void {

--- a/src/lib/components/library/Library.svelte
+++ b/src/lib/components/library/Library.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+/**
+ * The Library — the redesign's persistent pet list. One filter bar + one pet
+ * row, in card or table density, with multi-select that drives the Workspace.
+ * Replaces the Pets sidebar and the Stable filters. Behind the redesign flag
+ * until cutover. See docs/design/redesign-library-workspace-v1.md.
+ */
+import FilterBar from '$lib/components/shared/FilterBar.svelte';
+import PetRow from '$lib/components/shared/PetRow.svelte';
+import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { clearLibrarySelection, libraryView, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
+import { allTags as allTagsStore, pets } from '$lib/stores/pets.js';
+import { HORSE_BREEDS, type Pet } from '$lib/types/index.js';
+import { filterPets } from '$lib/utils/petFilter.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
+
+const speciesOptions = getSupportedSpecies();
+
+// Breed maps per species. Horse has canonical abbreviations; beewasp's
+// sub-types are their own labels (no invented abbreviations).
+const BREEDS_BY_SPECIES: Record<string, Record<string, string>> = {
+  beewasp: { Bee: 'Bee', Wasp: 'Wasp' },
+  horse: HORSE_BREEDS,
+};
+
+// Breed filtering only makes sense within a single species.
+const breedsForSpecies = $derived(libraryView.species ? BREEDS_BY_SPECIES[libraryView.species] : undefined);
+
+const filtered = $derived(
+  filterPets($pets, {
+    query: libraryView.search,
+    tags: libraryView.tags,
+    starredOnly: libraryView.starredOnly,
+    stabledOnly: libraryView.stabledOnly,
+    petQualityOnly: libraryView.petQualityOnly,
+    species: libraryView.species,
+    breed: libraryView.breed,
+  }),
+);
+
+const flags = $derived([
+  { key: 'starred', label: '★ Starred', active: libraryView.starredOnly },
+  { key: 'stabled', label: '🏠 Stabled', active: libraryView.stabledOnly },
+  { key: 'petQuality', label: '🏆 Pet quality', active: libraryView.petQualityOnly },
+]);
+
+// Switching species invalidates a breed from another species, and a stale
+// selection from another species shouldn't linger.
+$effect(() => {
+  libraryView.species;
+  if (libraryView.breed && (!breedsForSpecies || !(libraryView.breed in breedsForSpecies))) {
+    libraryView.breed = '';
+  }
+});
+
+function toggleFlag(key: string): void {
+  if (key === 'starred') libraryView.starredOnly = !libraryView.starredOnly;
+  else if (key === 'stabled') libraryView.stabledOnly = !libraryView.stabledOnly;
+  else if (key === 'petQuality') libraryView.petQualityOnly = !libraryView.petQualityOnly;
+}
+
+function metaFor(pet: Pet): string {
+  return [normalizeSpecies(pet.species), pet.breed || null, pet.gender].filter(Boolean).join(' · ');
+}
+</script>
+
+<div class="library" data-testid="library">
+  <div class="lib-head">
+    <FilterBar
+      search={libraryView.search}
+      onSearch={(v) => { libraryView.search = v; }}
+      species={speciesOptions}
+      activeSpecies={libraryView.species}
+      onSpecies={(v) => { libraryView.species = v; }}
+      breeds={breedsForSpecies}
+      breed={libraryView.breed}
+      onBreed={(v) => { libraryView.breed = v; }}
+      {flags}
+      onToggleFlag={toggleFlag}
+    />
+    <div class="lib-subhead">
+      <div class="density" role="group" aria-label="List density">
+        <button
+          type="button"
+          class:active={libraryView.density === 'card'}
+          aria-pressed={libraryView.density === 'card'}
+          onclick={() => { libraryView.density = 'card'; }}
+        >Cards</button>
+        <button
+          type="button"
+          class:active={libraryView.density === 'table'}
+          aria-pressed={libraryView.density === 'table'}
+          onclick={() => { libraryView.density = 'table'; }}
+        >Table</button>
+      </div>
+      <span class="lib-count" data-testid="library-count">{filtered.length} {filtered.length === 1 ? 'pet' : 'pets'}</span>
+    </div>
+  </div>
+
+  <div class="lib-list" class:table={libraryView.density === 'table'} data-testid="library-list">
+    {#if filtered.length === 0}
+      <p class="lib-empty">No pets match these filters.</p>
+    {:else}
+      {#each filtered as pet (pet.id)}
+        <PetRow
+          name={pet.name ?? `Pet ${pet.id}`}
+          avatar={getSpeciesEmoji(pet.species)}
+          meta={metaFor(pet)}
+          density={libraryView.density === 'table' ? 'row' : 'card'}
+          selectable
+          selected={libraryView.selectedIds.has(pet.id)}
+          onActivate={() => toggleLibrarySelection(pet.id)}
+          onToggleSelect={() => toggleLibrarySelection(pet.id)}
+        >
+          {#snippet trailing()}
+            {#if pet.starred}<span class="lib-star" title="Starred">★</span>{/if}
+          {/snippet}
+        </PetRow>
+      {/each}
+    {/if}
+  </div>
+
+  {#if libraryView.selectedIds.size > 0}
+    <div class="lib-foot" data-testid="library-foot">
+      <span class="sel-count">{libraryView.selectedIds.size} selected</span>
+      <button type="button" class="clear-btn" onclick={clearLibrarySelection}>Clear</button>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .library { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+  .lib-head { padding: 10px 12px; border-bottom: 1px solid var(--border-primary); display: flex; flex-direction: column; gap: 9px; }
+  .lib-subhead { display: flex; align-items: center; justify-content: space-between; }
+
+  .density { display: inline-flex; background: var(--bg-tertiary); border-radius: 7px; padding: 2px; }
+  .density button {
+    border: none; background: transparent; color: var(--text-tertiary);
+    font-size: 11px; font-weight: 600; padding: 3px 10px; border-radius: 5px; cursor: pointer;
+  }
+  .density button.active { background: var(--bg-primary); color: var(--text-primary); box-shadow: var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.06)); }
+  .lib-count { font-size: 11px; color: var(--text-muted); }
+
+  .lib-list { flex: 1; overflow: auto; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+  .lib-list.table { padding: 0; gap: 0; }
+  .lib-empty { color: var(--text-muted); font-size: 13px; text-align: center; padding: 24px; font-style: italic; }
+  .lib-star { color: #f5a623; font-size: 13px; }
+
+  .lib-foot {
+    border-top: 1px solid var(--border-primary); padding: 9px 12px;
+    display: flex; align-items: center; gap: 8px; background: var(--bg-secondary);
+  }
+  .sel-count { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
+  .clear-btn {
+    margin-left: auto; padding: 4px 10px; border: 1px solid var(--border-primary);
+    border-radius: 6px; background: var(--bg-primary); color: var(--text-tertiary);
+    font-size: 12px; font-weight: 600; cursor: pointer;
+  }
+  .clear-btn:hover { color: var(--text-secondary); }
+</style>

--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+/**
+ * The Workspace — the redesign's selection-aware main area. Driven by the
+ * Library's multi-select: 0 selected → prompt; 1 → the pet's detail view;
+ * 2+ → (later) Compare / Breed lenses. For now the 1-pet case embeds the
+ * existing PetVisualization unchanged — the GeneGrid/lens swap is a later
+ * slice once GeneGrid reaches parity. Behind the redesign flag until cutover.
+ * See docs/design/redesign-library-workspace-v1.md (§7).
+ */
+
+import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
+import EmptyState from '$lib/components/shared/EmptyState.svelte';
+import { libraryView } from '$lib/stores/library.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+
+const selected = $derived($pets.filter((p) => libraryView.selectedIds.has(p.id)));
+</script>
+
+<section class="workspace" data-testid="workspace">
+  {#if selected.length === 0}
+    <EmptyState
+      icon="🐾"
+      title="Pick a pet to begin"
+      body="Select one pet from the library to inspect its genes and stats, or several to compare and rank breeding pairs."
+    />
+  {:else if selected.length === 1}
+    <PetVisualization pet={selected[0]} />
+  {:else}
+    <EmptyState
+      icon="⚖️"
+      title="{selected.length} pets selected"
+      body="Compare and breeding lenses for a multi-pet selection arrive in the next step. Narrow to one pet to inspect it now."
+    />
+  {/if}
+</section>
+
+<style>
+  .workspace { flex: 1; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
+</style>

--- a/src/lib/stores/flags.ts
+++ b/src/lib/stores/flags.ts
@@ -1,0 +1,30 @@
+/**
+ * Build-time / dev feature flags. The redesign (Library + Workspace) is built
+ * in parallel behind `redesignEnabled` so the existing tabs keep working until
+ * the single cutover PR. Enable for review via `?redesign=1` in the URL or
+ * `localStorage['gorgonetics:redesign'] = '1'`; the URL form persists it.
+ * See docs/design/redesign-library-workspace-v1.md (§7 Adoption plan).
+ */
+
+const STORAGE_KEY = 'gorgonetics:redesign';
+
+function readRedesignFlag(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('redesign') === '1') {
+      window.localStorage.setItem(STORAGE_KEY, '1');
+      return true;
+    }
+    if (params.get('redesign') === '0') {
+      window.localStorage.removeItem(STORAGE_KEY);
+      return false;
+    }
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Read once at module load; stable for the session. */
+export const redesignEnabled: boolean = readRedesignFlag();

--- a/src/lib/stores/library.svelte.ts
+++ b/src/lib/stores/library.svelte.ts
@@ -1,0 +1,39 @@
+/**
+ * Reactive state for the redesign Library (the unified pet list + filters that
+ * replaces the Pets sidebar and the Stable filters). Module-scoped so it
+ * survives tab switches, mirroring `stableView`.
+ * See docs/design/redesign-library-workspace-v1.md.
+ */
+
+export type LibraryDensity = 'card' | 'table';
+
+export const libraryView = $state({
+  search: '',
+  /** Normalized species; '' = all. */
+  species: '' as string,
+  /** Breed name; '' = all. */
+  breed: '' as string,
+  starredOnly: false,
+  stabledOnly: false,
+  petQualityOnly: false,
+  tags: [] as string[],
+  density: 'card' as LibraryDensity,
+  /** Multi-select for bulk actions / driving the Workspace. */
+  selectedIds: new Set<number>() as Set<number>,
+});
+
+/** Replace the selection set (reassign so $state tracks the change). */
+export function setLibrarySelection(ids: Set<number>): void {
+  libraryView.selectedIds = ids;
+}
+
+export function toggleLibrarySelection(id: number): void {
+  const next = new Set(libraryView.selectedIds);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  libraryView.selectedIds = next;
+}
+
+export function clearLibrarySelection(): void {
+  libraryView.selectedIds = new Set();
+}

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -4,7 +4,7 @@ import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
 
-export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding' | 'community';
+export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding' | 'community' | 'library';
 
 /** Boolean pet flags toggled in-place via `setPetMarker` (no full reload). */
 export type MarkerKey = 'starred' | 'stabled' | 'is_pet_quality';
@@ -50,6 +50,9 @@ const TAB_STATE_RESETS: Record<Tab, () => void> = {
   stable: clearSelectionAndGeneView,
   breeding: clearSelectionAndGeneView,
   community: clearSelectionAndGeneView,
+  // The Library drives its own selection (libraryView.selectedIds); clear the
+  // legacy single-pet/gene-edit state so it can't leak into the workspace.
+  library: clearSelectionAndGeneView,
 };
 
 // Monotonic generation counter for in-flight `loadPets` calls. Concurrent

--- a/src/lib/utils/petFilter.ts
+++ b/src/lib/utils/petFilter.ts
@@ -1,11 +1,17 @@
 /**
- * Pure pet-list filtering for `PetList`.
+ * Pure pet-list filtering, shared by `PetList` and the redesign Library.
  *
  * Extracted from the in-component `filteredPets` $derived so the
  * search / tag / starred / stabled predicate can be unit-tested rather than
  * living as a closure over component reactive state (#306 audit per #310).
+ *
+ * The `species` / `breed` / `petQualityOnly` fields are optional so the
+ * Library can reuse this predicate as the single source of truth for filtering
+ * (absorbing the Stable filters) without changing `PetList`, which omits them.
+ * See docs/design/redesign-library-workspace-v1.md.
  */
 
+import { normalizeSpecies } from '$lib/services/configService.js';
 import type { Pet } from '$lib/types/index.js';
 
 export interface PetListFilters {
@@ -15,6 +21,11 @@ export interface PetListFilters {
   tags: string[];
   starredOnly: boolean;
   stabledOnly: boolean;
+  /** Normalized species; '' or omitted means all species. */
+  species?: string;
+  /** Breed name; '' or omitted means all breeds. */
+  breed?: string;
+  petQualityOnly?: boolean;
 }
 
 /** Whether a pet passes the active list filters. */
@@ -31,6 +42,9 @@ export function petMatchesFilters(pet: Pet, filters: PetListFilters): boolean {
   }
   if (filters.starredOnly && !pet.starred) return false;
   if (filters.stabledOnly && !pet.stabled) return false;
+  if (filters.petQualityOnly && !pet.is_pet_quality) return false;
+  if (filters.species && normalizeSpecies(pet.species) !== filters.species) return false;
+  if (filters.breed && pet.breed !== filters.breed) return false;
   return true;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@ import BreedingTab from '$lib/components/breeding/BreedingTab.svelte';
 import CommunityTab from '$lib/components/community/CommunityTab.svelte';
 import ComparisonView from '$lib/components/comparison/ComparisonView.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
+import Workspace from '$lib/components/library/Workspace.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import StableTable from '$lib/components/stable/StableTable.svelte';
 import { activeTab, appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
@@ -21,7 +22,9 @@ onMount(async () => {
 		</div>
 	{/if}
 
-	{#if $activeTab === 'stable'}
+	{#if $activeTab === 'library'}
+		<Workspace />
+	{:else if $activeTab === 'stable'}
 		<StableTable />
 	{:else if $activeTab === 'compare'}
 		<ComparisonView />

--- a/tests/unit/library.test.ts
+++ b/tests/unit/library.test.ts
@@ -91,6 +91,17 @@ describe('Library', () => {
     expect(libraryView.selectedIds.size).toBe(1);
   });
 
+  it('clears the selection when the species filter changes', async () => {
+    const { container } = render(Library);
+    await fireEvent.click(container.querySelector('[data-testid="pet-row-select"]') as HTMLInputElement);
+    expect(libraryView.selectedIds.size).toBe(1);
+
+    // Switching species would otherwise leave a now-hidden pet selected.
+    await fireEvent.click(container.querySelector('[data-species="horse"]') as HTMLButtonElement);
+    expect(libraryView.selectedIds.size).toBe(0);
+    expect(container.querySelector('[data-testid="library-foot"]')).toBeNull();
+  });
+
   it('clears the selection from the footer', async () => {
     const { container } = render(Library);
     await fireEvent.click(container.querySelector('[data-testid="pet-row-select"]') as HTMLInputElement);

--- a/tests/unit/library.test.ts
+++ b/tests/unit/library.test.ts
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Library from '$lib/components/library/Library.svelte';
+import { libraryView } from '$lib/stores/library.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+
+const pet = (over: Partial<Pet>): Pet =>
+  ({
+    id: 0,
+    name: 'Pet',
+    species: 'Horse',
+    breed: 'Standardbred',
+    gender: 'Female',
+    tags: [],
+    starred: false,
+    stabled: true,
+    is_pet_quality: false,
+    ...over,
+  }) as unknown as Pet;
+
+const SAMPLE = [
+  pet({ id: 1, name: 'Dusty', species: 'Horse', gender: 'Male', starred: true }),
+  pet({ id: 2, name: 'Roach', species: 'Horse', gender: 'Female' }),
+  pet({ id: 3, name: 'Buzz', species: 'BeeWasp', breed: '', gender: 'Female', stabled: false }),
+];
+
+beforeEach(() => {
+  // libraryView is module-scoped $state shared across tests — reset it.
+  libraryView.search = '';
+  libraryView.species = '';
+  libraryView.breed = '';
+  libraryView.starredOnly = false;
+  libraryView.stabledOnly = false;
+  libraryView.petQualityOnly = false;
+  libraryView.tags = [];
+  libraryView.density = 'card';
+  libraryView.selectedIds = new Set();
+  pets.set(SAMPLE);
+});
+
+afterEach(() => {
+  cleanup();
+  pets.set([]);
+});
+
+const rows = (c: HTMLElement) => c.querySelectorAll('[data-testid="pet-row"]');
+const count = (c: HTMLElement) => c.querySelector('[data-testid="library-count"]')?.textContent;
+
+describe('Library', () => {
+  it('lists every pet with a name and count', () => {
+    const { container } = render(Library);
+    expect(rows(container)).toHaveLength(3);
+    expect(count(container)).toBe('3 pets');
+    expect(container.textContent).toContain('Dusty');
+    expect(container.textContent).toContain('Buzz');
+  });
+
+  it('filters by the search box', async () => {
+    const { container } = render(Library);
+    await fireEvent.input(container.querySelector('[data-testid="filter-search"]') as HTMLInputElement, {
+      target: { value: 'roach' },
+    });
+    expect(rows(container)).toHaveLength(1);
+    expect(count(container)).toBe('1 pet');
+    expect(container.textContent).toContain('Roach');
+  });
+
+  it('filters by a flag pill (Starred)', async () => {
+    const { container } = render(Library);
+    await fireEvent.click(container.querySelector('[data-flag="starred"]') as HTMLButtonElement);
+    expect(rows(container)).toHaveLength(1);
+    expect(container.textContent).toContain('Dusty');
+  });
+
+  it('toggles list density', async () => {
+    const { container } = render(Library);
+    const list = container.querySelector('[data-testid="library-list"]') as HTMLElement;
+    expect(list.classList.contains('table')).toBe(false);
+    await fireEvent.click(container.querySelector('.density button[aria-pressed="false"]') as HTMLButtonElement);
+    expect(list.classList.contains('table')).toBe(true);
+  });
+
+  it('shows the selection footer after selecting a pet', async () => {
+    const { container } = render(Library);
+    expect(container.querySelector('[data-testid="library-foot"]')).toBeNull();
+    await fireEvent.click(container.querySelector('[data-testid="pet-row-select"]') as HTMLInputElement);
+    const foot = container.querySelector('[data-testid="library-foot"]');
+    expect(foot).not.toBeNull();
+    expect(foot?.textContent).toContain('1 selected');
+    expect(libraryView.selectedIds.size).toBe(1);
+  });
+
+  it('clears the selection from the footer', async () => {
+    const { container } = render(Library);
+    await fireEvent.click(container.querySelector('[data-testid="pet-row-select"]') as HTMLInputElement);
+    await fireEvent.click(container.querySelector('.clear-btn') as HTMLButtonElement);
+    expect(libraryView.selectedIds.size).toBe(0);
+    expect(container.querySelector('[data-testid="library-foot"]')).toBeNull();
+  });
+});

--- a/tests/unit/petFilter.test.ts
+++ b/tests/unit/petFilter.test.ts
@@ -85,3 +85,41 @@ describe('filterPets', () => {
     expect(pets).toEqual(input);
   });
 });
+
+describe('petMatchesFilters — Library criteria (species / breed / pet-quality)', () => {
+  it('matches normalized species; "" means all', () => {
+    expect(petMatchesFilters(pet({ species: 'Horse' }), { ...noFilters, species: 'horse' })).toBe(true);
+    expect(petMatchesFilters(pet({ species: 'BeeWasp' }), { ...noFilters, species: 'horse' })).toBe(false);
+    expect(petMatchesFilters(pet({ species: 'BeeWasp' }), { ...noFilters, species: '' })).toBe(true);
+  });
+
+  it('matches breed exactly; "" means all', () => {
+    expect(petMatchesFilters(pet({ breed: 'Standardbred' }), { ...noFilters, breed: 'Standardbred' })).toBe(true);
+    expect(petMatchesFilters(pet({ breed: 'Kurbone' }), { ...noFilters, breed: 'Standardbred' })).toBe(false);
+    expect(petMatchesFilters(pet({ breed: 'Kurbone' }), { ...noFilters, breed: '' })).toBe(true);
+  });
+
+  it('petQualityOnly requires is_pet_quality', () => {
+    expect(petMatchesFilters(pet({ is_pet_quality: true }), { ...noFilters, petQualityOnly: true })).toBe(true);
+    expect(petMatchesFilters(pet({ is_pet_quality: false }), { ...noFilters, petQualityOnly: true })).toBe(false);
+  });
+
+  it('combines new criteria with the existing ones (AND)', () => {
+    const matching = pet({
+      name: 'Dusty',
+      species: 'Horse',
+      breed: 'Standardbred',
+      is_pet_quality: true,
+      stabled: true,
+    });
+    const wrongBreed = pet({ name: 'Pip', species: 'Horse', breed: 'Kurbone', is_pet_quality: true, stabled: true });
+    const result = filterPets([matching, wrongBreed], {
+      ...noFilters,
+      species: 'horse',
+      breed: 'Standardbred',
+      petQualityOnly: true,
+      stabledOnly: true,
+    });
+    expect(result.map((p) => p.name)).toEqual(['Dusty']);
+  });
+});


### PR DESCRIPTION
First adoption slice (`docs/design/redesign-library-workspace-v1.md` §7). Builds the **Library + Workspace** shell as a flagged **My Pets** destination, alongside the existing tabs — the parallel-build approach, so the live app is untouched until the cutover PR.

## What
- **Library** (left panel): the shared `FilterBar` (search + species toggle + `BreedSelector` + flag pills) over a `PetRow` list, with a **card/table density** toggle and **multi-select**. Replaces the Pets sidebar + Stable filters.
- **Workspace** (main): selection-aware — **0** selected → `EmptyState` prompt; **1** → the existing `PetVisualization` unchanged (no parity gap; the GeneGrid/lens swap is a later slice); **2+** → an `EmptyState` placeholder for the upcoming Compare/Breed lenses.
- Wired through the existing `MasterPanel` + `+page` routing as a new `library` tab; **all existing tabs are unchanged**.

## Consolidation
Extends the shared `petFilter` predicate with optional `species`/`breed`/`petQualityOnly` so the Library reuses one filter (absorbing the Stable filters) **without touching `PetList`** (the new fields are optional). New `libraryView` store (filters + density + selection) and a `redesignEnabled` flag (`?redesign=1` / `localStorage['gorgonetics:redesign']`).

## Tests
- `petFilter.test.ts` — new species/breed/pet-quality + combined cases.
- `library.test.ts` — list/count, search filter, flag pill, density toggle, selection footer + clear.
- svelte-check 0 errors/0 warnings, lint clean, full unit suite green (746). Verified in the running app at `?redesign=1`: Library renders, selecting a pet drives the Workspace into `PetVisualization`, old tabs intact.

## Not in scope
Compare/Breed lenses (slice 3), GeneGrid swap (parity pass), Stable absorption, cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)