### PR TITLE
fix(redesign): UI review polish (rows, footer, detail, empty, toggle)

### DIFF
--- a/src/lib/components/breeding/BreedView.svelte
+++ b/src/lib/components/breeding/BreedView.svelte
@@ -130,14 +130,20 @@ onDestroy(() => {
 
 <style>
   .breed-view { display: flex; flex-direction: column; height: 100%; min-height: 0; }
-  .bv-species { display: flex; gap: 6px; padding: 0 20px 10px; flex-wrap: wrap; flex-shrink: 0; }
+  /* Segmented control, consistent with the My Pets species toggle (FilterBar). */
+  .bv-species {
+    display: inline-flex; align-self: flex-start; gap: 2px; flex-shrink: 0;
+    margin: 0 20px 10px; padding: 2px; border-radius: 8px; background: var(--bg-tertiary);
+  }
   .species-btn {
-    padding: 5px 14px; border: 1px solid var(--border-primary); border-radius: 16px;
-    background: var(--bg-primary); color: var(--text-tertiary);
-    font-size: 12px; font-weight: 600; cursor: pointer;
+    border: none; background: transparent; color: var(--text-tertiary);
+    font-size: 12px; font-weight: 600; padding: 5px 14px; border-radius: 6px; cursor: pointer;
   }
   .species-btn:hover { color: var(--text-secondary); }
-  .species-btn.active { background: var(--accent); color: var(--text-inverse); border-color: var(--accent); }
+  .species-btn.active {
+    background: var(--bg-primary); color: var(--text-primary);
+    box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.06));
+  }
   .bv-body { flex: 1; min-height: 0; overflow: auto; padding: 0 20px 16px; display: flex; flex-direction: column; gap: 8px; }
   .bv-meta { font-size: 12px; color: var(--text-tertiary); }
 </style>

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -19,7 +19,7 @@ import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearLibrarySelection, libraryView } from '$lib/stores/library.svelte.js';
-import { pets } from '$lib/stores/pets.js';
+import { loading, pets } from '$lib/stores/pets.js';
 import { type DialogResult, HORSE_BREEDS, type Pet } from '$lib/types/index.js';
 import { createGenomeUploadController } from '$lib/utils/genomeUploadController.svelte.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
