### PR TITLE
feat(redesign): Roster lens — absorb the Stable attribute table

### DIFF
--- a/src/lib/components/library/Roster.svelte
+++ b/src/lib/components/library/Roster.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+/**
+ * Roster — the Library's full attribute table, shown in the Workspace when no
+ * pet is selected. Absorbs the old Stable tab: a sortable matrix of the
+ * filtered pets with Name / Gender / Breed / per-species attributes / Total /
+ * +Genes, driven by `libraryView` (filters + sort + multi-select). Clicking a
+ * name opens that pet; checkboxes build a multi-selection for the lenses.
+ * See docs/design/redesign-library-workspace-v1.md (§2.1).
+ */
+import { getAllAttributeNames, getAllAttributes, normalizeSpecies } from '$lib/services/configService.js';
+import { libraryView, setLibrarySelection, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+import { filterPets } from '$lib/utils/petFilter.js';
+import { capitalize } from '$lib/utils/string.js';
+
+interface Column {
+  id: string;
+  label: string;
+  numeric: boolean;
+  accessor: (pet: Pet) => string | number;
+}
+
+// Per-attribute columns only when a single species is selected (different
+// species expose different attributes); species-agnostic columns are always
+// shown so the roster is useful for an all-species view too.
+const columns = $derived.by((): Column[] => {
+  const species = libraryView.species;
+  const attrNames = species ? getAllAttributeNames(species) : [];
+  const attrInfo = species ? (getAllAttributes(species) as Record<string, { name?: string }>) : {};
+  const num = (pet: Pet, k: string) => (pet as unknown as Record<string, number>)[k] ?? 0;
+
+  const attrCols: Column[] = attrNames.map((attr) => ({
+    id: attr,
+    label: attrInfo[attr]?.name ?? capitalize(attr),
+    numeric: true,
+    accessor: (pet: Pet) => num(pet, attr),
+  }));
+
+  return [
+    { id: 'name', label: 'Name', numeric: false, accessor: (p) => p.name ?? '' },
+    { id: 'gender', label: 'Gender', numeric: false, accessor: (p) => p.gender ?? '' },
+    { id: 'breed', label: 'Breed', numeric: false, accessor: (p) => p.breed ?? '' },
+    ...attrCols,
+    {
+      id: 'attr_total',
+      label: 'Total',
+      numeric: true,
+      accessor: (p) => attrNames.reduce((sum, a) => sum + num(p, a), 0),
+    },
+    { id: 'positive_genes', label: '+ Genes', numeric: true, accessor: (p) => p.positive_genes ?? 0 },
+  ];
+});
+
+const filtered = $derived(
+  filterPets($pets, {
+    query: libraryView.search,
+    tags: libraryView.tags,
+    starredOnly: libraryView.starredOnly,
+    stabledOnly: libraryView.stabledOnly,
+    petQualityOnly: libraryView.petQualityOnly,
+    species: libraryView.species,
+    breed: libraryView.breed,
+  }),
+);
+
+const sorted = $derived.by(() => {
+  const col = columns.find((c) => c.id === libraryView.sortCol) ?? columns[0];
+  const list = [...filtered];
+  list.sort((a, b) => {
+    const av = col.accessor(a);
+    const bv = col.accessor(b);
+    const cmp = col.numeric ? Number(av) - Number(bv) : String(av).localeCompare(String(bv));
+    return libraryView.sortDir === 'asc' ? cmp : -cmp;
+  });
+  return list;
+});
+
+// If the sorted column disappears (species change drops an attribute), fall
+// back to name so the table doesn't silently sort by a stale, missing column.
+$effect(() => {
+  const ids = new Set(columns.map((c) => c.id));
+  if (!ids.has(libraryView.sortCol)) {
+    libraryView.sortCol = 'name';
+    libraryView.sortDir = 'asc';
+  }
+});
+
+const selectedInView = $derived(sorted.reduce((n, p) => n + (libraryView.selectedIds.has(p.id) ? 1 : 0), 0));
+const allSelected = $derived(sorted.length > 0 && selectedInView === sorted.length);
+const someSelected = $derived(selectedInView > 0 && !allSelected);
+
+function toggleSort(colId: string): void {
+  if (libraryView.sortCol === colId) {
+    libraryView.sortDir = libraryView.sortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    libraryView.sortCol = colId;
+    libraryView.sortDir = 'asc';
+  }
+}
+
+function sortIndicator(colId: string): string {
+  if (colId !== libraryView.sortCol) return '';
+  return libraryView.sortDir === 'asc' ? ' ▲' : ' ▼';
+}
+
+function toggleSelectAll(): void {
+  const next = new Set(libraryView.selectedIds);
+  if (allSelected) for (const p of sorted) next.delete(p.id);
+  else for (const p of sorted) next.add(p.id);
+  setLibrarySelection(next);
+}
+
+// Open a single pet (replaces the selection so the Workspace shows its detail).
+function open(pet: Pet): void {
+  setLibrarySelection(new Set([pet.id]));
+}
+</script>
+
+<div class="roster" data-testid="roster">
+  <table class="roster-table">
+    <thead>
+      <tr>
+        <th class="sel-col">
+          <input
+            type="checkbox"
+            data-testid="roster-select-all"
+            checked={allSelected}
+            indeterminate={someSelected}
+            onchange={toggleSelectAll}
+            aria-label="Select all {sorted.length} pets"
+          />
+        </th>
+        {#each columns as col (col.id)}
+          <th class:numeric={col.numeric} class:active-sort={libraryView.sortCol === col.id}>
+            <button type="button" class="sort-btn" onclick={() => toggleSort(col.id)}>
+              {col.label}{sortIndicator(col.id)}
+            </button>
+          </th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#if sorted.length === 0}
+        <tr><td class="empty" colspan={columns.length + 1}>No pets match these filters.</td></tr>
+      {:else}
+        {#each sorted as pet (pet.id)}
+          <tr class:row-selected={libraryView.selectedIds.has(pet.id)} data-pet-id={pet.id}>
+            <td class="sel-col">
+              <input
+                type="checkbox"
+                data-testid="roster-row-select"
+                checked={libraryView.selectedIds.has(pet.id)}
+                onchange={() => toggleLibrarySelection(pet.id)}
+                aria-label="Select {pet.name}"
+              />
+            </td>
+            {#each columns as col (col.id)}
+              <td class:numeric={col.numeric}>
+                {#if col.id === 'name'}
+                  <button type="button" class="name-btn" data-testid="roster-open" onclick={() => open(pet)}>
+                    {col.accessor(pet)}
+                  </button>
+                {:else}
+                  {col.accessor(pet)}
+                {/if}
+              </td>
+            {/each}
+          </tr>
+        {/each}
+      {/if}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .roster { width: 100%; overflow: auto; }
+  .roster-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .roster-table th,
+  .roster-table td { padding: 6px 10px; text-align: left; border-bottom: 1px solid var(--border-primary); white-space: nowrap; }
+  .roster-table th.numeric,
+  .roster-table td.numeric { text-align: right; }
+  .roster-table thead th { position: sticky; top: 0; background: var(--bg-tertiary); color: var(--text-secondary); font-weight: 600; z-index: 1; }
+  .roster-table th.active-sort { color: var(--accent-text, var(--accent)); }
+  .sel-col { width: 1%; text-align: center; }
+  .sort-btn { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; }
+  .sort-btn:hover { color: var(--accent-text, var(--accent)); }
+  .name-btn { background: none; border: none; padding: 0; font: inherit; font-weight: 600; color: var(--accent-text, var(--accent)); cursor: pointer; }
+  .name-btn:hover { text-decoration: underline; }
+  .roster-table tbody tr:hover { background: var(--bg-secondary); }
+  .roster-table tbody tr.row-selected { background: var(--bg-selected); }
+  .empty { text-align: center; color: var(--text-muted); font-style: italic; padding: 24px; }
+</style>

--- a/src/lib/components/library/Roster.svelte
+++ b/src/lib/components/library/Roster.svelte
@@ -7,7 +7,7 @@
  * name opens that pet; checkboxes build a multi-selection for the lenses.
  * See docs/design/redesign-library-workspace-v1.md (§2.1).
  */
-import { getAllAttributeNames, getAllAttributes, normalizeSpecies } from '$lib/services/configService.js';
+import { getAllAttributeNames, getAllAttributes } from '$lib/services/configService.js';
 import { libraryView, setLibrarySelection, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
 import { pets } from '$lib/stores/pets.js';
 import type { Pet } from '$lib/types/index.js';

--- a/src/lib/components/library/Workspace.svelte
+++ b/src/lib/components/library/Workspace.svelte
@@ -11,6 +11,7 @@
  */
 import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
 import BreedLens from '$lib/components/library/BreedLens.svelte';
+import Roster from '$lib/components/library/Roster.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import { normalizeSpecies } from '$lib/services/configService.js';
@@ -45,11 +46,13 @@ $effect(() => {
 
 <section class="workspace" data-testid="workspace">
   {#if selected.length === 0}
-    <EmptyState
-      icon="🐾"
-      title="Pick a pet to begin"
-      body="Select one pet from the library to inspect its genes and stats, or two or more of the same species to compare and rank breeding pairs."
-    />
+    {#if $pets.length === 0}
+      <EmptyState icon="🐾" title="No pets yet" body="Upload a genome file from the library to get started." />
+    {:else}
+      <div class="roster-wrap" data-testid="workspace-roster">
+        <Roster />
+      </div>
+    {/if}
   {:else if selected.length === 1}
     <PetVisualization pet={selected[0]} />
   {:else if commonSpecies === null}
@@ -94,6 +97,7 @@ $effect(() => {
 
 <style>
   .workspace { flex: 1; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
+  .roster-wrap { flex: 1; min-height: 0; overflow: auto; padding: 16px 20px; }
   .multi { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 
   .lens-tabs {

--- a/src/lib/stores/library.svelte.ts
+++ b/src/lib/stores/library.svelte.ts
@@ -18,6 +18,9 @@ export const libraryView = $state({
   petQualityOnly: false,
   tags: [] as string[],
   density: 'card' as LibraryDensity,
+  /** Roster (table) sort — column id + direction. */
+  sortCol: 'name' as string,
+  sortDir: 'asc' as 'asc' | 'desc',
   /** Multi-select for bulk actions / driving the Workspace. */
   selectedIds: new Set<number>() as Set<number>,
 });

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -19,11 +19,14 @@ test.describe('Redesign — Library + Workspace shell', () => {
     await expect(page.locator('[data-testid="tab-library"]')).toBeVisible();
   });
 
-  test('selecting one pet shows its detail; the prompt shows when none selected', async ({ page }) => {
+  test('shows the roster when nothing is selected, and a pet detail once selected', async ({ page }) => {
     await openLibrary(page);
-    await expect(page.locator('[data-testid="workspace"] [data-testid="empty-state"]')).toBeVisible();
+    // Nothing selected → the full roster table fills the workspace.
+    await expect(page.locator('[data-testid="workspace-roster"]')).toBeVisible();
+    await expect(page.locator('[data-testid="roster"]')).toBeVisible();
 
-    await page.locator('[data-testid="pet-row-select"]').first().check();
+    // Opening a pet from the roster shows its detail.
+    await page.locator('[data-testid="roster-open"]').first().click();
     await expect(page.locator('.pet-visualization')).toBeVisible();
   });
 

--- a/tests/unit/roster.test.ts
+++ b/tests/unit/roster.test.ts
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import Roster from '$lib/components/library/Roster.svelte';
+import { libraryView } from '$lib/stores/library.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+
+const pet = (over: Partial<Pet>): Pet =>
+  ({
+    id: 0,
+    name: 'Pet',
+    species: 'Horse',
+    breed: 'Standardbred',
+    gender: 'Female',
+    tags: [],
+    stabled: true,
+    positive_genes: 0,
+    ...over,
+  }) as unknown as Pet;
+
+const SAMPLE = [
+  pet({ id: 1, name: 'Dusty', gender: 'Male', positive_genes: 30, toughness: 60 } as Partial<Pet>),
+  pet({ id: 2, name: 'Roach', gender: 'Female', positive_genes: 36, toughness: 40 } as Partial<Pet>),
+];
+
+function resetView() {
+  libraryView.search = '';
+  libraryView.species = '';
+  libraryView.breed = '';
+  libraryView.starredOnly = false;
+  libraryView.stabledOnly = false;
+  libraryView.petQualityOnly = false;
+  libraryView.tags = [];
+  libraryView.sortCol = 'name';
+  libraryView.sortDir = 'asc';
+  libraryView.selectedIds = new Set();
+}
+
+beforeEach(() => {
+  resetView();
+  pets.set(SAMPLE);
+});
+
+afterEach(() => {
+  cleanup();
+  pets.set([]);
+  resetView();
+});
+
+const headers = (c: HTMLElement) => [...c.querySelectorAll('thead .sort-btn')].map((b) => b.textContent?.trim());
+const rowNames = (c: HTMLElement) =>
+  [...c.querySelectorAll('[data-testid="roster-open"]')].map((b) => b.textContent?.trim());
+
+describe('Roster', () => {
+  it('shows species-agnostic columns when no species is selected (no per-attribute columns)', () => {
+    const { container } = render(Roster);
+    const labels = headers(container);
+    expect(labels?.some((l) => l?.startsWith('Name'))).toBe(true);
+    expect(labels).toContain('Gender');
+    expect(labels?.some((l) => l?.startsWith('Total'))).toBe(true);
+    expect(labels?.some((l) => l?.startsWith('+ Genes'))).toBe(true);
+    // No horse attribute column (e.g. Toughness) until a species is chosen.
+    expect(labels?.some((l) => l?.toLowerCase().includes('toughness'))).toBe(false);
+  });
+
+  it('adds per-attribute columns when a species is selected', () => {
+    libraryView.species = 'horse';
+    const { container } = render(Roster);
+    const labels = headers(container).map((l) => l?.toLowerCase() ?? '');
+    expect(labels.some((l) => l.includes('toughness'))).toBe(true);
+  });
+
+  it('lists the filtered pets and respects the search filter', async () => {
+    const { container, rerender } = render(Roster);
+    expect(rowNames(container)).toEqual(['Dusty', 'Roach']);
+    libraryView.search = 'roach';
+    await rerender({});
+    expect(rowNames(container)).toEqual(['Roach']);
+  });
+
+  it('sorts by a clicked column and toggles direction', async () => {
+    const { container } = render(Roster);
+    // Default name asc → Dusty, Roach.
+    expect(rowNames(container)).toEqual(['Dusty', 'Roach']);
+    // Click +Genes → asc (30, 36) → Dusty, Roach; click again → desc → Roach, Dusty.
+    const plusGenes = [...container.querySelectorAll('thead .sort-btn')].find((b) =>
+      b.textContent?.includes('+ Genes'),
+    ) as HTMLButtonElement;
+    await fireEvent.click(plusGenes);
+    expect(libraryView.sortCol).toBe('positive_genes');
+    expect(rowNames(container)).toEqual(['Dusty', 'Roach']);
+    await fireEvent.click(plusGenes);
+    expect(libraryView.sortDir).toBe('desc');
+    expect(rowNames(container)).toEqual(['Roach', 'Dusty']);
+  });
+
+  it('opening a pet by name sets it as the sole selection', async () => {
+    const { container } = render(Roster);
+    await fireEvent.click(container.querySelectorAll('[data-testid="roster-open"]')[1] as HTMLButtonElement);
+    expect([...libraryView.selectedIds]).toEqual([2]);
+  });
+
+  it('row checkbox toggles multi-selection; select-all covers the filtered set', async () => {
+    const { container } = render(Roster);
+    await fireEvent.click(container.querySelector('[data-testid="roster-row-select"]') as HTMLInputElement);
+    expect(libraryView.selectedIds.size).toBe(1);
+
+    await fireEvent.click(container.querySelector('[data-testid="roster-select-all"]') as HTMLInputElement);
+    expect(libraryView.selectedIds.size).toBe(2);
+  });
+});

--- a/tests/unit/workspace.test.ts
+++ b/tests/unit/workspace.test.ts
@@ -33,11 +33,20 @@ afterEach(() => {
 const emptyState = (c: HTMLElement) => c.querySelector('[data-testid="empty-state"]');
 
 describe('Workspace', () => {
-  it('prompts to pick a pet when nothing is selected', () => {
+  it('shows the roster when nothing is selected and pets exist', () => {
     select([]);
     const { container } = render(Workspace);
-    expect(emptyState(container)?.textContent).toContain('Pick a pet to begin');
+    expect(container.querySelector('[data-testid="workspace-roster"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="roster"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="workspace-multi"]')).toBeNull();
+  });
+
+  it('shows an empty state only when there are no pets at all', () => {
+    pets.set([]);
+    select([]);
+    const { container } = render(Workspace);
+    expect(emptyState(container)?.textContent).toContain('No pets yet');
+    expect(container.querySelector('[data-testid="workspace-roster"]')).toBeNull();
   });
 
   it('guides toward same-species when two different species are selected', () => {


### PR DESCRIPTION
Absorbs the Stable tab into the redesign (`docs/design/redesign-library-workspace-v1.md` §2.1). Targets the epic.

## Decision
The Stable attribute matrix is too wide for the Library sidebar (≤560px), so rather than a sidebar "table density" it becomes a **Roster lens in the Workspace**, shown when no pet is selected. The sidebar stays the navigable list; the wide table lives in the wide area.

## What
`Roster.svelte` — a sortable table of the **filtered** pets driven by `libraryView`:
- Columns: Name · Gender · Breed · (per-species attributes when a species is selected) · Total · +Genes. Species-agnostic columns always show, so the all-species view stays useful.
- **Click a name** → opens that pet (sole selection → its detail/lenses).
- **Checkboxes** → build a multi-selection that drives the Compare/Breed lenses; **select-all** covers the filtered set.
- Sort by clicking headers (persisted in `libraryView.sortCol/sortDir`; falls back to Name if a sorted attribute column disappears on species change).

Workspace empty-selection now renders the Roster (or an empty state only when there are genuinely no pets).

## Tests
- `roster.test.ts` (6) — column sets (agnostic vs species), search filter, sort + direction toggle, open-by-name selection, checkbox + select-all.
- `workspace.test.ts` — 0-selected → roster; no pets → empty state.
- `redesign-library.spec.ts` — roster visible at 0 selection, open-from-roster → detail.
- svelte-check 0/0, lint clean, full unit suite green (758).

🤖 Generated with [Claude Code](https://claude.com/claude-code)