### PR TITLE
test(breeding): widen perf budget to stop CI flake

### DIFF
--- a/tests/unit/breedingService.perf.test.ts
+++ b/tests/unit/breedingService.perf.test.ts
@@ -28,7 +28,11 @@ const SAMPLE_GENOME = parseGenome(SAMPLE_HORSE);
 
 const NUM_MALES = 15;
 const NUM_FEMALES = 15;
-const SCORING_BUDGET_MS = 500;
+// Generous headroom on purpose: a typical run is well under half this, but
+// shared CI runners jitter (a 500ms bound flaked at ~502ms). This is a
+// regression alarm — it should fire when scoring roughly doubles, not on
+// runner noise.
+const SCORING_BUDGET_MS = 1000;
 
 const ALLELE_CYCLE = ['D', 'R', 'x', 'D', 'R', 'D', 'x', 'R'];
 const EFFECTS = ['Toughness+', 'Friendliness+', 'Intelligence-', 'None', 'Ruggedness+', 'Temperament+'];


### PR DESCRIPTION
`breedingService.perf.test.ts` asserts the 15×15 horse scoring runs in <500ms with zero margin; it flaked at ~502ms on a slow CI runner (blocked #356 until a rerun). The test documents itself as "a regression alarm, not a tight bound", so the zero-margin threshold contradicts its intent.

Bump to **1000ms** — a typical run is well under half that, so it still fires on a real ~2× regression but not on runner jitter. No production code change.