### PR TITLE
feat(redesign): top-level Breed destination (IA v2 — slice R1)

### DIFF
--- a/src/lib/components/breeding/BreedView.svelte
+++ b/src/lib/components/breeding/BreedView.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+/**
+ * The Breed destination — a first-class, search-first breeding helper. Pick a
+ * species and it ranks male × female pairs across your whole stabled collection
+ * of that species, then opens the offspring Trio on inspect. Unlike the old
+ * selection-driven lens, breeding starts here without pre-selecting pets — the
+ * tool finds the best pairs for you. Reuses the breeding service + pair table +
+ * TrioView. See docs/design/redesign-library-workspace-v1.md (§2, IA v2).
+ */
+import { onDestroy } from 'svelte';
+import BreedingPairTable from '$lib/components/breeding/BreedingPairTable.svelte';
+import TrioView from '$lib/components/breeding/TrioView.svelte';
+import EmptyState from '$lib/components/shared/EmptyState.svelte';
+import PageHeader from '$lib/components/shared/PageHeader.svelte';
+import StatusPane from '$lib/components/shared/StatusPane.svelte';
+import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { getAllAttributeNames, getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import { pets } from '$lib/stores/pets.js';
+import type { BreedingPairResult } from '$lib/types/index.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
+import { capitalize } from '$lib/utils/string.js';
+
+// Species options, normalized for matching but shown with their display name.
+const speciesOptions = getSupportedSpecies().map((s) => ({
+  raw: s,
+  key: normalizeSpecies(s),
+  label: capitalize(normalizeSpecies(s)),
+}));
+
+let species = $state(speciesOptions[0]?.key ?? '');
+
+const attrNames = $derived(species ? getAllAttributeNames(species).map(capitalize) : []);
+
+// Breed across the stable: every stabled pet of the chosen species.
+const candidates = $derived($pets.filter((p) => p.stabled && normalizeSpecies(p.species) === species));
+
+let pairs = $state<BreedingPairResult[]>([]);
+let loading = $state(false);
+let errored = $state(false);
+let seq = 0;
+
+$effect(() => {
+  // Re-rank whenever the species (and thus the candidate set) changes. A
+  // sequence guard discards stale results if the inputs change faster than the
+  // service responds.
+  const sp = species;
+  const ps = candidates;
+  breedingView.selectedPair = null;
+
+  if (!sp || ps.length === 0) {
+    pairs = [];
+    loading = false;
+    errored = false;
+    return;
+  }
+
+  const mine = ++seq;
+  loading = true;
+  errored = false;
+  rankBreedingPairs({ species: sp, pets: ps })
+    .then((result) => {
+      if (mine !== seq) return;
+      pairs = result;
+      loading = false;
+    })
+    .catch((err: unknown) => {
+      if (mine !== seq) return;
+      console.error('rankBreedingPairs failed', err);
+      pairs = [];
+      errored = true;
+      loading = false;
+    });
+});
+
+onDestroy(() => {
+  breedingView.selectedPair = null;
+});
+</script>
+
+<div class="breed-view" data-testid="breed-view">
+  <PageHeader
+    icon="💞"
+    title="Breeding helper"
+    subtitle="Pick a species to rank the best male × female pairs across your stable, then inspect the offspring projection."
+  />
+
+  <div class="bv-species" role="group" aria-label="Species" data-testid="breed-species">
+    {#each speciesOptions as opt (opt.key)}
+      <button
+        type="button"
+        class="species-btn"
+        class:active={species === opt.key}
+        aria-pressed={species === opt.key}
+        data-species={opt.key}
+        onclick={() => { species = opt.key; }}
+      >
+        {getSpeciesEmoji(opt.raw)} {opt.label}
+      </button>
+    {/each}
+  </div>
+
+  <div class="bv-body">
+    {#if errored}
+      <StatusPane variant="error" title="Couldn't rank these pairs." body="Something went wrong computing scores. Switch species to retry." />
+    {:else if loading && pairs.length === 0}
+      <StatusPane variant="loading" body="Computing pair scores…" />
+    {:else if candidates.length === 0}
+      <EmptyState
+        icon="🐾"
+        title="No stabled {capitalize(species)} pets"
+        body="Breeding ranks pairs from your stabled pets. Stable some {capitalize(species)} pets in My Pets, then come back."
+      />
+    {:else if pairs.length === 0}
+      <EmptyState
+        icon="💞"
+        title="No pairs to rank"
+        body="Breeding pairs a male with a female. You need at least one stabled male and one stabled female of this species."
+      />
+    {:else}
+      <div class="bv-meta">{pairs.length} {pairs.length === 1 ? 'pair' : 'pairs'} · ranked by expected offspring quality</div>
+      <BreedingPairTable results={pairs} {attrNames} />
+    {/if}
+  </div>
+</div>
+
+{#if breedingView.selectedPair}
+  <TrioView pair={breedingView.selectedPair} onClose={() => { breedingView.selectedPair = null; }} />
+{/if}
+
+<style>
+  .breed-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
+  .bv-species { display: flex; gap: 6px; padding: 0 20px 10px; flex-wrap: wrap; flex-shrink: 0; }
+  .species-btn {
+    padding: 5px 14px; border: 1px solid var(--border-primary); border-radius: 16px;
+    background: var(--bg-primary); color: var(--text-tertiary);
+    font-size: 12px; font-weight: 600; cursor: pointer;
+  }
+  .species-btn:hover { color: var(--text-secondary); }
+  .species-btn.active { background: var(--accent); color: var(--accent-text); border-color: var(--accent); }
+  .bv-body { flex: 1; min-height: 0; overflow: auto; padding: 0 20px 16px; display: flex; flex-direction: column; gap: 8px; }
+  .bv-meta { font-size: 12px; color: var(--text-tertiary); }
+</style>

--- a/src/lib/components/layout/MasterPanel.svelte
+++ b/src/lib/components/layout/MasterPanel.svelte
@@ -62,7 +62,11 @@ function onHandleKeydown(e: KeyboardEvent) {
 }
 </script>
 
-{#if sidebar.collapsed}
+<!-- Only the destinations that have a master list use the sidebar; My Pets
+     (table-first), Breed, and Community render full-width with no rail. -->
+{#if $activeTab !== "reference" && $activeTab !== "library"}
+    <!-- no sidebar for this destination -->
+{:else if sidebar.collapsed}
     <button class="sidebar-rail" title="Expand sidebar" aria-label="Expand sidebar" onclick={toggleSidebar}>
         ›
     </button>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -56,6 +56,14 @@ function handleMouseUp(e: MouseEvent) {
         </button>
         <button
             class="tab-btn"
+            class:active={$activeTab === "breed"}
+            data-testid="tab-breed"
+            onclick={() => switchTab("breed")}
+        >
+            💞 Breed
+        </button>
+        <button
+            class="tab-btn"
             class:active={$activeTab === "community"}
             data-testid="tab-community"
             onclick={() => switchTab("community")}

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -4,7 +4,7 @@ import * as petService from '$lib/services/petService.js';
 import type { Pet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
 
-export type Tab = 'library' | 'community' | 'reference';
+export type Tab = 'library' | 'breed' | 'community' | 'reference';
 
 /** Boolean pet flags toggled in-place via `setPetMarker` (no full reload). */
 export type MarkerKey = 'starred' | 'stabled' | 'is_pet_quality';
@@ -47,6 +47,9 @@ const TAB_STATE_RESETS: Record<Tab, () => void> = {
   // The Library drives its own selection (libraryView.selectedIds); clear the
   // legacy single-pet/gene-edit state so it can't leak into the workspace.
   library: clearSelectionAndGeneView,
+  // Breed ranks across the whole stable by species; it doesn't use the library
+  // single-pet/gene state, so clear it on entry.
+  breed: clearSelectionAndGeneView,
   community: clearSelectionAndGeneView,
   // Reference (gene-template editing) clears any single-pet selection so it
   // can't carry over from the library when switching destinations.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import BreedView from '$lib/components/breeding/BreedView.svelte';
 import CommunityTab from '$lib/components/community/CommunityTab.svelte';
 import GeneEditingView from '$lib/components/GeneEditingView.svelte';
 import Workspace from '$lib/components/library/Workspace.svelte';
@@ -41,6 +42,8 @@ onMount(async () => {
 				body="Pick an animal type and chromosome in the sidebar, then choose Edit Genes."
 			/>
 		{/if}
+	{:else if $activeTab === 'breed'}
+		<BreedView />
 	{:else if $activeTab === 'community'}
 		<CommunityTab />
 	{:else}

--- a/tests/e2e/redesign-breed-destination.spec.ts
+++ b/tests/e2e/redesign-breed-destination.spec.ts
@@ -1,0 +1,42 @@
+import { expect, type Page, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+// The Breed destination — a first-class, search-first breeding helper reached
+// from the top nav. Pick a species; it ranks pairs across the stabled pets of
+// that species and opens the trio on inspect (no pre-selection needed).
+
+async function openBreed(page: Page) {
+  await page.goto('/');
+  await waitForAppReady(page);
+  await page.locator('[data-testid="tab-breed"]').click();
+  await expect(page.locator('[data-testid="breed-view"]')).toBeVisible();
+}
+
+test.describe('Redesign — Breed destination', () => {
+  test('is reachable from the top nav and ranks pairs by species', async ({ page }) => {
+    await openBreed(page);
+    await expect(page.locator('[data-testid="tab-breed"]')).toHaveClass(/active/);
+
+    // Pick horses (the demo has a male + female) → a ranked pair table appears
+    // without any pre-selection.
+    await page.locator('[data-testid="breed-species"] [data-species="horse"]').click();
+    await expect(page.locator('[data-testid="breeding-pair-table"]')).toBeVisible();
+    await expect(page.locator('[data-testid="breeding-pair-table"] tbody tr').first()).toBeVisible();
+  });
+
+  test('inspecting a pair opens the offspring trio', async ({ page }) => {
+    await openBreed(page);
+    await page.locator('[data-testid="breed-species"] [data-species="horse"]').click();
+    await expect(page.locator('[data-testid="breeding-pair-table"]')).toBeVisible();
+
+    await page.locator('[data-testid="inspect-pair"]').first().click();
+    const trio = page.getByTestId('trio-view');
+    await expect(trio).toBeVisible();
+    // Wait out the heavy grid render before asserting its labels.
+    await expect(trio.locator('.role-label').first()).toBeVisible({ timeout: 15000 });
+    await expect(trio.getByText('Offspring', { exact: false }).first()).toBeVisible();
+
+    await trio.getByRole('button', { name: 'Close trio view' }).click();
+    await expect(page.getByTestId('trio-view')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
First slice of the **table-first IA v2** rework, prompted by usability feedback: the redesign's persistent pet sidebar is dead weight at a few-hundred-pet scale, and breeding was buried behind a multi-select gesture.

This slice makes **breeding a first-class, search-first destination**. Pick a species → it ranks male × female pairs across your *stabled* pets of that species → inspect opens the offspring trio. No pre-selection needed (the tool's job is to find the pairs).

- New `💞 Breed` top-nav destination + `breed` tab; `BreedView` reuses `rankBreedingPairs` + `BreedingPairTable` + `TrioView` (same engine as the old lens, sourced from the stable instead of a manual selection).
- `MasterPanel` now renders only for destinations that have a master list (My Pets, Reference); Breed and Community are full-width with no empty sidebar rail.

Additive and low-risk: the existing My Pets/Workspace (incl. the breed lens) are untouched here and stay working. The table-first My Pets pivot and retiring the lens come in the next slice.

- check 0/0 · lint clean · unit 745 · e2e: new `redesign-breed-destination` spec green (the trio assertion shares the known heavy-grid render flake — passes clean in isolation/CI).

Part of the epic; the epic→main PR (#341) is on hold as a draft until IA v2 lands.