### PR TITLE
feat(redesign): Compare lens in the Workspace (slice 2a)

### DIFF
--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -1,19 +1,29 @@
 <script lang="ts">
 /**
  * The Workspace — the redesign's selection-aware main area. Driven by the
- * Library's multi-select: 0 selected → prompt; 1 → the pet's detail view;
- * 2+ → (later) Compare / Breed lenses. For now the 1-pet case embeds the
- * existing PetVisualization unchanged — the GeneGrid/lens swap is a later
- * slice once GeneGrid reaches parity. Behind the redesign flag until cutover.
+ * Library's multi-select:
+ *   0 selected → prompt
+ *   1          → the pet's detail view (existing PetVisualization, unchanged —
+ *                the GeneGrid/lens swap is a later slice once GeneGrid reaches
+ *                parity)
+ *   2 same-species → Compare lens (existing genome diff)
+ *   2 mixed / 3+   → guidance (the Breed-rank → Trio lens arrives next slice)
+ * Behind the redesign flag until cutover.
  * See docs/design/redesign-library-workspace-v1.md (§7).
  */
 
+import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
+import PageHeader from '$lib/components/shared/PageHeader.svelte';
+import { normalizeSpecies } from '$lib/services/configService.js';
 import { libraryView } from '$lib/stores/library.svelte.js';
 import { pets } from '$lib/stores/pets.js';
 
 const selected = $derived($pets.filter((p) => libraryView.selectedIds.has(p.id)));
+const sameSpecies = $derived(
+  selected.length === 2 && normalizeSpecies(selected[0].species) === normalizeSpecies(selected[1].species),
+);
 </script>
 
 <section class="workspace" data-testid="workspace">
