### PR TITLE
feat(redesign): genome upload + auto-scan parity in the Library

### DIFF
--- a/src/lib/components/library/Library.svelte
+++ b/src/lib/components/library/Library.svelte
@@ -9,13 +9,16 @@ import FilterBar from '$lib/components/shared/FilterBar.svelte';
 import PetActions from '$lib/components/shared/PetActions.svelte';
 import PetRow from '$lib/components/shared/PetRow.svelte';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearLibrarySelection, libraryView, toggleLibrarySelection } from '$lib/stores/library.svelte.js';
 import { pets } from '$lib/stores/pets.js';
 import { HORSE_BREEDS, type Pet } from '$lib/types/index.js';
+import { createGenomeUploadController } from '$lib/utils/genomeUploadController.svelte.js';
 import { filterPets } from '$lib/utils/petFilter.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
 
 const speciesOptions = getSupportedSpecies();
+const upload = createGenomeUploadController();
 
 // Breed maps per species. Horse has canonical abbreviations; beewasp's
 // sub-types are their own labels (no invented abbreviations).
@@ -107,7 +110,18 @@ function metaFor(pet: Pet): string {
     </div>
   </div>
 
-  <div class="lib-list" class:table={libraryView.density === 'table'} data-testid="library-list">
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="lib-list"
+    class:table={libraryView.density === 'table'}
+    data-testid="library-list"
+    ondragover={upload.handleFileDragOver}
+    ondragleave={upload.handleFileDragLeave}
+    ondrop={upload.handleFileDrop}
+  >
+    {#if upload.fileDragActive}
+      <div class="file-drop-overlay"><span>Drop genome files to upload</span></div>
+    {/if}
     {#if filtered.length === 0}
       <p class="lib-empty">No pets match these filters.</p>
     {:else}
@@ -137,6 +151,44 @@ function metaFor(pet: Pet): string {
       <button type="button" class="clear-btn" onclick={clearLibrarySelection}>Clear</button>
     </div>
   {/if}
+
+  <div class="lib-actions" data-testid="library-actions">
+    <button
+      type="button"
+      class="upload-btn"
+      data-testid="library-upload"
+      onclick={upload.handleUpload}
+      disabled={upload.uploading || upload.autoScanning}
+    >
+      {#if upload.uploadProgress}
+        Uploading… ({upload.uploadProgress.current}/{upload.uploadProgress.total})
+      {:else}
+        + Upload Genome
+      {/if}
+    </button>
+    <button
+      type="button"
+      class="auto-scan-btn"
+      data-testid="library-autoscan"
+      onclick={upload.handleAutoScan}
+      disabled={upload.uploading || upload.autoScanning}
+      title={$pendingImportCount > 0
+        ? `Auto-import: ${$pendingImportCount} new genome file${$pendingImportCount === 1 ? '' : 's'} in the game folder`
+        : 'Auto-import new genome files from the game folder'}
+      aria-label={$pendingImportCount > 0
+        ? `Auto-import ${$pendingImportCount} new genome file${$pendingImportCount === 1 ? '' : 's'} from the game folder`
+        : 'Auto-import new genome files from the game folder'}
+    >
+      {#if upload.autoScanProgress}
+        🔄 ({upload.autoScanProgress.current}/{upload.autoScanProgress.total})
+      {:else}
+        🔄
+        {#if $pendingImportCount > 0}
+          <span class="pending-badge" aria-hidden="true">{$pendingImportCount > 99 ? '99+' : $pendingImportCount}</span>
+        {/if}
+      {/if}
+    </button>
+  </div>
 </div>
 
 <style>
@@ -152,10 +204,24 @@ function metaFor(pet: Pet): string {
   .density button.active { background: var(--bg-primary); color: var(--text-primary); box-shadow: var(--shadow-sm, 0 1px 2px rgba(0,0,0,0.06)); }
   .lib-count { font-size: 11px; color: var(--text-muted); }
 
-  .lib-list { flex: 1; overflow: auto; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
+  .lib-list { position: relative; flex: 1; overflow: auto; padding: 8px; display: flex; flex-direction: column; gap: 6px; }
   .lib-list.table { padding: 0; gap: 0; }
   .lib-empty { color: var(--text-muted); font-size: 13px; text-align: center; padding: 24px; font-style: italic; }
   .lib-star { color: #f5a623; font-size: 13px; }
+
+  /* Drag-and-drop genome upload overlay. pointer-events: none lets the drag
+     events fall through to the list's drop handlers underneath. */
+  .file-drop-overlay {
+    position: absolute; inset: 0; z-index: 5;
+    display: flex; align-items: center; justify-content: center;
+    pointer-events: none;
+    background: var(--bg-selected); border: 2px dashed var(--accent); border-radius: 8px;
+    opacity: 0.95;
+  }
+  .file-drop-overlay span {
+    font-size: 14px; font-weight: 600; color: var(--accent-text);
+    padding: 12px 20px; border-radius: 8px; background: var(--bg-primary); box-shadow: var(--shadow-lg);
+  }
 
   .lib-foot {
     border-top: 1px solid var(--border-primary); padding: 9px 12px;
@@ -168,4 +234,27 @@ function metaFor(pet: Pet): string {
     font-size: 12px; font-weight: 600; cursor: pointer;
   }
   .clear-btn:hover { color: var(--text-secondary); }
+
+  .lib-actions {
+    border-top: 1px solid var(--border-primary); padding: 9px 12px;
+    display: flex; align-items: center; gap: 8px; background: var(--bg-secondary); flex-shrink: 0;
+  }
+  .upload-btn {
+    flex: 1; padding: 7px 12px; border: none; border-radius: 7px;
+    background: var(--accent); color: var(--accent-text);
+    font-size: 12px; font-weight: 600; cursor: pointer;
+  }
+  .upload-btn:hover:not(:disabled) { filter: brightness(1.05); }
+  .upload-btn:disabled { opacity: 0.6; cursor: default; }
+  .auto-scan-btn {
+    position: relative; flex-shrink: 0; padding: 7px 10px; border: 1px solid var(--border-primary);
+    border-radius: 7px; background: var(--bg-primary); font-size: 13px; cursor: pointer;
+  }
+  .auto-scan-btn:hover:not(:disabled) { background: var(--bg-hover); }
+  .auto-scan-btn:disabled { opacity: 0.6; cursor: default; }
+  .pending-badge {
+    position: absolute; top: -4px; right: -4px; min-width: 16px; height: 16px;
+    padding: 0 3px; border-radius: 8px; background: var(--accent); color: var(--accent-text);
+    font-size: 9px; font-weight: 700; line-height: 16px; text-align: center;
+  }
 </style>

--- a/src/lib/utils/genomeUploadController.svelte.ts
+++ b/src/lib/utils/genomeUploadController.svelte.ts
@@ -2,8 +2,9 @@
  * Reactive controller for the genome add-pet affordances: file-picker upload,
  * drag-and-drop upload, and the manual game-folder auto-scan. The pre-redesign
  * UI inlined all of this in PetList.svelte; the Library + Workspace shell needs
- * the same behaviour, so the orchestration lives here (the pure helpers stay in
- * `genomeUpload.ts`) and both surfaces drive it the same way.
+ * the same behaviour, so the orchestration is extracted here (the pure helpers
+ * stay in `genomeUpload.ts`). The Library drives it today; PetList keeps its own
+ * inline copy until the cutover removes that component.
  *
  * Wire the returned handlers onto a scroll container (drag/drop) and the
  * footer buttons (upload, auto-scan); read the `*` getters for button state and

--- a/src/lib/utils/genomeUploadController.svelte.ts
+++ b/src/lib/utils/genomeUploadController.svelte.ts
@@ -1,0 +1,166 @@
+/**
+ * Reactive controller for the genome add-pet affordances: file-picker upload,
+ * drag-and-drop upload, and the manual game-folder auto-scan. The pre-redesign
+ * UI inlined all of this in PetList.svelte; the Library + Workspace shell needs
+ * the same behaviour, so the orchestration lives here (the pure helpers stay in
+ * `genomeUpload.ts`) and both surfaces drive it the same way.
+ *
+ * Wire the returned handlers onto a scroll container (drag/drop) and the
+ * footer buttons (upload, auto-scan); read the `*` getters for button state and
+ * the drop overlay. See docs/design/redesign-library-workspace-v1.md §5.
+ */
+import { get } from 'svelte/store';
+import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
+import { autoScanGameFolder } from '$lib/services/gameImport.js';
+import { refreshPendingImportCount } from '$lib/stores/gameImport.js';
+import { appState, error } from '$lib/stores/pets.js';
+import { errorMessage } from '$lib/utils/error.js';
+import type { UploadSource } from '$lib/utils/genomeUpload.js';
+import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
+import { getBasename } from '$lib/utils/path.js';
+
+interface Progress {
+  current: number;
+  total: number;
+}
+
+export function createGenomeUploadController() {
+  let uploading = $state(false);
+  let uploadProgress = $state<Progress | null>(null);
+  let autoScanning = $state(false);
+  let autoScanProgress = $state<Progress | null>(null);
+  let fileDragActive = $state(false);
+
+  async function uploadSources(sources: UploadSource[]): Promise<void> {
+    if (sources.length === 0 || uploading || autoScanning) return;
+    uploading = true;
+    error.set(null);
+    try {
+      const { total, succeeded, failures } = await runGenomeUpload(sources, {
+        upload: (content: string) => appState.uploadPetQuiet(content),
+        onProgress: (current: number, t: number) => {
+          uploadProgress = { current, total: t };
+        },
+      });
+      await appState.loadPets();
+      if (failures.length > 0) {
+        error.set(`${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`);
+      }
+    } catch (err) {
+      error.set(`Upload failed: ${errorMessage(err)}`);
+    } finally {
+      uploading = false;
+      uploadProgress = null;
+    }
+  }
+
+  async function handleUpload(): Promise<void> {
+    let filePaths: string[];
+    try {
+      filePaths = await pickGenomeFiles();
+    } catch (err) {
+      error.set(`Upload failed: ${errorMessage(err)}`);
+      return;
+    }
+    await uploadSources(filePaths.map((path) => ({ name: getBasename(path), read: () => readFileContent(path) })));
+  }
+
+  // Drag-and-drop genome upload (#98). External OS file drags carry a 'Files'
+  // type; internal drags don't — isFileDrag() tells them apart.
+  function handleFileDragOver(e: DragEvent): void {
+    if (!isFileDrag(e.dataTransfer)) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+    fileDragActive = true;
+  }
+
+  function handleFileDragLeave(e: DragEvent & { currentTarget: EventTarget & Element }): void {
+    if (!isFileDrag(e.dataTransfer)) return;
+    // Ignore leaves into descendant elements; only clear when the cursor leaves
+    // the container entirely (relatedTarget is null when leaving the window).
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    fileDragActive = false;
+  }
+
+  async function handleFileDrop(e: DragEvent): Promise<void> {
+    if (!isFileDrag(e.dataTransfer)) return;
+    e.preventDefault();
+    fileDragActive = false;
+    const dropped = Array.from(e.dataTransfer?.files ?? []);
+    if (dropped.length === 0) return;
+
+    const { accepted, rejected } = selectGenomeFiles(dropped);
+    if (accepted.length === 0) {
+      error.set('No genome files (.txt) in the dropped items.');
+      return;
+    }
+    await uploadSources(accepted.map((file: File) => ({ name: file.name, read: () => file.text() })));
+    if (rejected.length > 0 && !get(error)) {
+      error.set(`Skipped ${rejected.length} non-genome file${rejected.length === 1 ? '' : 's'}.`);
+    }
+  }
+
+  async function handleAutoScan(): Promise<void> {
+    try {
+      autoScanning = true;
+      error.set(null);
+      const result = await autoScanGameFolder({
+        onProgress: (current: number, total: number) => {
+          autoScanProgress = { current, total };
+        },
+      });
+
+      if (result.status === 'not_configured') {
+        error.set('Auto-import folder is not configured. Set the path in Settings → Auto-import.');
+        return;
+      }
+      if (result.status === 'folder_missing') {
+        error.set(result.message ?? 'Configured game folder was not found.');
+        return;
+      }
+      if (result.status === 'error') {
+        error.set(result.message ?? 'Auto-import failed.');
+        return;
+      }
+
+      // autoScanGameFolder refreshes the pets store itself on a DB change (#253).
+      const backfillNote = result.backfilled > 0 ? `, ${result.backfilled} unlocked for sharing` : '';
+      const summary = `Auto-import: ${result.imported} new, ${result.skipped} already imported${backfillNote} (of ${result.scanned} files).`;
+      if (result.failures.length > 0) {
+        const lines = result.failures.map((f: { file: string; reason: string }) => `${f.file}: ${f.reason}`);
+        error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);
+      } else if (result.imported > 0 || result.backfilled > 0) {
+        error.set(summary);
+      }
+    } catch (err) {
+      error.set(`Auto-import failed: ${errorMessage(err)}`);
+    } finally {
+      autoScanning = false;
+      autoScanProgress = null;
+      void refreshPendingImportCount();
+    }
+  }
+
+  return {
+    get uploading() {
+      return uploading;
+    },
+    get uploadProgress() {
+      return uploadProgress;
+    },
+    get autoScanning() {
+      return autoScanning;
+    },
+    get autoScanProgress() {
+      return autoScanProgress;
+    },
+    get fileDragActive() {
+      return fileDragActive;
+    },
+    handleUpload,
+    handleAutoScan,
+    handleFileDragOver,
+    handleFileDragLeave,
+    handleFileDrop,
+  };
+}

--- a/tests/e2e/redesign-library.spec.ts
+++ b/tests/e2e/redesign-library.spec.ts
@@ -9,6 +9,21 @@ async function openLibrary(page: Page) {
   await expect(page.locator('[data-testid="library"]')).toBeVisible();
 }
 
+/** Dispatch a synthetic genome-file drop onto the library list (see drop-upload.spec). */
+async function dropGenomeOnLibrary(page: Page, files: { name: string; url?: string; content?: string }[]) {
+  await page.evaluate(async (files) => {
+    const dt = new DataTransfer();
+    for (const f of files) {
+      const content = f.url ? await (await fetch(f.url)).text() : (f.content ?? '');
+      dt.items.add(new File([content], f.name, { type: 'text/plain' }));
+    }
+    Object.defineProperty(dt, 'types', { value: ['Files'], configurable: true });
+    document
+      .querySelector('[data-testid="library-list"]')
+      ?.dispatchEvent(new DragEvent('drop', { bubbles: true, cancelable: true, dataTransfer: dt }));
+  }, files);
+}
+
 test.describe('Redesign — Library + Workspace shell', () => {
   test('the My Pets destination appears only with the flag', async ({ page }) => {
     await page.goto('/');
@@ -97,5 +112,42 @@ test.describe('Redesign — Library + Workspace shell', () => {
     await dialog.locator('.btn-danger').click();
 
     await expect(rows).toHaveCount(before - 1);
+  });
+
+  test('the library exposes upload and auto-scan actions', async ({ page }) => {
+    await openLibrary(page);
+    await expect(page.locator('[data-testid="library-upload"]')).toBeVisible();
+    await expect(page.locator('[data-testid="library-autoscan"]')).toBeVisible();
+  });
+
+  test('dragging genome files over the library shows a drop overlay', async ({ page }) => {
+    await openLibrary(page);
+    await page.evaluate(() => {
+      const dt = new DataTransfer();
+      Object.defineProperty(dt, 'types', { value: ['Files'], configurable: true });
+      document
+        .querySelector('[data-testid="library-list"]')
+        ?.dispatchEvent(new DragEvent('dragover', { bubbles: true, cancelable: true, dataTransfer: dt }));
+    });
+    await expect(page.locator('.file-drop-overlay')).toBeVisible();
+    await expect(page.locator('.file-drop-overlay')).toHaveText(/Drop genome files/);
+  });
+
+  test('dropping a genome file uploads it into the library', async ({ page }) => {
+    await openLibrary(page);
+    const rows = page.locator('[data-testid="pet-row"]');
+
+    // Remove the demo Sample Horse so the drop re-adds it (content-hash dedup
+    // makes re-uploading an existing pet a no-op otherwise).
+    const horseRow = rows.filter({ hasText: 'Sample Horse' }).first();
+    const before = await rows.count();
+    await horseRow.locator('[data-testid="pet-delete-btn"]').click();
+    await page.locator('[role="alertdialog"] .btn-danger').click();
+    await expect(rows).toHaveCount(before - 1);
+
+    await dropGenomeOnLibrary(page, [{ name: 'Genes_SampleHorse.txt', url: '/data/Genes_SampleHorse.txt' }]);
+
+    await expect(rows).toHaveCount(before);
+    await expect(rows.filter({ hasText: 'Sample Horse' }).first()).toBeVisible();
   });
 });


### PR DESCRIPTION
Second cutover prerequisite (slice 5). The Library had no way to add a pet — manual genome upload, drag-and-drop upload, and the manual game-folder auto-scan (with pending-import badge) lived only in the old Pets-tab footer (`PetList.svelte`), which the cutover removes. Automatic startup scanning already survives via `AuthWrapper`; the manual affordances did not.

- New `createGenomeUploadController` (`src/lib/utils/genomeUploadController.svelte.ts`) holds the upload/drop/auto-scan orchestration; the pure helpers stay in `genomeUpload.ts`. Both the old PetList behaviour and the new Library drive the same logic.
- Library gains a persistent action footer (Upload + auto-scan) and a drag-drop overlay on the list.

PetList is untouched (it's removed in the cutover's delete slice).

Tests (redesign-library.spec.ts):
- upload + auto-scan actions present
- drag-over shows the drop overlay
- dropping a genome re-adds a deleted pet (mirrors drop-upload.spec on the new list)

- check: 0/0 · lint: clean · unit: 764 passed · e2e: redesign-library (8) green