### PR TITLE
fix(e2e): wait for startup backfills to settle before interacting

### DIFF
--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -21,6 +21,10 @@ interface Props {
 
 const { children }: Props = $props();
 let ready = $state(false);
+// Flips true once the startup backfill chain settles. The backfills fire
+// `loadPets()` after `ready`, re-rendering the roster after the spinner is gone;
+// e2e waits on this marker so it never clicks a row/control mid-DOM-swap.
+let backfillsDone = $state(false);
 let liveScanRunning = false;
 let pendingRescan = false;
 
@@ -139,6 +143,8 @@ onMount(async () => {
     // runs (legacy DBs start without it), so recompute now that it's seeded —
     // otherwise the startup count can over-report until the next scan/event.
     void refreshPendingImportCount();
+
+    backfillsDone = true;
   })();
 });
 </script>
@@ -149,7 +155,7 @@ onMount(async () => {
     <p>Loading...</p>
   </div>
 {:else}
-  <div class="app-root">
+  <div class="app-root" data-backfills-done={backfillsDone}>
     {@render children()}
   </div>
 {/if}

--- a/src/lib/components/AuthWrapper.svelte
+++ b/src/lib/components/AuthWrapper.svelte
@@ -109,42 +109,45 @@ onMount(async () => {
   // for the slow ones (pet_genes can take minutes on big stables).
   void (async () => {
     try {
-      await backfillParsedGeneEffectsIfNeeded();
-    } catch (err) {
-      console.warn('parsed-effects backfill aborted:', err);
-    }
+      try {
+        await backfillParsedGeneEffectsIfNeeded();
+      } catch (err) {
+        console.warn('parsed-effects backfill aborted:', err);
+      }
 
-    try {
-      await backfillPositiveGenesIfNeeded();
-      void appState.loadPets();
-    } catch (err) {
-      console.warn('positive_genes backfill aborted:', err);
-    }
+      try {
+        await backfillPositiveGenesIfNeeded();
+        void appState.loadPets();
+      } catch (err) {
+        console.warn('positive_genes backfill aborted:', err);
+      }
 
-    try {
-      await backfillPetGenesIfNeeded();
-    } catch (err) {
-      console.warn('pet_genes backfill aborted:', err);
-    }
+      try {
+        await backfillPetGenesIfNeeded();
+      } catch (err) {
+        console.warn('pet_genes backfill aborted:', err);
+      }
 
-    try {
-      await backfillGeneCountsIfNeeded();
-      void appState.loadPets();
-    } catch (err) {
-      console.warn('gene_counts backfill aborted:', err);
-    }
+      try {
+        await backfillGeneCountsIfNeeded();
+        void appState.loadPets();
+      } catch (err) {
+        console.warn('gene_counts backfill aborted:', err);
+      }
 
-    try {
-      await backfillImportedFilesIfNeeded();
-    } catch (err) {
-      console.warn('imported_files backfill aborted:', err);
+      try {
+        await backfillImportedFilesIfNeeded();
+      } catch (err) {
+        console.warn('imported_files backfill aborted:', err);
+      }
+      // The ledger the pending count reads is only populated once this backfill
+      // runs (legacy DBs start without it), so recompute now that it's seeded —
+      // otherwise the startup count can over-report until the next scan/event.
+      void refreshPendingImportCount();
+    } finally {
+      // Flip even if an unguarded step throws, so waitForPets() never hangs.
+      backfillsDone = true;
     }
-    // The ledger the pending count reads is only populated once this backfill
-    // runs (legacy DBs start without it), so recompute now that it's seeded —
-    // otherwise the startup count can over-report until the next scan/event.
-    void refreshPendingImportCount();
-
-    backfillsDone = true;
   })();
 });
 </script>

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -14,6 +14,10 @@ export async function waitForAppReady(page: Page) {
 export async function waitForPets(page: Page) {
   await waitForAppReady(page);
   await page.waitForSelector('[data-testid="roster-open"]');
+  // The startup backfill chain fires loadPets() after the spinner clears,
+  // re-rendering the roster. Wait for it to settle so a click doesn't race a
+  // DOM swap that detaches the row/control mid-action. See AuthWrapper.
+  await page.waitForSelector('[data-backfills-done="true"]');
 }
 
 /** Open one of the destinations by its nav button. */


### PR DESCRIPTION
## Problem

The Integration Tests run on `redesign/library-workspace` is flaky. On the same SHA `03acde6`, the `pull_request` run passed while the `push` run failed (1 failed, 3 flaky): `gallery.spec.ts › Clicking Gallery shows the gallery view` failed all 3 retries; `app.spec` view-control buttons, and two `community.spec` share-dialog tests passed only on retry.

## Root cause

All four share one pattern: open a pet detail, then click a control. `AuthWrapper.onMount` sets `ready = true` (clearing the spinner, so `waitForPets()` returns) and *then* runs a sequential backfill chain that fires `void appState.loadPets()` twice. Each `loadPets()` does `pets.set(...)`, re-rendering the Roster table after the test has started. A click landing during one of those re-renders races a DOM swap that detaches the row/control, and Playwright's actionability wait times out at 30s.

The detail-pane snapshot logic in `MyPets.svelte` already keeps the *data* stable across these reloads; what it can't prevent is Playwright clicking mid-DOM-swap.

## Fix

- `AuthWrapper`: expose `data-backfills-done` on `.app-root`, flipped to `true` once the backfill chain settles (always reached — each step is `try/catch`).
- `waitForPets`: wait for `[data-backfills-done="true"]` after the roster appears, so no test interacts during backfill churn.

Test-harness timing fix only; no product behaviour change.

## Verification

`gallery`, `community`, `app` specs run `--repeat-each=5 --retries=0 --workers=1`: **175 passed**, including the previously hard-failing gallery test. `pnpm run lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)