### PR TITLE
deps-dev: bump @testing-library/svelte from 5.3.1 to 5.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tauri-apps/cli": "^2.11.2",
     "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/svelte": "^5.3.1",
+    "@testing-library/svelte": "^5.4.1",
     "@types/node": "^26.0.0",
     "@vitest/ui": "^4.1.9",
     "firebase-admin": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/svelte':
-        specifier: ^5.3.1
-        version: 5.3.1(svelte@5.56.3)(vite@8.0.16(@types/node@26.0.0)(yaml@2.9.0))(vitest@4.1.9)
+        specifier: ^5.4.1
+        version: 5.4.1(svelte@5.56.3)(vite@8.0.16(@types/node@26.0.0)(yaml@2.9.0))(vitest@4.1.9)
       '@types/node':
         specifier: ^26.0.0
         version: 26.0.0
@@ -1058,14 +1058,14 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
-  '@testing-library/svelte-core@1.0.0':
-    resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
+  '@testing-library/svelte-core@1.1.2':
+    resolution: {integrity: sha512-HiAsJfEiOtgqXLCAjKI5yZTbXqD0ByYBMhBxPLnw5wzMUZ050Ex3kvsxBgeXOboBUwgZWRDoRYanhp4j3z0AKQ==}
     engines: {node: '>=16'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
 
-  '@testing-library/svelte@5.3.1':
-    resolution: {integrity: sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==}
+  '@testing-library/svelte@5.4.1':
+    resolution: {integrity: sha512-Ju8RZYx7AIAjv+Sc9KN/CbsWI/qjimz1hzGN4KGezw7vKivlDKjDwCXXpJxQrYu/xGx888dhApU+hPupQK6/PA==}
     engines: {node: '>= 10'}
     peerDependencies:
       svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
@@ -4888,14 +4888,14 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.56.3)':
+  '@testing-library/svelte-core@1.1.2(svelte@5.56.3)':
     dependencies:
       svelte: 5.56.3
 
-  '@testing-library/svelte@5.3.1(svelte@5.56.3)(vite@8.0.16(@types/node@26.0.0)(yaml@2.9.0))(vitest@4.1.9)':
+  '@testing-library/svelte@5.4.1(svelte@5.56.3)(vite@8.0.16(@types/node@26.0.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/svelte-core': 1.0.0(svelte@5.56.3)
+      '@testing-library/svelte-core': 1.1.2(svelte@5.56.3)
       svelte: 5.56.3
     optionalDependencies:
       vite: 8.0.16(@types/node@26.0.0)(yaml@2.9.0)


### PR DESCRIPTION
Replaces #347 (dependabot's recreate stalled on the pnpm-lock conflict).

Verified locally: `pnpm run test` 688 passed, `pnpm run lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)