### PR TITLE
feat(redesign): pet edit/delete parity in the Library shell

### DIFF
--- a/src/lib/components/library/Library.svelte
+++ b/src/lib/components/library/Library.svelte
@@ -6,6 +6,7 @@
  * until cutover. See docs/design/redesign-library-workspace-v1.md.
  */
 import FilterBar from '$lib/components/shared/FilterBar.svelte';
+import PetActions from '$lib/components/shared/PetActions.svelte';
 import PetRow from '$lib/components/shared/PetRow.svelte';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { clearLibrarySelection, libraryView, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
@@ -123,6 +124,7 @@ function metaFor(pet: Pet): string {
         >
           {#snippet trailing()}
             {#if pet.starred}<span class="lib-star" title="Starred">★</span>{/if}
+            <PetActions {pet} variant="icon" />
           {/snippet}
         </PetRow>
       {/each}

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -3,6 +3,7 @@ import { onDestroy } from 'svelte';
 import SharePetDialog from '$lib/components/community/SharePetDialog.svelte';
 import GeneStatsTable from '$lib/components/gene/GeneStatsTable.svelte';
 import GeneVisualizer from '$lib/components/gene/GeneVisualizer.svelte';
+import PetActions from '$lib/components/shared/PetActions.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { settings } from '$lib/stores/settings.js';
 import type { DialogResult, Pet } from '$lib/types/index.js';
@@ -216,6 +217,7 @@ onDestroy(() => {
                 >
                     Share
                 </button>
+                {#if pet}<PetActions {pet} variant="button" />{/if}
             </div>
         </div>
     </div>

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -90,7 +90,11 @@ async function doDelete(): Promise<void> {
 
 {#if confirming}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="modal-backdrop" onclick={cancelDelete} onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }}>
+  <div
+    class="modal-backdrop"
+    onclick={(e) => { if (e.target === e.currentTarget) cancelDelete(); }}
+    onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }}
+  >
     <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" aria-modal="true" use:focusTrap>
       <p class="confirm-message">Delete <strong>{pet.name}</strong>?</p>
       <p class="confirm-subtext">This action cannot be undone.</p>

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+/**
+ * Edit + delete actions for a single pet, reusable across the redesign shell.
+ *
+ * The pre-redesign UI wired these only into the Pets-tab card list
+ * (`PetList.svelte`). The Library + Workspace IA has no equivalent, so this
+ * lifts the same `PetEditor` modal and delete-confirm dialog into a shared
+ * component that the library rows (icon variant) and the single-pet workspace
+ * header (button variant) both mount. Deletion goes through the same
+ * `appState.deletePet`. See docs/design/redesign-library-workspace-v1.md §5.
+ */
+
+import PetEditor from '$lib/components/pet/PetEditor.svelte';
+import { appState } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
+
+interface Props {
+  pet: Pet;
+  /** `icon` → compact ✎/✕ glyphs for list rows; `button` → labelled controls for the detail header. */
+  variant?: 'icon' | 'button';
+}
+
+const { pet, variant = 'icon' }: Props = $props();
+
+let showEditor = $state(false);
+let confirming = $state(false);
+
+function openEditor(): void {
+  showEditor = true;
+}
+
+function closeEditor(): void {
+  showEditor = false;
+}
+
+function confirmDelete(): void {
+  confirming = true;
+}
+
+function cancelDelete(): void {
+  confirming = false;
+}
+
+async function doDelete(): Promise<void> {
+  await appState.deletePet(pet.id);
+  confirming = false;
+}
+</script>
+
+{#if variant === 'icon'}
+  <button
+    class="action-btn edit-btn"
+    title="Edit pet"
+    data-testid="pet-edit-btn"
+    data-action="edit"
+    data-pet-id={pet.id}
+    onclick={openEditor}
+  >✎</button>
+  <button
+    class="action-btn delete-btn"
+    title="Delete pet"
+    data-testid="pet-delete-btn"
+    data-action="delete"
+    data-pet-id={pet.id}
+    onclick={confirmDelete}
+  >✕</button>
+{:else}
+  <button
+    class="hdr-btn"
+    title="Edit pet"
+    data-testid="pet-edit-btn"
+    data-action="edit"
+    data-pet-id={pet.id}
+    onclick={openEditor}
+  >Edit</button>
+  <button
+    class="hdr-btn hdr-delete"
+    title="Delete pet"
+    data-testid="pet-delete-btn"
+    data-action="delete"
+    data-pet-id={pet.id}
+    onclick={confirmDelete}
+  >Delete</button>
+{/if}
+
+{#if showEditor}
+  <PetEditor {pet} bind:open={showEditor} onClose={closeEditor} onSave={() => {}} />
+{/if}
+
+{#if confirming}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="modal-backdrop" onclick={cancelDelete} onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }}>
+    <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" aria-modal="true" use:focusTrap>
+      <p class="confirm-message">Delete <strong>{pet.name}</strong>?</p>
+      <p class="confirm-subtext">This action cannot be undone.</p>
+      <div class="confirm-actions">
+        <button class="btn btn-secondary" onclick={cancelDelete}>Cancel</button>
+        <button class="btn btn-danger" onclick={doDelete}>Delete</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Compact glyph buttons for list rows (icon variant). */
+  .action-btn {
+    width: 22px;
+    height: 22px;
+    display: grid;
+    place-items: center;
+    border: none;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s;
+  }
+  .action-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .edit-btn:hover { color: var(--accent); }
+  .action-btn.delete-btn:hover { color: var(--gene-negative); }
+
+  /* Button variant: self-styled to match the detail header's .view-btn look
+     (a sibling's scoped style won't reach this child component's elements). */
+  .hdr-btn {
+    padding: 5px 14px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .hdr-btn:hover { color: var(--text-secondary); }
+  .hdr-delete:hover { color: var(--gene-negative); }
+
+  .confirm-dialog {
+    background: var(--bg-primary);
+    border-radius: 12px;
+    box-shadow: var(--shadow-xl);
+    padding: 24px;
+    width: 340px;
+    max-width: 90vw;
+    text-align: center;
+  }
+
+  .confirm-message {
+    font-size: 15px;
+    color: var(--text-primary);
+    margin: 0 0 4px 0;
+  }
+
+  .confirm-subtext {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0 0 20px 0;
+  }
+
+  .confirm-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+  }
+</style>

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -70,4 +70,32 @@ test.describe('Redesign — Library + Workspace shell', () => {
     await checks2.nth(1).check();
     await expect(page.locator('[data-testid="lens-tab-compare"]')).toHaveClass(/active/);
   });
+
+  test('a library row can edit a pet via the shared editor', async ({ page }) => {
+    await openLibrary(page);
+    const firstRow = page.locator('[data-testid="pet-row"]').first();
+    const newName = `Renamed-${Date.now()}`;
+
+    await firstRow.locator('[data-testid="pet-edit-btn"]').click();
+    await expect(page.locator('.modal-panel')).toBeVisible();
+    await page.locator('#petName').fill(newName);
+    await page.locator('.btn-primary').click();
+
+    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-row"] .pr-name').filter({ hasText: newName }).first()).toBeVisible();
+  });
+
+  test('a library row can delete a pet after confirmation', async ({ page }) => {
+    await openLibrary(page);
+    const rows = page.locator('[data-testid="pet-row"]');
+    const before = await rows.count();
+    expect(before).toBeGreaterThan(0);
+
+    await rows.first().locator('[data-testid="pet-delete-btn"]').click();
+    const dialog = page.locator('[role="alertdialog"]');
+    await expect(dialog).toBeVisible();
+    await dialog.locator('.btn-danger').click();
+
+    await expect(rows).toHaveCount(before - 1);
+  });
 });

--- a/tests/fixtures/PetEditorStub.svelte
+++ b/tests/fixtures/PetEditorStub.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+// Lightweight stand-in for PetEditor so PetActions tests don't pull the real
+// editor's config/store dependencies. Mirrors the `open` prop it is bound to.
+const { open = false }: { open?: boolean } = $props();
+</script>
+
+{#if open}<div data-testid="pet-editor-stub">editor open</div>{/if}

--- a/tests/unit/petActions.test.ts
+++ b/tests/unit/petActions.test.ts
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Pet } from '$lib/types/index.js';
+
+// PetActions is the redesign's edit/delete affordance (icon variant for library
+// rows, button variant for the workspace header). It owns the PetEditor modal
+// and the delete-confirm dialog, deleting via appState.deletePet. The real
+// editor is stubbed so this stays a focused unit; deletePet is spied on.
+
+const deletePet = vi.fn(async (_id: number) => {});
+vi.mock('$lib/stores/pets.js', () => ({
+  appState: { deletePet: (id: number) => deletePet(id) },
+}));
+
+vi.mock('$lib/components/pet/PetEditor.svelte', async () => ({
+  default: (await import('../fixtures/PetEditorStub.svelte')).default,
+}));
+
+import PetActions from '$lib/components/shared/PetActions.svelte';
+
+const pet = { id: 7, name: 'Dobbin' } as Pet;
+
+const q = (c: HTMLElement, sel: string) => c.querySelector(sel) as HTMLElement | null;
+
+afterEach(() => {
+  cleanup();
+  deletePet.mockClear();
+});
+
+describe('PetActions', () => {
+  it('renders glyph buttons in the icon variant', () => {
+    const { container } = render(PetActions, { pet, variant: 'icon' } as never);
+    expect(q(container, '[data-testid="pet-edit-btn"]')?.textContent).toBe('✎');
+    expect(q(container, '[data-testid="pet-delete-btn"]')?.textContent).toBe('✕');
+  });
+
+  it('renders labelled buttons in the button variant', () => {
+    const { container } = render(PetActions, { pet, variant: 'button' } as never);
+    expect(q(container, '[data-testid="pet-edit-btn"]')?.textContent).toBe('Edit');
+    expect(q(container, '[data-testid="pet-delete-btn"]')?.textContent).toBe('Delete');
+  });
+
+  it('opens the editor when edit is clicked', async () => {
+    const { container } = render(PetActions, { pet } as never);
+    expect(q(container, '[data-testid="pet-editor-stub"]')).toBeNull();
+    await fireEvent.click(q(container, '[data-testid="pet-edit-btn"]') as HTMLElement);
+    await waitFor(() => expect(q(container, '[data-testid="pet-editor-stub"]')).not.toBeNull());
+  });
+
+  it('shows a confirm dialog on delete and calls deletePet on confirm', async () => {
+    const { container } = render(PetActions, { pet } as never);
+    expect(q(container, '[role="alertdialog"]')).toBeNull();
+
+    await fireEvent.click(q(container, '[data-testid="pet-delete-btn"]') as HTMLElement);
+    const dialog = await waitFor(() => {
+      const d = q(container, '[role="alertdialog"]');
+      expect(d).not.toBeNull();
+      return d as HTMLElement;
+    });
+    expect(dialog.textContent).toContain('Dobbin');
+
+    const confirm = q(dialog, '.btn-danger') as HTMLElement;
+    await fireEvent.click(confirm);
+    expect(deletePet).toHaveBeenCalledWith(7);
+  });
+
+  it('cancel dismisses the confirm dialog without deleting', async () => {
+    const { container } = render(PetActions, { pet } as never);
+    await fireEvent.click(q(container, '[data-testid="pet-delete-btn"]') as HTMLElement);
+    await waitFor(() => expect(q(container, '[role="alertdialog"]')).not.toBeNull());
+
+    await fireEvent.click(q(container, '.btn-secondary') as HTMLElement);
+    await waitFor(() => expect(q(container, '[role="alertdialog"]')).toBeNull());
+    expect(deletePet).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/petActions.test.ts
+++ b/tests/unit/petActions.test.ts
@@ -65,6 +65,21 @@ describe('PetActions', () => {
     expect(deletePet).toHaveBeenCalledWith(7);
   });
 
+  it('clicking inside the dialog does not dismiss it (only the backdrop does)', async () => {
+    const { container } = render(PetActions, { pet } as never);
+    await fireEvent.click(q(container, '[data-testid="pet-delete-btn"]') as HTMLElement);
+    await waitFor(() => expect(q(container, '[role="alertdialog"]')).not.toBeNull());
+
+    // A click that bubbles up from the dialog body must not close it.
+    await fireEvent.click(q(container, '.confirm-message') as HTMLElement);
+    expect(q(container, '[role="alertdialog"]')).not.toBeNull();
+    expect(deletePet).not.toHaveBeenCalled();
+
+    // The backdrop itself does close it.
+    await fireEvent.click(q(container, '.modal-backdrop') as HTMLElement);
+    await waitFor(() => expect(q(container, '[role="alertdialog"]')).toBeNull());
+  });
+
   it('cancel dismisses the confirm dialog without deleting', async () => {
     const { container } = render(PetActions, { pet } as never);
     await fireEvent.click(q(container, '[data-testid="pet-delete-btn"]') as HTMLElement);


### PR DESCRIPTION
Prerequisite for the cutover (slice 5). The new Library + Workspace IA had no edit/rename/delete affordance — those lived only in the old Pets-tab card list (`PetList.svelte`), which the cutover removes. Without this, flipping the default nav would silently drop pet editing and deletion.

Adds a shared `PetActions.svelte`:
- **icon variant** (✎/✕) in the Library `PetRow` trailing slot
- **button variant** (Edit/Delete) in the `PetVisualization` header next to Share

Both reuse the existing `PetEditor` modal and delete-confirm dialog; deletion goes through the same `appState.deletePet`. No new editor logic. The detail header is shared with the old single-pet view, which now also gains the header buttons (additive).

Tests:
- `petActions.test.ts` — variants render, edit opens the editor, delete confirms and calls `deletePet`, cancel dismisses without deleting (PetEditor stubbed, `deletePet` spied).
- `redesign-library.spec.ts` — edit a row updates the name; delete a row removes it after confirmation.

- check: 0/0 · lint: clean · unit: 768 passed · e2e: redesign-library (5) green