### PR TITLE
fix(redesign): UI review must-fixes (contrast, Total col, Breed inspect)

### DIFF
--- a/src/lib/components/breeding/BreedView.svelte
+++ b/src/lib/components/breeding/BreedView.svelte
@@ -137,7 +137,7 @@ onDestroy(() => {
     font-size: 12px; font-weight: 600; cursor: pointer;
   }
   .species-btn:hover { color: var(--text-secondary); }
-  .species-btn.active { background: var(--accent); color: var(--accent-text); border-color: var(--accent); }
+  .species-btn.active { background: var(--accent); color: var(--text-inverse); border-color: var(--accent); }
   .bv-body { flex: 1; min-height: 0; overflow: auto; padding: 0 20px 16px; display: flex; flex-direction: column; gap: 8px; }
   .bv-meta { font-size: 12px; color: var(--text-tertiary); }
 </style>

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -80,7 +80,7 @@ function fmt(n: number) {
     <table>
         <thead>
             <tr>
-                <th class="action-col" aria-label="Inspect"></th>
+                <th class="action-col">Offspring</th>
                 {#each columns as col (col.id)}
                     {@const isActive = breedingView.sortCol === col.id}
                     <th
@@ -110,7 +110,7 @@ function fmt(n: number) {
                             title="View offspring trio"
                             aria-label={`View offspring trio for ${pair.male.name} × ${pair.female.name}`}
                             data-testid="inspect-pair"
-                        >🔬</button>
+                        >🔬 Trio</button>
                     </td>
                     <td><button class="parent-link" onclick={() => openPet(pair.male)}>{pair.male.name}</button></td>
                     <td><button class="parent-link" onclick={() => openPet(pair.female)}>{pair.female.name}</button></td>
@@ -209,30 +209,48 @@ function fmt(n: number) {
         text-decoration: underline;
     }
 
+    /* The pair table is wide (attribute columns); pin the offspring action to
+       the left so it stays reachable at any horizontal scroll position. */
     .action-col {
-        width: 32px;
-        min-width: 32px;
+        width: 84px;
+        min-width: 84px;
+        left: 0;
+        z-index: 2;
     }
 
     .action-cell {
         text-align: center;
-        padding: 2px 4px;
+        padding: 4px 8px;
+        position: sticky;
+        left: 0;
+        background: var(--bg-primary);
+        z-index: 1;
+    }
+
+    tbody tr:hover .action-cell {
+        background: var(--bg-secondary);
     }
 
     .inspect-btn {
-        background: none;
-        border: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-primary);
+        color: var(--text-secondary);
         cursor: pointer;
-        font-size: 14px;
+        font-size: 12px;
+        font-weight: 600;
         line-height: 1;
-        padding: 4px;
-        border-radius: 4px;
-        opacity: 0.65;
-        transition: opacity 0.15s ease, background 0.15s ease;
+        padding: 4px 8px;
+        border-radius: 6px;
+        white-space: nowrap;
+        transition: all 0.15s ease;
     }
 
     .inspect-btn:hover {
-        opacity: 1;
-        background: var(--bg-tertiary);
+        background: var(--accent);
+        color: var(--text-inverse);
+        border-color: var(--accent);
     }
 </style>

--- a/src/lib/components/gene/ReferenceView.svelte
+++ b/src/lib/components/gene/ReferenceView.svelte
@@ -127,7 +127,7 @@ $effect(() => {
   .ref-field select:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
   .ref-field select:disabled { background: var(--bg-secondary); color: var(--text-muted); }
   .load-btn {
-    padding: 7px 16px; background: var(--accent); color: var(--accent-text, var(--text-inverse));
+    padding: 7px 16px; background: var(--accent); color: var(--text-inverse);
     border: none; border-radius: 6px; font-size: 13px; font-weight: 600; cursor: pointer;
   }
   .load-btn:hover:not(:disabled) { filter: brightness(1.05); }

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -291,7 +291,7 @@ function handleBulkShareResult(result: DialogResult): void {
   .mp-add { display: flex; align-items: center; gap: 8px; padding: 9px 16px; }
   .upload-btn {
     padding: 7px 14px; border: none; border-radius: 7px;
-    background: var(--accent); color: var(--accent-text); font-size: 12px; font-weight: 600; cursor: pointer;
+    background: var(--accent); color: var(--text-inverse); font-size: 12px; font-weight: 600; cursor: pointer;
   }
   .upload-btn:hover:not(:disabled) { filter: brightness(1.05); }
   .upload-btn:disabled { opacity: 0.6; cursor: default; }
@@ -303,7 +303,7 @@ function handleBulkShareResult(result: DialogResult): void {
   .auto-scan-btn:disabled { opacity: 0.6; cursor: default; }
   .pending-badge {
     position: absolute; top: -4px; right: -4px; min-width: 16px; height: 16px;
-    padding: 0 3px; border-radius: 8px; background: var(--accent); color: var(--accent-text);
+    padding: 0 3px; border-radius: 8px; background: var(--accent); color: var(--text-inverse);
     font-size: 9px; font-weight: 700; line-height: 16px; text-align: center;
   }
 

--- a/src/lib/components/library/Roster.svelte
+++ b/src/lib/components/library/Roster.svelte
@@ -46,17 +46,26 @@ const columns = $derived.by((): Column[] => {
     accessor: (pet: Pet) => num(pet, attr),
   }));
 
+  // Total only makes sense alongside the per-species attribute columns; under
+  // "All" species there are no attributes to sum, so it would read 0 for every
+  // pet — omit it (and the attr columns) there.
+  const totalCol: Column[] = attrNames.length
+    ? [
+        {
+          id: 'attr_total',
+          label: 'Total',
+          numeric: true,
+          accessor: (p: Pet) => attrNames.reduce((sum, a) => sum + num(p, a), 0),
+        },
+      ]
+    : [];
+
   return [
     { id: 'name', label: 'Name', numeric: false, accessor: (p) => p.name ?? '' },
     { id: 'gender', label: 'Gender', numeric: false, accessor: (p) => p.gender ?? '' },
     { id: 'breed', label: 'Breed', numeric: false, accessor: (p) => p.breed ?? '' },
     ...attrCols,
-    {
-      id: 'attr_total',
-      label: 'Total',
-      numeric: true,
-      accessor: (p) => attrNames.reduce((sum, a) => sum + num(p, a), 0),
-    },
+    ...totalCol,
     { id: 'positive_genes', label: '+ Genes', numeric: true, accessor: (p) => p.positive_genes ?? 0 },
   ];
 });

--- a/tests/unit/roster.test.ts
+++ b/tests/unit/roster.test.ts
@@ -57,10 +57,11 @@ describe('Roster', () => {
     const labels = headers(container);
     expect(labels?.some((l) => l?.startsWith('Name'))).toBe(true);
     expect(labels).toContain('Gender');
-    expect(labels?.some((l) => l?.startsWith('Total'))).toBe(true);
     expect(labels?.some((l) => l?.startsWith('+ Genes'))).toBe(true);
-    // No horse attribute column (e.g. Toughness) until a species is chosen.
+    // No horse attribute column (e.g. Toughness) until a species is chosen…
     expect(labels?.some((l) => l?.toLowerCase().includes('toughness'))).toBe(false);
+    // …and no Total either — with no attributes to sum it would read 0 for all.
+    expect(labels?.some((l) => l?.startsWith('Total'))).toBe(false);
   });
 
   it('adds per-attribute columns when a species is selected', () => {


### PR DESCRIPTION
The three must-fix findings from the UI/UX review (verified in-browser via Playwright).

1. **Invisible accent-button labels.** `--accent-text` is defined as the accent hue itself (blue), so filled buttons doing `background: var(--accent); color: var(--accent-text)` rendered blue-on-blue — the Upload, Breed species pill, Reference "Edit Genes", and pending-badge labels were invisible. Switch those to `--text-inverse` (the working `.btn-primary` pattern). Link/text-on-neutral usages of `--accent-text` are correct and untouched.
2. **Total column under "All".** It summed an empty attribute set → 0 for every pet. Omit it under "All" species; it returns alongside the per-species attribute columns.
3. **Breed offspring inspector.** Was a faint unlabelled 🔬 that scrolled off behind the wide attribute columns. Now a labelled **"🔬 Trio"** button under an **"Offspring"** header, pinned **sticky-left** so it's reachable at any scroll position.

Findings #4–#9 (faint row icons, Community detail consistency, footer consolidation, detail action grouping, empty state, species-toggle polish) follow in subsequent PRs.

- check 0/0 · lint clean · unit 726 · e2e: roster/breed/mypets pass (one heavy-trio close-click flakes only under local CPU contention; passes in isolation/CI).