@@ -21,19 +31,34 @@ const selected = $derived($pets.filter((p) => libraryView.selectedIds.has(p.id))
     <EmptyState
       icon="🐾"
       title="Pick a pet to begin"
-      body="Select one pet from the library to inspect its genes and stats, or several to compare and rank breeding pairs."
+      body="Select one pet from the library to inspect its genes and stats, or two of the same species to compare them."
     />
   {:else if selected.length === 1}
     <PetVisualization pet={selected[0]} />
-  {:else}
+  {:else if selected.length === 2 && sameSpecies}
+    <div class="lens-compare" data-testid="workspace-compare">
+      <PageHeader title="Compare" subtitle="{selected[0].name} vs {selected[1].name}" icon="⚖️" />
+      <div class="lens-body">
+        <GenomeGridDiff petA={selected[0]} petB={selected[1]} />
+      </div>
+    </div>
+  {:else if selected.length === 2}
     <EmptyState
       icon="⚖️"
+      title="Pick two pets of the same species"
+      body="Comparison is within a species. {selected[0].name} and {selected[1].name} are different species — select two horses or two beewasps to compare."
+    />
+  {:else}
+    <EmptyState
+      icon="💞"
       title="{selected.length} pets selected"
-      body="Compare and breeding lenses for a multi-pet selection arrive in the next step. Narrow to one pet to inspect it now."
+      body="The breeding-rank lens for a multi-pet selection arrives in the next step. Select exactly two pets of the same species to compare them now."
     />
   {/if}
 </section>
 
 <style>
   .workspace { flex: 1; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
+  .lens-compare { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  .lens-body { flex: 1; min-height: 0; overflow: auto; padding: 16px 20px; }
 </style>

--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -21,9 +21,14 @@ import { libraryView } from '$lib/stores/library.svelte.js';
 import { pets } from '$lib/stores/pets.js';
 
 const selected = $derived($pets.filter((p) => libraryView.selectedIds.has(p.id)));
-const sameSpecies = $derived(
-  selected.length === 2 && normalizeSpecies(selected[0].species) === normalizeSpecies(selected[1].species),
-);
+const sameSpecies = $derived.by(() => {
+  if (selected.length !== 2) return false;
+  const a = normalizeSpecies(selected[0].species);
+  // Require a known species: two species-less pets both normalize to '' and
+  // would otherwise compare-equal, opening a Compare lens that errors when
+  // GenomeGridDiff looks up config for an empty species key.
+  return a !== '' && a === normalizeSpecies(selected[1].species);
+});
 </script>
 
 <section class="workspace" data-testid="workspace">

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -1,0 +1,43 @@
+import { expect, type Page, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+// The redesign Library + Workspace shell lives behind the ?redesign=1 flag.
+async function openLibrary(page: Page) {
+  await page.goto('/?redesign=1');
+  await waitForAppReady(page);
+  await page.locator('[data-testid="tab-library"]').click();
+  await expect(page.locator('[data-testid="library"]')).toBeVisible();
+}
+
+test.describe('Redesign — Library + Workspace shell', () => {
+  test('the My Pets destination appears only with the flag', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+    await expect(page.locator('[data-testid="tab-library"]')).toHaveCount(0);
+
+    await openLibrary(page);
+    await expect(page.locator('[data-testid="tab-library"]')).toBeVisible();
+  });
+
+  test('selecting one pet shows its detail; the prompt shows when none selected', async ({ page }) => {
+    await openLibrary(page);
+    await expect(page.locator('[data-testid="workspace"] [data-testid="empty-state"]')).toBeVisible();
+
+    await page.locator('[data-testid="pet-row-select"]').first().check();
+    await expect(page.locator('.pet-visualization')).toBeVisible();
+  });
+
+  test('selecting two same-species pets opens the Compare lens', async ({ page }) => {
+    await openLibrary(page);
+
+    // Narrow to horses (the demo has two) so both selected pets share a species.
+    await page.locator('[data-testid="filter-species"] [data-species="horse"]').click();
+    const checks = page.locator('[data-testid="pet-row-select"]');
+    await expect(checks).toHaveCount(2);
+    await checks.nth(0).check();
+    await checks.nth(1).check();
+
+    await expect(page.locator('[data-testid="workspace-compare"]')).toBeVisible();
+    await expect(page.locator('[data-testid="workspace-compare"]')).toContainText('Compare');
+  });
+});

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -1,0 +1,56 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Workspace from '$lib/components/library/Workspace.svelte';
+import { libraryView } from '$lib/stores/library.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+
+// The 1-pet (PetVisualization) and 2-same-species (GenomeGridDiff) branches
+// mount heavy components that load genome data asynchronously from the DB
+// layer — those are covered by the redesign e2e. Here we assert the pure,
+// deterministic EmptyState branches: 0, 2-mixed-species, and 3+.
+
+const pet = (id: number, species: string, name: string): Pet =>
+  ({ id, name, species, breed: '', gender: 'Female', tags: [] }) as unknown as Pet;
+
+const ALL = [pet(1, 'Horse', 'Dusty'), pet(2, 'Horse', 'Roach'), pet(3, 'BeeWasp', 'Buzz')];
+
+function select(ids: number[]) {
+  libraryView.selectedIds = new Set(ids);
+}
+
+beforeEach(() => {
+  pets.set(ALL);
+  libraryView.selectedIds = new Set();
+});
+
+afterEach(() => {
+  cleanup();
+  pets.set([]);
+  libraryView.selectedIds = new Set();
+});
+
+const emptyState = (c: HTMLElement) => c.querySelector('[data-testid="empty-state"]');
+
+describe('Workspace', () => {
+  it('prompts to pick a pet when nothing is selected', () => {
+    select([]);
+    const { container } = render(Workspace);
+    expect(emptyState(container)?.textContent).toContain('Pick a pet to begin');
+    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+  });
+
+  it('guides toward same-species when two different species are selected', () => {
+    select([1, 3]); // Horse + BeeWasp
+    const { container } = render(Workspace);
+    expect(emptyState(container)?.textContent).toContain('Pick two pets of the same species');
+    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+  });
+
+  it('points at the breeding lens for 3+ selected (next slice)', () => {
+    select([1, 2, 3]);
+    const { container } = render(Workspace);
+    expect(emptyState(container)?.textContent).toContain('3 pets selected');
+    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+  });
+});

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -53,4 +53,13 @@ describe('Workspace', () => {
     expect(emptyState(container)?.textContent).toContain('3 pets selected');
     expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
   });
+
+  it('does NOT treat two unknown-species pets as same-species', () => {
+    // Both normalize to '' — must not open a Compare lens (would error in the diff).
+    pets.set([pet(10, 'Mystery', 'Q'), pet(11, '', 'Z')]);
+    select([10, 11]);
+    const { container } = render(Workspace);
+    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+    expect(emptyState(container)?.textContent).toContain('Pick two pets of the same species');
+  });
 });


### PR DESCRIPTION
Adoption slice 2a (`docs/design/redesign-library-workspace-v1.md` §8). Adds the **Compare lens** to the Workspace; targets the epic.

## What
When two **same-species** pets are selected in the Library, the Workspace shows a Compare lens — a `PageHeader` ("A vs B") over the existing `GenomeGridDiff`. This replaces the old Compare tab's bespoke A/B picker flow, driven directly by the Library's multi-select.

Selection-aware behavior:
- 0 → prompt
- 1 → `PetVisualization` (unchanged)
- 2 same species → **Compare lens**
- 2 different species → guidance to pick same-species
- 3+ → guidance (the breeding-rank → Trio lens is slice 2b)

## Scope
Compare only. The Breed-rank/Trio lens (scoped ranking + trio on inspect) and absorbing the Stable table as the Library's table density are the next slice — kept separate since they're meatier.

## Tests
- `workspace.test.ts` — the deterministic EmptyState branches (0, 2-mixed, 3+); the heavy 1-pet/2-same mounts are covered by e2e.
- `redesign-library.spec.ts` (e2e) — flag-gated My Pets destination, 1-pet detail + empty prompt, and the 2-same-species Compare lens.
- svelte-check 0/0, lint clean, unit + e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)