### PR TITLE
fix(library): keep pet detail overlay mounted across background reloads

### DIFF
--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -87,8 +87,30 @@ $effect(() => {
   libraryView.openPetId = null;
 });
 
-// Resolve against the live pet list so a deleted pet drops out (→ back to table).
-const detailPet = $derived(detailPetId == null ? null : ($pets.find((p) => p.id === detailPetId) ?? null));
+// Resolve against the live pet list, but retain a snapshot of the open pet so a
+// transient absence during a background reload can't blink the overlay shut.
+// AuthWrapper's startup backfills each fire `loadPets()` → `pets.set(...)` well
+// after mount; coupling the overlay's lifetime directly to a `$pets.find()`
+// would tear down the detail (and its Share/Edit/Delete controls) mid-render if
+// a reload momentarily lands without our pet. Reconcile to the fresh object
+// whenever it's present so backfilled fields (gene counts, …) still surface.
+const livePet = $derived(detailPetId == null ? null : ($pets.find((p) => p.id === detailPetId) ?? null));
+let detailPetSnapshot = $state<Pet | null>(null);
+$effect(() => {
+  if (livePet) detailPetSnapshot = livePet;
+});
+const detailPet = $derived(detailPetId == null ? null : (livePet ?? detailPetSnapshot));
+
+// A genuinely deleted pet still drops us back to the table — but only on a
+// *settled* load (`!$loading`). During an in-flight reload the list can briefly
+// lack the pet; that window always closes with `loading` true, so it can't be
+// mistaken for a deletion.
+$effect(() => {
+  if (detailPetId != null && !$loading && !$pets.some((p) => p.id === detailPetId)) {
+    detailPetId = null;
+    detailPetSnapshot = null;
+  }
+});
 
 // Visible pets = the same filtered set the Roster shows (one source of truth via
 // getLibraryFilters). The selection is scoped to these so a pet hidden by a

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -99,7 +99,11 @@ let detailPetSnapshot = $state<Pet | null>(null);
 $effect(() => {
   if (livePet) detailPetSnapshot = livePet;
 });
-const detailPet = $derived(detailPetId == null ? null : (livePet ?? detailPetSnapshot));
+// Only fall back to the snapshot when it's the *same* pet — otherwise switching
+// to another pet while its row hasn't landed yet would briefly show the prior one.
+const detailPet = $derived(
+  detailPetId == null ? null : (livePet ?? (detailPetSnapshot?.id === detailPetId ? detailPetSnapshot : null)),
+);
 
 // A genuinely deleted pet still drops us back to the table — but only on a
 // *settled* load (`!$loading`). During an in-flight reload the list can briefly

--- a/tests/fixtures/PetVisualizationStub.svelte
+++ b/tests/fixtures/PetVisualizationStub.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+// Lightweight stand-in for PetVisualization so MyPets overlay-lifecycle tests
+// don't mount the real gene visualizer (2304 cells, window/document reads).
+// Surfaces the pet id/name so a test can assert which pet the detail shows.
+import type { Pet } from '$lib/types/index.js';
+
+const { pet }: { pet: Pet } = $props();
+</script>
+
+<div data-testid="pet-visualization-stub" data-pet-id={pet.id}>{pet.name}</div>

