### PR TITLE
feat(redesign): Reference destination for gene templates (slice 3a)

### DIFF
--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -78,7 +78,7 @@ function onHandleKeydown(e: KeyboardEvent) {
         >‹</button>
         {#if $activeTab === "pets"}
             <PetList />
-        {:else if $activeTab === "editor"}
+        {:else if $activeTab === "editor" || $activeTab === "reference"}
             <div class="gene-editor-wrapper">
                 <GeneEditor />
             </div>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -56,6 +56,14 @@ function handleMouseUp(e: MouseEvent) {
             >
                 ✨ My Pets
             </button>
+            <button
+                class="tab-btn"
+                class:active={$activeTab === "reference"}
+                data-testid="tab-reference"
+                onclick={() => switchTab("reference")}
+            >
+                📚 Reference
+            </button>
         {/if}
         <button
             class="tab-btn"

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -4,7 +4,7 @@ import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
 
-export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding' | 'community' | 'library';
+export type Tab = 'pets' | 'editor' | 'compare' | 'stable' | 'breeding' | 'community' | 'library' | 'reference';
 
 /** Boolean pet flags toggled in-place via `setPetMarker` (no full reload). */
 export type MarkerKey = 'starred' | 'stabled' | 'is_pet_quality';
@@ -53,6 +53,9 @@ const TAB_STATE_RESETS: Record<Tab, () => void> = {
   // The Library drives its own selection (libraryView.selectedIds); clear the
   // legacy single-pet/gene-edit state so it can't leak into the workspace.
   library: clearSelectionAndGeneView,
+  // Reference (gene-template editing) is its own destination, like 'editor';
+  // clear any selected pet so the legacy detail view doesn't bleed through.
+  reference: () => selectedPet.set(null),
 };
 
 // Monotonic generation counter for in-flight `loadPets` calls. Concurrent

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@ import ComparisonView from '$lib/components/comparison/ComparisonView.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
 import Workspace from '$lib/components/library/Workspace.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
+import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import StableTable from '$lib/components/stable/StableTable.svelte';
 import { activeTab, appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
 
@@ -24,6 +25,19 @@ onMount(async () => {
 
 	{#if $activeTab === 'library'}
 		<Workspace />
+	{:else if $activeTab === 'reference'}
+		{#if $geneEditingView}
+			<GeneEditingView
+				animalType={($geneEditingView as { animalType?: string; chromosome?: string }).animalType}
+				chromosome={($geneEditingView as { animalType?: string; chromosome?: string }).chromosome}
+			/>
+		{:else}
+			<EmptyState
+				icon="📚"
+				title="Edit gene templates"
+				body="Pick an animal type and chromosome in the sidebar, then choose Edit Genes."
+			/>
+		{/if}
 	{:else if $activeTab === 'stable'}
 		<StableTable />
 	{:else if $activeTab === 'compare'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,10 @@ import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import StableTable from '$lib/components/stable/StableTable.svelte';
 import { activeTab, appState, error, geneEditingView, loading, selectedPet } from '$lib/stores/pets.js';
 
+// `geneEditingView` is an untyped store carrying the editor target; type it
+// once here rather than re-asserting the shape at each prop site.
+const geneEdit = $derived($geneEditingView as { animalType?: string; chromosome?: string } | null);
+
 onMount(async () => {
   await appState.loadPets();
 });
@@ -28,8 +32,8 @@ onMount(async () => {
 	{:else if $activeTab === 'reference'}
 		{#if $geneEditingView}
 			<GeneEditingView
-				animalType={($geneEditingView as { animalType?: string; chromosome?: string }).animalType}
-				chromosome={($geneEditingView as { animalType?: string; chromosome?: string }).chromosome}
+				animalType={geneEdit?.animalType}
+				chromosome={geneEdit?.chromosome}
 			/>
 		{:else}
 			<EmptyState
@@ -55,8 +59,8 @@ onMount(async () => {
 		<PetVisualization pet={$selectedPet} />
 	{:else if $geneEditingView}
 		<GeneEditingView
-			animalType={($geneEditingView as { animalType?: string; chromosome?: string }).animalType}
-			chromosome={($geneEditingView as { animalType?: string; chromosome?: string }).chromosome}
+			animalType={geneEdit?.animalType}
+			chromosome={geneEdit?.chromosome}
 		/>
 	{:else}
 		<div class="center-state">

--- a/tests/e2e/redesign-reference.spec.ts
+++ b/tests/e2e/redesign-reference.spec.ts
@@ -19,7 +19,7 @@ test.describe('Redesign — Reference destination', () => {
 
     // Picking an animal type + chromosome and editing opens the editing view.
     await page.locator('#animalType').selectOption('beewasp');
-    await page.locator('select').nth(1).selectOption({ index: 1 });
+    await page.locator('#chromosome').selectOption({ index: 1 });
     await page.getByRole('button', { name: 'Edit Genes' }).click();
     await expect(page.locator('.gene-editing-view')).toBeVisible();
   });

--- a/tests/e2e/redesign-reference.spec.ts
+++ b/tests/e2e/redesign-reference.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+test.describe('Redesign — Reference destination', () => {
+  test('flag-gated Reference hosts the gene-template editor with its own empty state', async ({ page }) => {
+    // Hidden without the flag.
+    await page.goto('/');
+    await waitForAppReady(page);
+    await expect(page.locator('[data-testid="tab-reference"]')).toHaveCount(0);
+
+    await page.goto('/?redesign=1');
+    await waitForAppReady(page);
+    await page.locator('[data-testid="tab-reference"]').click();
+
+    // Sidebar shows the gene-template editor controls…
+    await expect(page.locator('#animalType')).toBeVisible();
+    // …and the main area shows a fitting empty state (not the "select a pet" copy).
+    await expect(page.locator('[data-testid="empty-state"]')).toContainText('Edit gene templates');
+
+    // Picking an animal type + chromosome and editing opens the editing view.
+    await page.locator('#animalType').selectOption('beewasp');
+    await page.locator('select').nth(1).selectOption({ index: 1 });
+    await page.getByRole('button', { name: 'Edit Genes' }).click();
+    await expect(page.locator('.gene-editing-view')).toBeVisible();
+  });
+});


### PR DESCRIPTION
Adoption slice 3a (`docs/design/redesign-library-workspace-v1.md` §7, decision #4). Targets the epic.

## What
A flagged **📚 Reference** destination that hosts gene-template editing — the existing `GeneEditor` sidebar + `GeneEditingView` — separating per-species config from the pet views (it was an odd peer of the pet tabs). The legacy `editor` tab is left intact until cutover (parallel build).

Its empty state uses the `EmptyState` primitive with fitting copy ("Edit gene templates — pick an animal type and chromosome, then Edit Genes"), **fixing the §1.6 bug** where the editor surface showed the "Select a pet to view details" copy.

## Tests
- `redesign-reference.spec.ts` (e2e) — Reference hidden without the flag; with it, the editor sidebar (`#animalType`) + the correct empty state render, and picking type + chromosome + Edit Genes opens the editing view.
- svelte-check 0/0, lint clean, full unit suite green (758).

## Next
Slice 3b — Community → shared Library+detail shell with a source switch (decision #3); then slice 4 (GeneGrid parity + swap), slice 5 (cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)