@@ -160,7 +160,7 @@ function handleBulkShareResult(result: DialogResult): void {
       {#if upload.fileDragActive}
         <div class="file-drop-overlay"><span>Drop genome files to upload</span></div>
       {/if}
-      {#if $pets.length === 0}
+      {#if $pets.length === 0 && !$loading}
         <div class="mp-empty" data-testid="mypets-empty">
           <EmptyState
             icon="🐾"
@@ -174,27 +174,6 @@ function handleBulkShareResult(result: DialogResult): void {
     </div>
 
     <div class="mp-foot">
-      {#if selectedPets.length > 0}
-        <div class="mp-selection" data-testid="mypets-selection">
-          <span class="sel-count">{selectedPets.length} selected</span>
-          <button
-            type="button"
-            class="act-btn"
-            data-testid="mypets-compare"
-            disabled={!canCompare}
-            title={canCompare ? 'Compare the two selected pets' : 'Select exactly two pets of the same species'}
-            onclick={openCompare}
-          >⚖️ Compare</button>
-          <button
-            type="button"
-            class="act-btn"
-            data-testid="mypets-share"
-            title="Share the selected pets to the community catalogue"
-            onclick={() => { bulkShareOpen = true; }}
-          >🌐 Share</button>
-          <button type="button" class="act-btn ghost" data-testid="mypets-clear" onclick={clearLibrarySelection}>Clear</button>
-        </div>
-      {/if}
       <div class="mp-add" data-testid="mypets-actions">
         <button
           type="button"
@@ -232,6 +211,27 @@ function handleBulkShareResult(result: DialogResult): void {
           {/if}
         </button>
       </div>
+      {#if selectedPets.length > 0}
+        <div class="mp-selection" data-testid="mypets-selection">
+          <span class="sel-count">{selectedPets.length} selected</span>
+          <button
+            type="button"
+            class="act-btn"
+            data-testid="mypets-compare"
+            disabled={!canCompare}
+            title={canCompare ? 'Compare the two selected pets' : 'Select exactly two pets of the same species'}
+            onclick={openCompare}
+          >⚖️ Compare</button>
+          <button
+            type="button"
+            class="act-btn"
+            data-testid="mypets-share"
+            title="Share the selected pets to the community catalogue"
+            onclick={() => { bulkShareOpen = true; }}
+          >🌐 Share</button>
+          <button type="button" class="act-btn ghost" data-testid="mypets-clear" onclick={clearLibrarySelection}>Clear</button>
+        </div>
+      {/if}
     </div>
   </div>
 
@@ -291,7 +291,7 @@ function handleBulkShareResult(result: DialogResult): void {
     display: flex; align-items: center; gap: 12px; padding: 8px 16px;
     border-top: 1px solid var(--border-primary); background: var(--bg-secondary); flex-shrink: 0;
   }
-  .mp-selection { order: 2; margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .mp-selection { margin-left: auto; display: flex; align-items: center; gap: 8px; }
   .sel-count { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
   .act-btn {
     padding: 5px 12px; border: 1px solid var(--border-primary); border-radius: 6px;
@@ -302,7 +302,7 @@ function handleBulkShareResult(result: DialogResult): void {
   .act-btn:disabled { opacity: 0.5; cursor: default; }
   .act-btn.ghost { border-color: transparent; color: var(--text-tertiary); }
 
-  .mp-add { order: 1; display: flex; align-items: center; gap: 8px; }
+  .mp-add { display: flex; align-items: center; gap: 8px; }
   .upload-btn {
     padding: 7px 14px; border: none; border-radius: 7px;
     background: var(--accent); color: var(--text-inverse); font-size: 12px; font-weight: 600; cursor: pointer;

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -13,6 +13,7 @@ import BulkSharePetDialog from '$lib/components/community/BulkSharePetDialog.sve
 import GenomeGridDiff from '$lib/components/comparison/GenomeGridDiff.svelte';
 import Roster from '$lib/components/library/Roster.svelte';
 import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
+import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import FilterBar from '$lib/components/shared/FilterBar.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
@@ -159,7 +160,17 @@ function handleBulkShareResult(result: DialogResult): void {
       {#if upload.fileDragActive}
         <div class="file-drop-overlay"><span>Drop genome files to upload</span></div>
       {/if}
-      <Roster onOpen={openDetail} />
+      {#if $pets.length === 0}
+        <div class="mp-empty" data-testid="mypets-empty">
+          <EmptyState
+            icon="🐾"
+            title="No pets yet"
+            body="Upload a genome file (or drop one here) to start building your stable."
+          />
+        </div>
+      {:else}
+        <Roster onOpen={openDetail} />
+      {/if}
     </div>
 
     <div class="mp-foot">
@@ -261,6 +272,7 @@ function handleBulkShareResult(result: DialogResult): void {
   .mp-share-status { padding: 8px 16px 0; }
 
   .mp-table { position: relative; flex: 1; min-height: 0; overflow: auto; }
+  .mp-empty { height: 100%; display: flex; align-items: center; justify-content: center; }
 
   .file-drop-overlay {
     position: absolute; inset: 0; z-index: 5;
@@ -273,12 +285,14 @@ function handleBulkShareResult(result: DialogResult): void {
     padding: 12px 20px; border-radius: 8px; background: var(--bg-primary); box-shadow: var(--shadow-lg);
   }
 
-  .mp-foot { border-top: 1px solid var(--border-primary); background: var(--bg-secondary); flex-shrink: 0; }
-  .mp-selection {
-    display: flex; align-items: center; gap: 8px; padding: 8px 16px;
-    border-bottom: 1px solid var(--border-primary);
+  /* One footer strip: add-actions on the left, selection-actions on the right
+     (when a selection exists) — no stacked bars. */
+  .mp-foot {
+    display: flex; align-items: center; gap: 12px; padding: 8px 16px;
+    border-top: 1px solid var(--border-primary); background: var(--bg-secondary); flex-shrink: 0;
   }
-  .sel-count { font-size: 12px; font-weight: 600; color: var(--text-secondary); margin-right: auto; }
+  .mp-selection { order: 2; margin-left: auto; display: flex; align-items: center; gap: 8px; }
+  .sel-count { font-size: 12px; font-weight: 600; color: var(--text-secondary); }
   .act-btn {
     padding: 5px 12px; border: 1px solid var(--border-primary); border-radius: 6px;
     background: var(--bg-primary); color: var(--text-secondary);
@@ -288,7 +302,7 @@ function handleBulkShareResult(result: DialogResult): void {
   .act-btn:disabled { opacity: 0.5; cursor: default; }
   .act-btn.ghost { border-color: transparent; color: var(--text-tertiary); }
 
-  .mp-add { display: flex; align-items: center; gap: 8px; padding: 9px 16px; }
+  .mp-add { order: 1; display: flex; align-items: center; gap: 8px; }
   .upload-btn {
     padding: 7px 14px; border: none; border-radius: 7px;
     background: var(--accent); color: var(--text-inverse); font-size: 12px; font-weight: 600; cursor: pointer;

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -209,6 +209,7 @@ onDestroy(() => {
                 >
                     Gallery
                 </button>
+                <span class="vc-divider" aria-hidden="true"></span>
                 <button
                     class="view-btn share-btn"
                     data-testid="share-pet-btn"
@@ -378,10 +379,21 @@ onDestroy(() => {
 
     .view-controls {
         display: flex;
+        align-items: center;
         gap: 4px;
         background: var(--bg-tertiary);
         border-radius: 6px;
         padding: 3px;
+    }
+
+    /* Separates the view toggles (Attributes/Appearance/Stats/Gallery) from the
+       actions (Share/Edit/Delete) so the destructive Delete isn't adjacent to a
+       routine view toggle. */
+    .vc-divider {
+        width: 1px;
+        align-self: stretch;
+        margin: 2px 4px;
+        background: var(--border-secondary);
     }
 
     .view-btn {

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -122,6 +122,7 @@ async function doDelete(): Promise<void> {
     transition: background 0.12s, color 0.12s, border-color 0.12s;
   }
   .action-btn:hover { background: var(--bg-hover); border-color: var(--border-primary); color: var(--text-primary); }
+  .action-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -109,19 +109,19 @@ async function doDelete(): Promise<void> {
 <style>
   /* Compact glyph buttons for list rows (icon variant). */
   .action-btn {
-    width: 22px;
-    height: 22px;
+    width: 24px;
+    height: 24px;
     display: grid;
     place-items: center;
-    border: none;
+    border: 1px solid transparent;
     border-radius: 5px;
     background: transparent;
-    color: var(--text-tertiary);
-    font-size: 12px;
+    color: var(--text-secondary);
+    font-size: 13px;
     cursor: pointer;
-    transition: background 0.12s, color 0.12s;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
   }
-  .action-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .action-btn:hover { background: var(--bg-hover); border-color: var(--border-primary); color: var(--text-primary); }
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 


### PR DESCRIPTION
The should-fix/polish findings from the UI/UX review (verified in-browser).

- **#4 Row actions** — roster edit/delete icons were too faint; raise to `--text-secondary`, 22→24px, add a hover border so they read as buttons.
- **#6 Footer** — My Pets had two stacked bottom bars; consolidate into one strip (add-actions left, selection actions right via flex `order`).
- **#7 Detail header** — separate the view toggles (Attributes/Appearance/Stats/Gallery) from the actions (Share/Edit/Delete) with a divider, so Delete isn't flush against a view toggle.
- **#8 Empty state** — first-run My Pets (0 pets) now shows a "No pets yet — upload to get started" state instead of an empty table.
- **#9 Breed toggle** — restyled as a segmented control matching the My Pets (FilterBar) species toggle.

**Deliberately not done — #5 (unify Community detail).** Community's side-by-side master/detail is the right pattern for a browse-and-import catalogue (rapid preview without losing your place); forcing it into My Pets' full-view-with-back would regress that flow. Flagged for your call rather than changed.

- check 0/0 · lint clean · e2e: 48/51 in a thrashed local run; the 3 are the known cold-dev-server/heavy-grid flakes that pass on retry & isolation (CI runs retries:2).