### PR TITLE
feat(redesign): Breed-rank lens + Workspace lens tabs (slice 2b)

### DIFF
--- a/src/lib/components/library/BreedLens.svelte
+++ b/src/lib/components/library/BreedLens.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+/**
+ * Breed-rank lens for the Workspace: ranks male × female pairs among the
+ * selected (same-species) pets and opens the offspring Trio view on inspect.
+ * Reuses the breeding service + table + TrioView; mirrors BreedingTab's
+ * rank-with-sequence-guard wiring, but scoped to the Library selection rather
+ * than all stabled pets. See docs/design/redesign-library-workspace-v1.md (§7).
+ */
+import { onDestroy } from 'svelte';
+import BreedingPairTable from '$lib/components/breeding/BreedingPairTable.svelte';
+import TrioView from '$lib/components/breeding/TrioView.svelte';
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
+import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { getAllAttributeNames } from '$lib/services/configService.js';
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import type { BreedingPairResult, Pet } from '$lib/types/index.js';
+import { capitalize } from '$lib/utils/string.js';
+
+interface Props {
+  /** The selected pets to rank among — assumed same (normalized) species. */
+  pets: Pet[];
+  /** Normalized species of the selection. */
+  species: string;
+}
+
+const { pets, species }: Props = $props();
+
+const attrNames = $derived(species ? getAllAttributeNames(species).map(capitalize) : []);
+
+let pairs = $state<BreedingPairResult[]>([]);
+let loading = $state(false);
+let errored = $state(false);
+let seq = 0;
+
+$effect(() => {
+  // Re-rank whenever the selection or species changes. A sequence counter
+  // discards stale results if inputs change faster than the service responds.
+  const sp = species;
+  const ps = pets;
+  // Close any open trio from a previous selection so it can't dangle.
+  breedingView.selectedPair = null;
+
+  const mine = ++seq;
+  loading = true;
+  errored = false;
+  rankBreedingPairs({ species: sp, pets: ps })
+    .then((result) => {
+      if (mine !== seq) return;
+      pairs = result;
+      loading = false;
+    })
+    .catch((err: unknown) => {
+      if (mine !== seq) return;
+      console.error('rankBreedingPairs failed', err);
+      pairs = [];
+      errored = true;
+      loading = false;
+    });
+});
+
+// Leaving the lens shouldn't leave a trio selection lingering for the old tab.
+onDestroy(() => {
+  breedingView.selectedPair = null;
+});
+</script>
+
+<div class="breed-lens" data-testid="breed-lens">
+  {#if errored}
+    <div class="bl-state">
+      <StatusPane variant="error" title="Couldn't rank these pairs." body="Something went wrong computing scores. Change the selection to retry." />
+    </div>
+  {:else if loading && pairs.length === 0}
+    <div class="bl-state"><StatusPane variant="loading" body="Computing pair scores…" /></div>
+  {:else if pairs.length === 0}
+    <div class="bl-state">
+      <StatusPane
+        variant="empty"
+        title="No pairs to rank"
+        body="Breeding ranks male × female pairs. Select at least one male and one female of the same species."
+      />
+    </div>
+  {:else}
+    <div class="bl-meta">{pairs.length} {pairs.length === 1 ? 'pair' : 'pairs'} · ranked by expected offspring quality</div>
+    <BreedingPairTable results={pairs} {attrNames} />
+  {/if}
+</div>
+
+{#if breedingView.selectedPair}
+  <TrioView pair={breedingView.selectedPair} onClose={() => { breedingView.selectedPair = null; }} />
+{/if}
+
+<style>
+  .breed-lens { flex: 1; min-height: 0; display: flex; flex-direction: column; gap: 8px; }
+  .bl-state { flex: 1; display: flex; align-items: center; justify-content: center; }
+  .bl-meta { font-size: 12px; color: var(--text-tertiary); }
+</style>

--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -34,6 +34,13 @@ const canCompare = $derived(selected.length === 2 && commonSpecies !== null);
 let multiLens = $state<'compare' | 'breed'>('compare');
 // Compare needs exactly two pets; fall back to Breed otherwise.
 const activeLens = $derived(multiLens === 'compare' && canCompare ? 'compare' : 'breed');
+
+// Reset to the default lens when the selection is fully cleared, so a fresh
+// 2-pet selection always opens on Compare. Edits within a selection keep the
+// user's chosen lens (no flip on every checkbox toggle).
+$effect(() => {
+  if (selected.length === 0) multiLens = 'compare';
+});
 </script>
 
 <section class="workspace" data-testid="workspace">
@@ -53,13 +60,12 @@ const activeLens = $derived(multiLens === 'compare' && canCompare ? 'compare' : 
     />
   {:else}
     <div class="multi" data-testid="workspace-multi">
-      <div class="lens-tabs" role="tablist" aria-label="Lens">
+      <div class="lens-tabs" role="group" aria-label="Workspace lens">
         <button
           type="button"
-          role="tab"
           class="lens-tab"
           class:active={activeLens === 'compare'}
-          aria-selected={activeLens === 'compare'}
+          aria-pressed={activeLens === 'compare'}
           disabled={!canCompare}
           title={canCompare ? 'Head-to-head genome diff' : 'Select exactly two pets to compare'}
           data-testid="lens-tab-compare"
@@ -67,10 +73,9 @@ const activeLens = $derived(multiLens === 'compare' && canCompare ? 'compare' : 
         >⚖️ Compare</button>
         <button
           type="button"
-          role="tab"
           class="lens-tab"
           class:active={activeLens === 'breed'}
-          aria-selected={activeLens === 'breed'}
+          aria-pressed={activeLens === 'breed'}
           data-testid="lens-tab-breed"
           onclick={() => { multiLens = 'breed'; }}
         >💞 Breed</button>

--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -3,32 +3,37 @@
  * The Workspace — the redesign's selection-aware main area. Driven by the
  * Library's multi-select:
  *   0 selected → prompt
- *   1          → the pet's detail view (existing PetVisualization, unchanged —
- *                the GeneGrid/lens swap is a later slice once GeneGrid reaches
- *                parity)
- *   2 same-species → Compare lens (existing genome diff)
- *   2 mixed / 3+   → guidance (the Breed-rank → Trio lens arrives next slice)
+ *   1          → the pet's detail view (existing PetVisualization, unchanged)
+ *   2+ same-species → lens tabs: Compare (exactly 2) and Breed-rank → Trio
+ *   mixed species   → guidance
  * Behind the redesign flag until cutover.
  * See docs/design/redesign-library-workspace-v1.md (§7).
  */
-
 import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
+import BreedLens from '$lib/components/library/BreedLens.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
-import PageHeader from '$lib/components/shared/PageHeader.svelte';
 import { normalizeSpecies } from '$lib/services/configService.js';
 import { libraryView } from '$lib/stores/library.svelte.js';
 import { pets } from '$lib/stores/pets.js';
 
 const selected = $derived($pets.filter((p) => libraryView.selectedIds.has(p.id)));
-const sameSpecies = $derived.by(() => {
-  if (selected.length !== 2) return false;
-  const a = normalizeSpecies(selected[0].species);
-  // Require a known species: two species-less pets both normalize to '' and
-  // would otherwise compare-equal, opening a Compare lens that errors when
-  // GenomeGridDiff looks up config for an empty species key.
-  return a !== '' && a === normalizeSpecies(selected[1].species);
+
+// The single normalized species shared by all selected pets, or null when the
+// selection is empty/singleton, spans species, or any pet's species is unknown
+// (normalizeSpecies → '') — guards against comparing/ranking on an empty key.
+const commonSpecies = $derived.by(() => {
+  if (selected.length < 2) return null;
+  const s = normalizeSpecies(selected[0].species);
+  if (!s) return null;
+  return selected.every((p) => normalizeSpecies(p.species) === s) ? s : null;
 });
+
+const canCompare = $derived(selected.length === 2 && commonSpecies !== null);
+
+let multiLens = $state<'compare' | 'breed'>('compare');
+// Compare needs exactly two pets; fall back to Breed otherwise.
+const activeLens = $derived(multiLens === 'compare' && canCompare ? 'compare' : 'breed');
 </script>
 
 <section class="workspace" data-testid="workspace">
@@ -36,34 +41,79 @@ const sameSpecies = $derived.by(() => {
     <EmptyState
       icon="🐾"
       title="Pick a pet to begin"
-      body="Select one pet from the library to inspect its genes and stats, or two of the same species to compare them."
+      body="Select one pet from the library to inspect its genes and stats, or two or more of the same species to compare and rank breeding pairs."
     />
   {:else if selected.length === 1}
     <PetVisualization pet={selected[0]} />
-  {:else if selected.length === 2 && sameSpecies}
-    <div class="lens-compare" data-testid="workspace-compare">
-      <PageHeader title="Compare" subtitle="{selected[0].name} vs {selected[1].name}" icon="⚖️" />
-      <div class="lens-body">
-        <GenomeGridDiff petA={selected[0]} petB={selected[1]} />
-      </div>
-    </div>
-  {:else if selected.length === 2}
+  {:else if commonSpecies === null}
     <EmptyState
       icon="⚖️"
-      title="Pick two pets of the same species"
-      body="Comparison is within a species. {selected[0].name} and {selected[1].name} are different species — select two horses or two beewasps to compare."
+      title="Pick pets of the same species"
+      body="Comparing and breeding work within a single species. Narrow your selection to one species (e.g. all horses) to continue."
     />
   {:else}
-    <EmptyState
-      icon="💞"
-      title="{selected.length} pets selected"
-      body="The breeding-rank lens for a multi-pet selection arrives in the next step. Select exactly two pets of the same species to compare them now."
-    />
+    <div class="multi" data-testid="workspace-multi">
+      <div class="lens-tabs" role="tablist" aria-label="Lens">
+        <button
+          type="button"
+          role="tab"
+          class="lens-tab"
+          class:active={activeLens === 'compare'}
+          aria-selected={activeLens === 'compare'}
+          disabled={!canCompare}
+          title={canCompare ? 'Head-to-head genome diff' : 'Select exactly two pets to compare'}
+          data-testid="lens-tab-compare"
+          onclick={() => { multiLens = 'compare'; }}
+        >⚖️ Compare</button>
+        <button
+          type="button"
+          role="tab"
+          class="lens-tab"
+          class:active={activeLens === 'breed'}
+          aria-selected={activeLens === 'breed'}
+          data-testid="lens-tab-breed"
+          onclick={() => { multiLens = 'breed'; }}
+        >💞 Breed</button>
+        <span class="lens-count">{selected.length} selected</span>
+      </div>
+      <div class="lens-body">
+        {#if activeLens === 'compare'}
+          <GenomeGridDiff petA={selected[0]} petB={selected[1]} />
+        {:else}
+          <BreedLens pets={selected} species={commonSpecies} />
+        {/if}
+      </div>
+    </div>
   {/if}
 </section>
 
 <style>
   .workspace { flex: 1; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
-  .lens-compare { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+  .multi { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+
+  .lens-tabs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 10px 20px 0;
+    border-bottom: 1px solid var(--border-primary);
+    flex-shrink: 0;
+  }
+  .lens-tab {
+    border: none;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 13px;
+    font-weight: 600;
+    padding: 7px 4px;
+    margin-right: 16px;
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+  }
+  .lens-tab:hover:not(:disabled) { color: var(--text-secondary); }
+  .lens-tab.active { color: var(--text-primary); border-bottom-color: var(--accent); }
+  .lens-tab:disabled { opacity: 0.4; cursor: default; }
+  .lens-count { margin-left: auto; font-size: 11px; color: var(--text-muted); }
+
   .lens-body { flex: 1; min-height: 0; overflow: auto; padding: 16px 20px; }
 </style>

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -27,7 +27,7 @@ test.describe('Redesign — Library + Workspace shell', () => {
     await expect(page.locator('.pet-visualization')).toBeVisible();
   });
 
-  test('selecting two same-species pets opens the Compare lens', async ({ page }) => {
+  test('two same-species pets open the multi lens with Compare and Breed tabs', async ({ page }) => {
     await openLibrary(page);
 
     // Narrow to horses (the demo has two) so both selected pets share a species.
@@ -37,7 +37,14 @@ test.describe('Redesign — Library + Workspace shell', () => {
     await checks.nth(0).check();
     await checks.nth(1).check();
 
-    await expect(page.locator('[data-testid="workspace-compare"]')).toBeVisible();
-    await expect(page.locator('[data-testid="workspace-compare"]')).toContainText('Compare');
+    // Compare is the default lens for exactly two same-species pets.
+    await expect(page.locator('[data-testid="workspace-multi"]')).toBeVisible();
+    await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
+
+    // Switching to the Breed lens ranks the pair; inspecting opens the trio.
+    await page.locator('[data-testid="lens-tab-breed"]').click();
+    await expect(page.locator('[data-testid="breeding-pair-table"]')).toBeVisible();
+    await page.locator('[data-testid="inspect-pair"]').first().click();
+    await expect(page.getByTestId('trio-view')).toBeVisible();
   });
 });

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -43,8 +43,17 @@ test.describe('Redesign — Library + Workspace shell', () => {
 
     // Switching to the Breed lens ranks the pair; inspecting opens the trio.
     await page.locator('[data-testid="lens-tab-breed"]').click();
+    await expect(page.locator('[data-testid="lens-tab-breed"]')).toHaveClass(/active/);
     await expect(page.locator('[data-testid="breeding-pair-table"]')).toBeVisible();
     await page.locator('[data-testid="inspect-pair"]').first().click();
     await expect(page.getByTestId('trio-view')).toBeVisible();
+    await page.getByTestId('trio-view').getByRole('button', { name: 'Close trio view' }).click();
+
+    // Clearing the selection resets the lens — a fresh 2-pet selection reopens on Compare.
+    await page.locator('[data-testid="library-foot"] .clear-btn').click();
+    const checks2 = page.locator('[data-testid="pet-row-select"]');
+    await checks2.nth(0).check();
+    await checks2.nth(1).check();
+    await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
   });
 });

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -37,29 +37,29 @@ describe('Workspace', () => {
     select([]);
     const { container } = render(Workspace);
     expect(emptyState(container)?.textContent).toContain('Pick a pet to begin');
-    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+    expect(container.querySelector('[data-testid="workspace-multi"]')).toBeNull();
   });
 
   it('guides toward same-species when two different species are selected', () => {
     select([1, 3]); // Horse + BeeWasp
     const { container } = render(Workspace);
-    expect(emptyState(container)?.textContent).toContain('Pick two pets of the same species');
-    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+    expect(emptyState(container)?.textContent).toContain('Pick pets of the same species');
+    expect(container.querySelector('[data-testid="workspace-multi"]')).toBeNull();
   });
 
-  it('points at the breeding lens for 3+ selected (next slice)', () => {
-    select([1, 2, 3]);
+  it('guides toward same-species for a 3+ mixed-species selection', () => {
+    select([1, 2, 3]); // Horse, Horse, BeeWasp
     const { container } = render(Workspace);
-    expect(emptyState(container)?.textContent).toContain('3 pets selected');
-    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
+    expect(emptyState(container)?.textContent).toContain('Pick pets of the same species');
+    expect(container.querySelector('[data-testid="workspace-multi"]')).toBeNull();
   });
 
   it('does NOT treat two unknown-species pets as same-species', () => {
-    // Both normalize to '' — must not open a Compare lens (would error in the diff).
+    // Both normalize to '' — must not open the multi lens (would error in the diff/rank).
     pets.set([pet(10, 'Mystery', 'Q'), pet(11, '', 'Z')]);
     select([10, 11]);
     const { container } = render(Workspace);
-    expect(container.querySelector('[data-testid="workspace-compare"]')).toBeNull();
-    expect(emptyState(container)?.textContent).toContain('Pick two pets of the same species');
+    expect(container.querySelector('[data-testid="workspace-multi"]')).toBeNull();
+    expect(emptyState(container)?.textContent).toContain('Pick pets of the same species');
   });
 });


### PR DESCRIPTION
Adoption slice 2b (`docs/design/redesign-library-workspace-v1.md` §8) — completes the Workspace lenses. Targets the epic.

## What
A same-species multi-pet selection now shows **lens tabs** in the Workspace:
- **⚖️ Compare** — enabled for exactly 2 pets → the existing `GenomeGridDiff`.
- **💞 Breed** — for 2+ pets → new `BreedLens`: ranks male × female pairs **among the selection** via `rankBreedingPairs`, renders the existing `BreedingPairTable`, and opens the offspring `TrioView` on inspect (with its breed/attribute filters intact).

Selection logic: 0 → prompt; 1 → `PetVisualization`; 2+ same species → lens tabs (Compare defaults when exactly 2, else Breed); mixed/unknown species → guidance. Scopes breeding rank to the selection per decision #6.

## Reuse
`BreedLens` mirrors `BreedingTab`'s rank-with-sequence-guard wiring but scoped to the Library selection, reusing `rankBreedingPairs` + `BreedingPairTable` + `TrioView` + the shared `breedingView.selectedPair` (cleared on selection change / unmount so no trio dangles).

## Tests
- `workspace.test.ts` — deterministic guidance branches (0, 2-mixed, 3+-mixed, 2-unknown); the same-species lens mounts (heavy/async) are covered by e2e.
- `redesign-library.spec.ts` — two horses → multi lens with Compare active by default, then Breed tab → pair table → inspect → trio.
- svelte-check 0/0, lint clean, unit + e2e green.

## Next
Slice 2 also calls for absorbing the **Stable table as the Library's table density** — I left that out to keep this PR to the lenses; it's a small follow-up. Then slice 3 (relocate), 4 (GeneGrid parity+swap), 5 (cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)