### PR TITLE
feat(community): auto-share pets on import (opt-in, off by default)

### DIFF
--- a/src/lib/components/layout/SettingsModal.svelte
+++ b/src/lib/components/layout/SettingsModal.svelte
@@ -233,6 +233,28 @@ async function installUpdate() {
         </div>
 
         <div class="settings-section">
+          <h4>Community</h4>
+
+          <label class="setting-row">
+            <div class="setting-info">
+              <span class="setting-name">Auto-share pets on import</span>
+              <span class="setting-desc">Automatically publish newly imported pets to the public community catalogue. Off by default — leave it off to keep imports private.</span>
+            </div>
+            <button
+              class="toggle"
+              class:toggle-on={$settings['community.autoShareOnImport']}
+              onclick={() => toggleSetting('community.autoShareOnImport')}
+              role="switch"
+              aria-label="Auto-share pets on import"
+              aria-checked={!!$settings['community.autoShareOnImport']}
+              data-testid="setting-auto-share"
+            >
+              <span class="toggle-thumb"></span>
+            </button>
+          </label>
+        </div>
+
+        <div class="settings-section">
           <h4>Updates</h4>
 
           <div class="setting-row" style="cursor: default;">

--- a/src/lib/services/autoShare.ts
+++ b/src/lib/services/autoShare.ts
@@ -1,0 +1,63 @@
+/**
+ * Auto-share-on-import: when the user opts in, freshly imported pets are
+ * published to the public community catalogue automatically.
+ *
+ * Gated by the `community.autoShareOnImport` setting, which is OFF by default —
+ * sharing is privacy-sensitive (it publishes a pet to the public Firestore
+ * catalogue), so nothing is ever shared unless the user explicitly enables it.
+ *
+ * Reuses `shareService.uploadPets`, so it inherits the bulk path's guarantees:
+ * sequential writes (Spark-quota friendly), per-pet error isolation, idempotent
+ * dedupe on `content_hash` (`already-shared`), and skipping legacy rows that
+ * have no shareable genome text. Failures never throw out of here — the caller's
+ * import must succeed regardless of whether the share did.
+ */
+import { get } from 'svelte/store';
+import { isPlaceholderConfig } from '$lib/firebase.js';
+import { pets } from '$lib/stores/pets.js';
+import { settings } from '$lib/stores/settings.js';
+import { type BulkUploadSummary, uploadPets } from './shareService.js';
+
+/** Settings key for the opt-in toggle. */
+export const AUTO_SHARE_ON_IMPORT = 'community.autoShareOnImport';
+
+/** True when the setting is on AND this build can actually reach the catalogue. */
+export function autoShareEnabled(): boolean {
+  return !isPlaceholderConfig && get(settings)[AUTO_SHARE_ON_IMPORT] === true;
+}
+
+/**
+ * Share the just-imported pets identified by `petIds`, if auto-share is enabled.
+ *
+ * Resolves the ids against the live `pets` store, so callers must refresh it
+ * (`loadPets()`) before calling — both import paths already do. Returns the
+ * bulk summary, or `null` when sharing was skipped (disabled, not configured,
+ * or nothing to share). Never rejects.
+ */
+export async function autoShareImportedPets(petIds: number[]): Promise<BulkUploadSummary | null> {
+  if (petIds.length === 0 || !autoShareEnabled()) return null;
+
+  const wanted = new Set(petIds);
+  const toShare = get(pets).filter((p) => wanted.has(p.id));
+  if (toShare.length === 0) return null;
+
+  try {
+    return await uploadPets(toShare);
+  } catch (err) {
+    // uploadPets isolates per-pet errors internally, so reaching here means an
+    // unexpected failure (e.g. genome-text loader throwing). Swallow it — a
+    // failed auto-share must never break the import that triggered it.
+    console.warn('auto-share on import failed:', err);
+    return null;
+  }
+}
+
+/** One-line, user-facing summary of an auto-share run, or null if nothing notable. */
+export function summarizeAutoShare(summary: BulkUploadSummary | null): string | null {
+  if (!summary) return null;
+  const parts: string[] = [];
+  if (summary.created > 0) parts.push(`${summary.created} shared to community`);
+  if (summary.alreadyShared > 0) parts.push(`${summary.alreadyShared} already shared`);
+  if (summary.failed > 0) parts.push(`${summary.failed} failed to share`);
+  return parts.length > 0 ? parts.join(', ') : null;
+}

--- a/src/lib/services/gameImport.ts
+++ b/src/lib/services/gameImport.ts
@@ -19,6 +19,7 @@ import {
   uploadPet,
 } from './petService.js';
 import { getSetting, setSetting } from './settingsService.js';
+import type { BulkUploadSummary } from './shareService.js';
 
 export type Platform = 'windows' | 'mac' | 'linux' | 'unknown';
 
@@ -110,10 +111,16 @@ export interface AutoScanResult {
    */
   backfilled: number;
   failures: Array<{ file: string; reason: string }>;
+  /**
+   * Auto-share outcome for the freshly-imported pets, when the opt-in
+   * `community.autoShareOnImport` setting is on. `null` when sharing was
+   * skipped (disabled, not configured, or nothing new to share).
+   */
+  shared?: BulkUploadSummary | null;
 }
 
 function emptyResult(status: AutoScanResult['status'], message?: string): AutoScanResult {
-  return { status, message, scanned: 0, skipped: 0, imported: 0, backfilled: 0, failures: [] };
+  return { status, message, scanned: 0, skipped: 0, imported: 0, backfilled: 0, failures: [], shared: null };
 }
 
 /**
@@ -154,7 +161,10 @@ export async function autoScanGameFolder(options?: {
     imported: 0,
     backfilled: 0,
     failures: [],
+    shared: null,
   };
+  // Ids of fresh inserts this scan, for auto-share once the store is reloaded.
+  const createdPetIds: number[] = [];
 
   // Read+hash in parallel chunks — the slow step on cold scans is disk
   // I/O, and SHA-256 of a small text file is negligible. SQL writes
@@ -221,6 +231,7 @@ export async function autoScanGameFolder(options?: {
           result.backfilled++;
         } else {
           result.imported++;
+          if (upload.pet_id != null) createdPetIds.push(upload.pet_id);
         }
       } else {
         // pets.content_hash matched but imported_files was missing the
@@ -244,6 +255,16 @@ export async function autoScanGameFolder(options?: {
     // loadPets() handles its own errors (surfaces via the store's error state)
     // and never rejects, so awaiting it bare is safe.
     await appState.loadPets();
+  }
+
+  // Auto-share the fresh inserts once the store reflects them. Dynamic import
+  // keeps the shareService/store/firebase graph off this service's static deps
+  // (same rationale as the loadPets import above). No-op unless the user opted
+  // in; never throws — a failed share must not fail the scan. Covers every scan
+  // caller, including AuthWrapper's background folder watcher.
+  if (createdPetIds.length > 0) {
+    const { autoShareImportedPets } = await import('./autoShare.js');
+    result.shared = await autoShareImportedPets(createdPetIds);
   }
 
   return result;

--- a/src/lib/services/settingsService.ts
+++ b/src/lib/services/settingsService.ts
@@ -12,6 +12,9 @@ const SETTING_DEFAULTS: Record<string, unknown> = {
   'display.fontScale': 100,
   'display.theme': 'system',
   'import.gameFolderPath': '',
+  // Privacy-sensitive: sharing publishes a pet to the public catalogue, so this
+  // stays OFF unless the user explicitly opts in. See autoShare.ts.
+  'community.autoShareOnImport': false,
 };
 
 export function getDefaultSettings(): Record<string, unknown> {

--- a/src/lib/utils/genomeUpload.ts
+++ b/src/lib/utils/genomeUpload.ts
@@ -30,6 +30,12 @@ export interface UploadSummary {
   succeeded: number;
   /** `"<name>: <reason>"` for each source that failed to read or import. */
   failures: string[];
+  /**
+   * Ids of pets freshly created by this batch (`kind: 'created'`), in upload
+   * order. Excludes backfilled/repaired rows, which already existed. Lets the
+   * caller auto-share exactly the new pets without re-deriving them.
+   */
+  createdPetIds: number[];
 }
 
 /**
@@ -43,6 +49,7 @@ export async function runGenomeUpload(
 ): Promise<UploadSummary> {
   const total = sources.length;
   const failures: string[] = [];
+  const createdPetIds: number[] = [];
 
   for (let i = 0; i < total; i++) {
     onProgress?.(i + 1, total);
@@ -51,12 +58,13 @@ export async function runGenomeUpload(
       const content = await read();
       const result = await upload(content);
       if (result.status === 'error') failures.push(`${name}: ${result.message}`);
+      else if (result.kind === 'created' && result.pet_id != null) createdPetIds.push(result.pet_id);
     } catch (err) {
       failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
-  return { total, succeeded: total - failures.length, failures };
+  return { total, succeeded: total - failures.length, failures, createdPetIds };
 }
 
 /** True when a drag carries OS files (vs. an internal card-reorder drag). */

