### PR TITLE
feat(redesign): square cells in the pet view (slice 4b)

### DIFF
--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -62,6 +62,12 @@ function computeCssClass(
     cssClass += ' gene-filtered-out';
   }
 
+  // Squares (redesign decision #2). GeneCell is used only by the pet view, so
+  // opting in here squares Pets without touching the inline-rendered Compare
+  // (already squared) or trio cells. Once trio opts in too, the circle default
+  // can be dropped and this modifier folded into the base rule.
+  cssClass += ' gene-cell--square';
+
   return cssClass;
 }
 

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -28,9 +28,8 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Opening a pet from the roster shows its detail.
     await page.locator('[data-testid="roster-open"]').first().click();
     await expect(page.locator('.pet-visualization')).toBeVisible();
-    // The pet detail still renders circle cells (squares are opt-in per surface).
-    await expect(page.locator('.pet-visualization .gene-cell').first()).toBeVisible();
-    await expect(page.locator('.pet-visualization .gene-cell--square')).toHaveCount(0);
+    // The pet detail now renders square cells too (slice 4b).
+    await expect(page.locator('.pet-visualization .gene-cell--square').first()).toBeVisible();
   });
 
   test('two same-species pets open the multi lens with Compare and Breed tabs', async ({ page }) => {


### PR DESCRIPTION
Slice 4b of the squares unification (decision #2). Targets the epic.

## What
`GeneCell` opts into the `gene-cell--square` modifier (added in 4a). Since `GeneCell` is used **only** by `GeneVisualizer` (the pet detail) — Compare and trio render cells inline — this squares the **Pets** view without affecting other surfaces. Colour / zygosity / appearance / breed / filter behavior unchanged.

State after this PR: Compare ✅ square (4a), Pets ✅ square (4b), trio still circles (4c next). Once trio opts in, the circle default folds into the base rule.

## Tests
- `redesign-library.spec.ts` — the 4a isolation assertion is updated: the pet detail now renders `.gene-cell--square`.
- svelte-check 0/0, lint clean, full unit suite green (758). (The `geneGridCells`/`filterCSS`/`trioGrid` unit tests assert the factory class strings, not `GeneCell`'s rendered class, so they're unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)