### PR TITLE
refactor(redesign): unify gene-cell as square by default

### DIFF
--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -434,7 +434,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class="{currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} gene-cell--square" data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}
@@ -452,7 +452,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class="{currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} gene-cell--square" data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}

--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -62,12 +62,6 @@ function computeCssClass(
     cssClass += ' gene-filtered-out';
   }
 
-  // Squares (redesign decision #2). GeneCell is used only by the pet view, so
-  // opting in here squares Pets without touching the inline-rendered Compare
-  // (already squared) or trio cells. Once trio opts in too, the circle default
-  // can be dropped and this modifier folded into the base rule.
-  cssClass += ' gene-cell--square';
-
   return cssClass;
 }
 
@@ -140,7 +134,7 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
         width: 14px;
         height: 14px;
         margin: 0px;
-        border-radius: 50%;
+        border-radius: 3px;
         border: 2px solid;
         cursor: pointer;
         transition: all 0.2s ease;
@@ -155,15 +149,6 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
         transform: scale(1.2);
         z-index: 20;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    }
-
-    /* Opt-in square shape (redesign decision #2). The circle remains the
-       default; only surfaces that add `gene-cell--square` (currently the
-       comparison grid) render squares — colour/zygosity/appearance/breed
-       encoding is unchanged. Retire the circle default once every surface
-       opts in. */
-    :global(.gene-cell.gene-cell--square) {
-        border-radius: 3px;
     }
 
     /* Gene effect colors — values from --gene-* CSS vars (src/lib/theme/gene-colors.ts) */

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -28,8 +28,8 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Opening a pet from the roster shows its detail.
     await page.locator('[data-testid="roster-open"]').first().click();
     await expect(page.locator('.pet-visualization')).toBeVisible();
-    // The pet detail now renders square cells too (slice 4b).
-    await expect(page.locator('.pet-visualization .gene-cell--square').first()).toBeVisible();
+    // The pet detail renders gene cells (now square — the unified shape).
+    await expect(page.locator('.pet-visualization .gene-cell').first()).toBeVisible();
   });
 
   test('two same-species pets open the multi lens with Compare and Breed tabs', async ({ page }) => {
@@ -45,8 +45,8 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Compare is the default lens for exactly two same-species pets.
     await expect(page.locator('[data-testid="workspace-multi"]')).toBeVisible();
     await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
-    // The Compare diff renders square cells (the redesign squares pilot).
-    await expect(page.locator('[data-testid="workspace-multi"] .gene-cell--square').first()).toBeVisible();
+    // The Compare diff renders gene cells (now square — the unified shape).
+    await expect(page.locator('[data-testid="workspace-multi"] .gene-cell').first()).toBeVisible();
 
     // Switching to the Breed lens ranks the pair; inspecting opens the trio.
     await page.locator('[data-testid="lens-tab-breed"]').click();

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -28,8 +28,12 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Opening a pet from the roster shows its detail.
     await page.locator('[data-testid="roster-open"]').first().click();
     await expect(page.locator('.pet-visualization')).toBeVisible();
-    // The pet detail renders gene cells (now square — the unified shape).
-    await expect(page.locator('.pet-visualization .gene-cell').first()).toBeVisible();
+    // The pet detail renders gene cells in the unified square shape — assert
+    // the computed border-radius so a regression back to circles (50% → 7px)
+    // fails the test rather than passing on mere presence.
+    const petCell = page.locator('.pet-visualization .gene-cell').first();
+    await expect(petCell).toBeVisible();
+    await expect.poll(() => petCell.evaluate((el) => getComputedStyle(el).borderRadius)).toBe('3px');
   });
 
   test('two same-species pets open the multi lens with Compare and Breed tabs', async ({ page }) => {
@@ -45,8 +49,11 @@ test.describe('Redesign — Library + Workspace shell', () => {
     // Compare is the default lens for exactly two same-species pets.
     await expect(page.locator('[data-testid="workspace-multi"]')).toBeVisible();
     await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
-    // The Compare diff renders gene cells (now square — the unified shape).
-    await expect(page.locator('[data-testid="workspace-multi"] .gene-cell').first()).toBeVisible();
+    // The Compare diff renders gene cells in the unified square shape — assert
+    // the computed border-radius to guard against a regression to circles.
+    const compareCell = page.locator('[data-testid="workspace-multi"] .gene-cell').first();
+    await expect(compareCell).toBeVisible();
+    await expect.poll(() => compareCell.evaluate((el) => getComputedStyle(el).borderRadius)).toBe('3px');
 
     // Switching to the Breed lens ranks the pair; inspecting opens the trio.
     await page.locator('[data-testid="lens-tab-breed"]').click();


### PR DESCRIPTION
Completes slice 4 (squares unification). Trio parent cells rendered `.gene-cell` without the opt-in `gene-cell--square` modifier, so they stayed circular while Pets (4b) and Compare (4a) were square.

Rather than add the modifier to trio and then remove it, this retires the circle default: the base `.gene-cell` is now square (`border-radius: 3px`) and the `gene-cell--square` modifier is dropped from GeneCell, GenomeGridDiff, and the e2e assertions. Trio parents inherit the square shape automatically. The offspring distribution bar (`.dist-bar`) is unchanged.

After this, only slice 5 (cutover) remains.

- check: 0 errors / 0 warnings
- lint:ci: clean
- unit: 758 passed
- e2e: redesign-library + redesign-reference pass