--- a/src/lib/utils/genomeUploadController.svelte.ts
+++ b/src/lib/utils/genomeUploadController.svelte.ts
@@ -11,6 +11,7 @@
  * the drop overlay. See docs/design/redesign-library-workspace-v1.md §5.
  */
 import { get } from 'svelte/store';
+import { autoShareImportedPets, summarizeAutoShare } from '$lib/services/autoShare.js';
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { refreshPendingImportCount } from '$lib/stores/gameImport.js';
@@ -37,15 +38,21 @@ export function createGenomeUploadController() {
     uploading = true;
     error.set(null);
     try {
-      const { total, succeeded, failures } = await runGenomeUpload(sources, {
+      const { total, succeeded, failures, createdPetIds } = await runGenomeUpload(sources, {
         upload: (content: string) => appState.uploadPetQuiet(content),
         onProgress: (current: number, t: number) => {
           uploadProgress = { current, total: t };
         },
       });
       await appState.loadPets();
+      // Auto-share runs against the freshly-reloaded store and is a no-op unless
+      // the user opted in. It never throws, so it can't fail the upload.
+      const shareNote = summarizeAutoShare(await autoShareImportedPets(createdPetIds));
       if (failures.length > 0) {
-        error.set(`${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`);
+        const base = `${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`;
+        error.set(shareNote ? `${base}\n${shareNote}` : base);
+      } else if (shareNote) {
+        error.set(shareNote);
       }
     } catch (err) {
       error.set(`Upload failed: ${errorMessage(err)}`);
@@ -131,9 +138,13 @@ export function createGenomeUploadController() {
         return;
       }
 
-      // autoScanGameFolder refreshes the pets store itself on a DB change (#253).
+      // autoScanGameFolder refreshes the pets store itself on a DB change (#253),
+      // and auto-shares the fresh inserts itself when the opt-in is on (#363).
       const backfillNote = result.backfilled > 0 ? `, ${result.backfilled} unlocked for sharing` : '';
-      const summary = `Auto-import: ${result.imported} new, ${result.skipped} already imported${backfillNote} (of ${result.scanned} files).`;
+      const shareNote = summarizeAutoShare(result.shared ?? null);
+      const summary =
+        `Auto-import: ${result.imported} new, ${result.skipped} already imported${backfillNote} (of ${result.scanned} files).` +
+        (shareNote ? `\n${shareNote}` : '');
       if (result.failures.length > 0) {
         const lines = result.failures.map((f: { file: string; reason: string }) => `${f.file}: ${f.reason}`);
         error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);

--- a/tests/e2e/autoShare.spec.ts
+++ b/tests/e2e/autoShare.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+import { waitForAppReady } from './helpers.js';
+
+// The auto-share-on-import toggle. Sharing itself needs Firestore (covered by
+// unit tests with mocks); here we only assert the opt-in control is present,
+// defaults OFF, toggles, and persists — the privacy-critical contract is that
+// it is never on unless the user turned it on.
+
+test.describe('Auto-share on import setting', () => {
+  test('toggle is present and defaults to OFF', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    const toggle = page.locator('[data-testid="setting-auto-share"]');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+    await expect(toggle).not.toHaveClass(/toggle-on/);
+  });
+
+  test('toggling on persists across reopen', async ({ page }) => {
+    await page.goto('/');
+    await waitForAppReady(page);
+
+    await page.locator('.settings-toggle').click();
+    const toggle = page.locator('[data-testid="setting-auto-share"]');
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    // Close and reopen — the setting is read back from the DB.
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.settings-dialog')).not.toBeVisible();
+    await page.locator('.settings-toggle').click();
+    await expect(page.locator('[data-testid="setting-auto-share"]')).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/tests/e2e/autoShare.spec.ts
+++ b/tests/e2e/autoShare.spec.ts
@@ -18,7 +18,9 @@ test.describe('Auto-share on import setting', () => {
     await expect(toggle).not.toHaveClass(/toggle-on/);
   });
 
-  test('toggling on persists across reopen', async ({ page }) => {
+  test('toggling on survives closing and reopening the modal', async ({ page }) => {
+    // Within-session only: the e2e DB is in-memory and resets on reload, so true
+    // cross-session DB persistence is covered by the settingsService unit test.
     await page.goto('/');
     await waitForAppReady(page);
 
@@ -27,7 +29,6 @@ test.describe('Auto-share on import setting', () => {
     await toggle.click();
     await expect(toggle).toHaveAttribute('aria-checked', 'true');
 
-    // Close and reopen — the setting is read back from the DB.
     await page.keyboard.press('Escape');
     await expect(page.locator('.settings-dialog')).not.toBeVisible();
     await page.locator('.settings-toggle').click();

--- a/tests/unit/autoShare.test.ts
+++ b/tests/unit/autoShare.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable test state shared between the hoisted mock factories and the cases.
+const h = vi.hoisted(() => {
+  function makeStore<T>(initial: T) {
+    let value = initial;
+    return {
+      store: {
+        subscribe(run: (v: T) => void) {
+          run(value);
+          return () => {};
+        },
+      },
+      set(v: T) {
+        value = v;
+      },
+    };
+  }
+  return {
+    placeholder: false,
+    settings: makeStore<Record<string, unknown>>({}),
+    pets: makeStore<Array<{ id: number }>>([]),
+  };
+});
+
+vi.mock('$lib/firebase.js', () => ({
+  get isPlaceholderConfig() {
+    return h.placeholder;
+  },
+}));
+
+vi.mock('$lib/stores/settings.js', () => ({ settings: h.settings.store }));
+vi.mock('$lib/stores/pets.js', () => ({ pets: h.pets.store }));
+vi.mock('$lib/services/shareService.js', () => ({ uploadPets: vi.fn() }));
+
+import { AUTO_SHARE_ON_IMPORT, autoShareImportedPets, summarizeAutoShare } from '$lib/services/autoShare.js';
+import { uploadPets } from '$lib/services/shareService.js';
+
+const uploadPetsMock = vi.mocked(uploadPets);
+
+function summary(over: Partial<Record<string, number>> = {}) {
+  return { created: 0, alreadyShared: 0, skipped: 0, failed: 0, items: [], ...over } as never;
+}
+
+describe('autoShareImportedPets', () => {
+  beforeEach(() => {
+    uploadPetsMock.mockReset();
+    h.placeholder = false;
+    h.settings.set({ [AUTO_SHARE_ON_IMPORT]: true });
+    h.pets.set([{ id: 1 }, { id: 2 }, { id: 3 }]);
+  });
+
+  it('shares the matching imported pets when enabled', async () => {
+    uploadPetsMock.mockResolvedValue(summary({ created: 2 }));
+    const result = await autoShareImportedPets([1, 3]);
+
+    expect(uploadPetsMock).toHaveBeenCalledTimes(1);
+    expect(uploadPetsMock.mock.calls[0][0]).toEqual([{ id: 1 }, { id: 3 }]);
+    expect(result).toEqual(summary({ created: 2 }));
+  });
+
+  it('does nothing when the setting is off (default-safe)', async () => {
+    h.settings.set({ [AUTO_SHARE_ON_IMPORT]: false });
+    const result = await autoShareImportedPets([1, 2]);
+
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('does nothing when the setting key is absent (unset = off)', async () => {
+    h.settings.set({});
+    expect(await autoShareImportedPets([1])).toBeNull();
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+  });
+
+  it('does not share when Firebase is not configured, even if enabled', async () => {
+    h.placeholder = true;
+    const result = await autoShareImportedPets([1, 2]);
+
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an empty id list without touching the store', async () => {
+    expect(await autoShareImportedPets([])).toBeNull();
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no imported id is present in the store', async () => {
+    expect(await autoShareImportedPets([99])).toBeNull();
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows an unexpected uploadPets rejection (import must not fail)', async () => {
+    uploadPetsMock.mockRejectedValue(new Error('network down'));
+    expect(await autoShareImportedPets([1])).toBeNull();
+  });
+});
+
+describe('summarizeAutoShare', () => {
+  it('returns null when nothing notable happened', () => {
+    expect(summarizeAutoShare(null)).toBeNull();
+    expect(summarizeAutoShare(summary())).toBeNull();
+  });
+
+  it('summarizes created / already-shared / failed counts', () => {
+    expect(summarizeAutoShare(summary({ created: 2, alreadyShared: 1, failed: 1 }))).toBe(
+      '2 shared to community, 1 already shared, 1 failed to share',
+    );
+  });
+});

--- a/tests/unit/genomeUpload.test.ts
+++ b/tests/unit/genomeUpload.test.ts
@@ -13,7 +13,7 @@ describe('runGenomeUpload', () => {
 
     expect(upload).toHaveBeenCalledTimes(2);
     expect(upload).toHaveBeenNthCalledWith(1, 'A');
-    expect(summary).toEqual({ total: 2, succeeded: 2, failures: [] });
+    expect(summary).toEqual({ total: 2, succeeded: 2, failures: [], createdPetIds: [] });
   });
 
   it('reports per-file progress, 1-based', async () => {
@@ -33,7 +33,7 @@ describe('runGenomeUpload', () => {
     const summary = await runGenomeUpload([source('bad.txt', 'X'), source('ok.txt', 'Y')], { upload });
 
     expect(upload).toHaveBeenCalledTimes(2);
-    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['bad.txt: bad genome'] });
+    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['bad.txt: bad genome'], createdPetIds: [] });
   });
 
   it('treats a read failure as a failure for that file only', async () => {
@@ -45,7 +45,7 @@ describe('runGenomeUpload', () => {
     const summary = await runGenomeUpload(sources, { upload });
 
     expect(upload).toHaveBeenCalledTimes(1);
-    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['unreadable.txt: EACCES'] });
+    expect(summary).toEqual({ total: 2, succeeded: 1, failures: ['unreadable.txt: EACCES'], createdPetIds: [] });
   });
 
   it('returns an empty summary for no sources', async () => {
@@ -53,7 +53,23 @@ describe('runGenomeUpload', () => {
     const summary = await runGenomeUpload([], { upload });
 
     expect(upload).not.toHaveBeenCalled();
-    expect(summary).toEqual({ total: 0, succeeded: 0, failures: [] });
+    expect(summary).toEqual({ total: 0, succeeded: 0, failures: [], createdPetIds: [] });
+  });
+
+  it('collects ids of freshly created pets, excluding backfilled/errored', async () => {
+    const upload = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 'success', kind: 'created', pet_id: 7 })
+      .mockResolvedValueOnce({ status: 'success', kind: 'backfilled', pet_id: 8 })
+      .mockResolvedValueOnce({ status: 'error', message: 'bad' })
+      .mockResolvedValueOnce({ status: 'success', kind: 'created', pet_id: 9 });
+    const summary = await runGenomeUpload(
+      [source('a.txt', 'A'), source('b.txt', 'B'), source('c.txt', 'C'), source('d.txt', 'D')],
+      { upload },
+    );
+
+    expect(summary.createdPetIds).toEqual([7, 9]);
+    expect(summary.succeeded).toBe(3);
   });
 });
 

--- a/tests/unit/settingsService.test.ts
+++ b/tests/unit/settingsService.test.ts
@@ -17,6 +17,10 @@ describe('Settings Service', () => {
       defaults['horse.autoSelectBreedFilter'] = false;
       expect(settings.getDefaultSettings()['horse.autoSelectBreedFilter']).toBe(true);
     });
+
+    it('defaults auto-share-on-import to OFF (privacy-safe)', () => {
+      expect(settings.getDefaultSettings()).toHaveProperty('community.autoShareOnImport', false);
+    });
   });
 
   describe('getSetting / setSetting', () => {


### PR DESCRIPTION
Closes #363.

## What

A `community.autoShareOnImport` setting. When **on**, pets are automatically published to the public community catalogue as they're imported. **Off by default** — sharing is privacy-sensitive (it publishes to the public Firestore catalogue), so nothing is shared unless the user explicitly opts in.

Per the scoping decision, auto-share fires on **all import paths**: manual file upload / drag-drop, the manual auto-scan button, and AuthWrapper's background game-folder watcher.

## How

- **`autoShare.ts`** (new): `autoShareImportedPets(petIds)` resolves the ids against the live `pets` store and delegates to `shareService.uploadPets`, inheriting its sequential writes, per-pet error isolation, `content_hash` dedupe (`already-shared`), and legacy-genome skip. Gated by `autoShareEnabled()` (`setting === true && !isPlaceholderConfig`). Never throws — a failed share can't break the import that triggered it.
- Both import routes now collect the ids of **fresh inserts only** (`kind: 'created'`, excluding backfilled/repaired rows) and pass them to auto-share after the store reloads:
  - manual upload: `runGenomeUpload` returns `createdPetIds`; the controller shares them.
  - auto-scan: `autoScanGameFolder` collects them and auto-shares internally, so the background watcher is covered too. Outcome surfaces on `AutoScanResult.shared`.
- Settings UI: new **Community** section with the toggle (`data-testid="setting-auto-share"`), default off.

## Tests

- `autoShare.test.ts`: enabled→shares the matching pets; off→no-op; key absent→no-op; not-configured→no-op; empty/no-match→null; uploadPets rejection swallowed. Plus `summarizeAutoShare`.
- `genomeUpload.test.ts`: `createdPetIds` collects only `created` ids (excludes backfilled/errored).
- `settingsService.test.ts`: default is OFF.
- `autoShare.spec.ts` (e2e): toggle present + defaults off; toggling on persists across reopen.

Full unit suite (748) green; `svelte-check` and `lint:ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)