--- a/tests/unit/myPetsDetailReload.test.ts
+++ b/tests/unit/myPetsDetailReload.test.ts
@@ -1,0 +1,99 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { libraryView } from '$lib/stores/library.svelte.js';
+import { loading, pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+
+// MyPets opens a pet's detail as a full-view overlay. AuthWrapper runs startup
+// backfills that each call `loadPets()` → `pets.set(...)` well after mount, so
+// the $pets array is replaced repeatedly while a detail may be open. The detail
+// must survive that churn (regression for the redesign e2e flake where the open
+// overlay — and its Share button — blinked shut mid-interaction), while still
+// dropping back to the table when the open pet is genuinely deleted.
+//
+// The real PetVisualization (gene grid, window/document reads) is stubbed so
+// this stays a focused test of MyPets' overlay lifecycle.
+vi.mock('$lib/components/pet/PetVisualization.svelte', async () => ({
+  default: (await import('../fixtures/PetVisualizationStub.svelte')).default,
+}));
+
+import MyPets from '$lib/components/library/MyPets.svelte';
+
+const pet = (over: Partial<Pet>): Pet =>
+  ({
+    id: 0,
+    name: 'Pet',
+    species: 'Horse',
+    breed: 'Standardbred',
+    gender: 'Female',
+    tags: [],
+    stabled: true,
+    positive_genes: 0,
+    ...over,
+  }) as unknown as Pet;
+
+const sample = () => [pet({ id: 1, name: 'Dusty', gender: 'Male' }), pet({ id: 2, name: 'Roach' })];
+
+function resetView() {
+  libraryView.search = '';
+  libraryView.species = '';
+  libraryView.breed = '';
+  libraryView.gender = '';
+  libraryView.starredOnly = false;
+  libraryView.stabledOnly = false;
+  libraryView.petQualityOnly = false;
+  libraryView.tags = [];
+  libraryView.selectedIds = new Set();
+  libraryView.openPetId = null;
+}
+
+beforeEach(() => {
+  resetView();
+  loading.set(false);
+  pets.set(sample());
+});
+
+afterEach(() => {
+  cleanup();
+  loading.set(false);
+  pets.set([]);
+  resetView();
+});
+
+const detail = (c: HTMLElement) => c.querySelector('[data-testid="pet-detail"]');
+
+describe('MyPets — detail overlay survives background pet reloads', () => {
+  it('keeps the open detail mounted while $pets is replaced (and briefly empty) during a reload', async () => {
+    libraryView.openPetId = 1; // consumed on mount → opens pet 1's detail
+    const { container, rerender } = render(MyPets);
+    await rerender({});
+    expect(detail(container)).not.toBeNull();
+
+    // Mid-reload: a background loadPets is in flight (loading true) and the
+    // array is momentarily replaced — worst case, briefly without our pet.
+    loading.set(true);
+    pets.set([]);
+    await rerender({});
+    expect(detail(container)).not.toBeNull();
+
+    // Reload settles with the pet present again (fresh object refs).
+    pets.set(sample());
+    loading.set(false);
+    await rerender({});
+    expect(detail(container)).not.toBeNull();
+    expect(container.querySelector('[data-testid="pet-visualization-stub"]')?.getAttribute('data-pet-id')).toBe('1');
+  });
+
+  it('closes back to the table when the open pet is deleted (settled load without it)', async () => {
+    libraryView.openPetId = 1;
+    const { container, rerender } = render(MyPets);
+    await rerender({});
+    expect(detail(container)).not.toBeNull();
+
+    // A settled load (loading false) that no longer contains the pet = deletion.
+    loading.set(false);
+    pets.set([pet({ id: 2, name: 'Roach' })]);
+    await rerender({});
+    expect(detail(container)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
On `redesign/library-workspace` (PR #341), the `e2e-integration` job fails: `community.spec.ts:20 › Share Pet Dialog › opens dialog showing a preview` times out on all attempts (`gallery.spec.ts:15` and `pet-crud.spec.ts:14` flake on the same root cause).

The signature is a button that "resolves" in the DOM but never becomes "visible, enabled and stable". The trace shows the pet detail overlay flickering open then shut during the first test.

## Root cause
`MyPets.svelte` derived the detail overlay's existence straight from the live pet list:

```js
const detailPet = $derived(detailPetId == null ? null : ($pets.find((p) => p.id === detailPetId) ?? null));
{#if detailPet} <section data-testid="pet-detail"> ... <PetVisualization pet={detailPet} /> ... {/if}
```

`AuthWrapper` runs startup backfills off the critical path and calls `appState.loadPets()` several times after mount; each does `pets.set(...)`. When one of those reloads lands while a detail is open, `detailPet` recomputes — and any window where the array doesn't resolve the open pet tears the overlay down, taking the Share/Edit/Delete controls with it. The first test races against those backfills (later tests run after they settle), which is why only it fails consistently.

## Fix
Snapshot the open pet so `$pets` churn can't blink the overlay shut, reconciling to the fresh object whenever it's present (so backfilled fields still surface). Close back to the table only on a **settled** load (`!$loading`) that lacks the pet — a genuine deletion. An in-flight reload's transient absence always carries `loading=true`, so it can't be mistaken for a deletion.

## Tests
- New `tests/unit/myPetsDetailReload.test.ts` (+ `PetVisualizationStub`) is a deterministic regression test: it fails against the old code (overlay unmounts on `$pets` churn) and passes with the fix, and asserts a real deletion still closes the detail.
- Full unit suite: 737 passing. Lint clean.

Targets `redesign/library-workspace` so #341's CI goes green.