### PR TITLE
feat(redesign): square cells in the Compare grid (slice 4a)

### DIFF
--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -434,7 +434,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class="{currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} gene-cell--square" data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}
@@ -452,7 +452,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class="{currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} gene-cell--square" data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}

--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -151,6 +151,15 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     }
 
+    /* Opt-in square shape (redesign decision #2). The circle remains the
+       default; only surfaces that add `gene-cell--square` (currently the
+       comparison grid) render squares — colour/zygosity/appearance/breed
+       encoding is unchanged. Retire the circle default once every surface
+       opts in. */
+    :global(.gene-cell.gene-cell--square) {
+        border-radius: 3px;
+    }
+
     /* Gene effect colors — values from --gene-* CSS vars (src/lib/theme/gene-colors.ts) */
     :global(.gene-positive.gene-dominant) {
         background-color: var(--gene-positive);

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -28,6 +28,9 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Opening a pet from the roster shows its detail.
     await page.locator('[data-testid="roster-open"]').first().click();
     await expect(page.locator('.pet-visualization')).toBeVisible();
+    // The pet detail still renders circle cells (squares are opt-in per surface).
+    await expect(page.locator('.pet-visualization .gene-cell').first()).toBeVisible();
+    await expect(page.locator('.pet-visualization .gene-cell--square')).toHaveCount(0);
   });
 
   test('two same-species pets open the multi lens with Compare and Breed tabs', async ({ page }) => {
@@ -43,6 +46,8 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Compare is the default lens for exactly two same-species pets.
     await expect(page.locator('[data-testid="workspace-multi"]')).toBeVisible();
     await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
+    // The Compare diff renders square cells (the redesign squares pilot).
+    await expect(page.locator('[data-testid="workspace-multi"] .gene-cell--square').first()).toBeVisible();
 
     // Switching to the Breed lens ranks the pair; inspecting opens the trio.
     await page.locator('[data-testid="lens-tab-breed"]').click();


### PR DESCRIPTION
First step of the squares unification (`docs/design/redesign-library-workspace-v1.md` decision #2), piloted on Compare. Targets the epic.

## Insight
On the existing gene-cell system the circle↔square difference is **just `border-radius`** — the global `.gene-cell` classes already encode effect *and* appearance colour, zygosity fill, breed-inactive styling, and filter dimming. So rather than a scoped `GeneGridCell` that would re-implement the whole appearance color system, this adds an **opt-in `gene-cell--square` modifier** (the circle remains the default) and applies it to `GenomeGridDiff`'s cells.

## Result
- **Compare** renders square cells (both the old Compare tab and the new Compare lens use `GenomeGridDiff`).
- **Pets** and **trio** keep circles — they haven't opted in. The circle default retires once every surface adopts the modifier.
- No change to colour / zygosity / appearance / breed / filter behavior.

## Tests
- `redesign-library.spec.ts` — asserts the Compare lens renders `.gene-cell--square`, and the pet detail renders `.gene-cell` with **zero** `.gene-cell--square` (isolation).
- Old `comparison.spec.ts` (12) still green; svelte-check 0/0, lint clean.

## Note
This reframes the standalone `GeneGrid` primitive: for the live swap, squaring the proven global system per-surface is lower-risk than routing live grids through a re-implemented cell. Pets/trio adoption follows; then retire the circle default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)