### PR TITLE
feat(community): "Share all pets" background bulk-share with throttling

### DIFF
--- a/src/lib/components/community/BulkShareProgress.svelte
+++ b/src/lib/components/community/BulkShareProgress.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+/**
+ * Global, non-blocking progress for the background "Share all pets" job.
+ * Mounted once at the layout root so it persists across destination switches
+ * while the job runs. Reads the module-scoped `bulkShareJob` state directly.
+ */
+import { bulkShareJob, bulkSharePercent, cancelBulkShare, dismissBulkShare } from '$lib/stores/bulkShare.svelte.js';
+
+const job = bulkShareJob;
+
+const summaryText = $derived.by(() => {
+  if (job.error) return `Sharing failed: ${job.error}`;
+  const s = job.summary;
+  if (!s) return 'Sharing complete.';
+  const parts = [`${s.created} shared`];
+  if (s.alreadyShared > 0) parts.push(`${s.alreadyShared} already in catalogue`);
+  if (s.skipped > 0) parts.push(`${s.skipped} skipped`);
+  if (s.failed > 0) parts.push(`${s.failed} failed`);
+  return parts.join(' · ');
+});
+
+const tone = $derived(job.error || (job.summary?.failed ?? 0) > 0 ? 'warn' : 'ok');
+</script>
+
+{#if job.status !== 'idle'}
+  <section class="bulk-share-progress" class:tone-warn={tone === 'warn'} data-testid="bulk-share-progress-global" aria-live="polite">
+    {#if job.status === 'running'}
+      <div class="bsp-row">
+        <span class="bsp-title">Sharing pets to community…</span>
+        <button type="button" class="bsp-btn" data-testid="bulk-share-cancel" onclick={cancelBulkShare}>Cancel</button>
+      </div>
+      <div
+        class="bsp-bar"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={job.total}
+        aria-valuenow={job.done}
+      >
+        <div class="bsp-fill" style="width: {bulkSharePercent()}%"></div>
+      </div>
+      <span class="bsp-count">{job.done} / {job.total}</span>
+    {:else}
+      <div class="bsp-row">
+        <span class="bsp-title" data-testid="bulk-share-done">{summaryText}</span>
+        <button type="button" class="bsp-btn" data-testid="bulk-share-dismiss" onclick={dismissBulkShare} aria-label="Dismiss">×</button>
+      </div>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .bulk-share-progress {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 1000;
+    width: min(360px, calc(100vw - 32px));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-primary);
+    border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-lg);
+  }
+  .bulk-share-progress.tone-warn { border-left-color: var(--warning-text, #b8860b); }
+
+  .bsp-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .bsp-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+  .bsp-count { font-size: 12px; color: var(--text-tertiary); }
+
+  .bsp-bar {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-secondary);
+    overflow: hidden;
+  }
+  .bsp-fill {
+    height: 100%;
+    background: var(--accent);
+    border-radius: 3px;
+    transition: width 0.2s ease;
+  }
+
+  .bsp-btn {
+    flex-shrink: 0;
+    padding: 3px 10px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  .bsp-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+</style>

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -23,6 +23,7 @@ import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearLibrarySelection, getLibraryFilters, libraryView } from '$lib/stores/library.svelte.js';
 import { allTags, loading, pets } from '$lib/stores/pets.js';
 import { type DialogResult, type Gender, HORSE_BREEDS, type Pet } from '$lib/types/index.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 import { createGenomeUploadController } from '$lib/utils/genomeUploadController.svelte.js';
 import { filterPets } from '$lib/utils/petFilter.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
@@ -329,14 +330,23 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
 
 {#if showShareAllConfirm}
   <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div class="modal-backdrop" onclick={() => { showShareAllConfirm = false; }}>
+  <div
+    class="modal-backdrop"
+    onclick={() => { showShareAllConfirm = false; }}
+    onkeydown={(e) => { if (e.key === 'Escape') showShareAllConfirm = false; }}
+    role="presentation"
+  >
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="dialog share-all-dialog"
       role="dialog"
       aria-modal="true"
       aria-label="Share all pets to community"
+      tabindex="-1"
+      use:focusTrap
       data-testid="share-all-dialog"
       onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => { if (e.key === 'Escape') showShareAllConfirm = false; }}
     >
       <div class="dialog-header"><h3>Share all {$pets.length} {$pets.length === 1 ? 'pet' : 'pets'} to the community?</h3></div>
       <div class="dialog-body">

--- a/src/lib/components/library/MyPets.svelte
+++ b/src/lib/components/library/MyPets.svelte
@@ -16,7 +16,9 @@ import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import FilterBar from '$lib/components/shared/FilterBar.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
+import { isPlaceholderConfig } from '$lib/firebase.js';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
+import { bulkShareJob, startBulkShare } from '$lib/stores/bulkShare.svelte.js';
 import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearLibrarySelection, getLibraryFilters, libraryView } from '$lib/stores/library.svelte.js';
 import { allTags, loading, pets } from '$lib/stores/pets.js';
@@ -157,6 +159,13 @@ function handleBulkShareResult(result: DialogResult): void {
   shareStatus = result;
   if (result.type !== 'error') clearLibrarySelection();
 }
+
+// --- Share all (whole collection, background job) ---------------------------
+// "All" means every pet, deliberately not the Stabled subset — the button
+// label/confirm say so to avoid conflating it with the Stabled flag. Hidden
+// when there's nothing to share or this build can't reach the catalogue.
+let showShareAllConfirm = $state(false);
+const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
 </script>
 
 <div class="my-pets" data-testid="my-pets">
@@ -256,6 +265,16 @@ function handleBulkShareResult(result: DialogResult): void {
           {/if}
         </button>
       </div>
+      {#if canShareAll}
+        <button
+          type="button"
+          class="act-btn share-all-btn"
+          data-testid="mypets-share-all"
+          disabled={bulkShareJob.status === 'running'}
+          title="Share every pet in your collection to the public community catalogue"
+          onclick={() => { showShareAllConfirm = true; }}
+        >🌐 Share all</button>
+      {/if}
       {#if selectedPets.length > 0}
         <div class="mp-selection" data-testid="mypets-selection">
           <span class="sel-count">{selectedPets.length} selected</span>
@@ -308,6 +327,38 @@ function handleBulkShareResult(result: DialogResult): void {
   />
 {/if}
 
+{#if showShareAllConfirm}
+  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="modal-backdrop" onclick={() => { showShareAllConfirm = false; }}>
+    <div
+      class="dialog share-all-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Share all pets to community"
+      data-testid="share-all-dialog"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <div class="dialog-header"><h3>Share all {$pets.length} {$pets.length === 1 ? 'pet' : 'pets'} to the community?</h3></div>
+      <div class="dialog-body">
+        <p class="dialog-desc">
+          This publishes <strong>every pet in your collection</strong> — not just stabled ones — to the public
+          community catalogue. Pets already shared are skipped. Sharing runs in the background; you can keep using the
+          app and cancel any time.
+        </p>
+      </div>
+      <div class="dialog-footer">
+        <button type="button" class="act-btn ghost" onclick={() => { showShareAllConfirm = false; }}>Cancel</button>
+        <button
+          type="button"
+          class="upload-btn"
+          data-testid="share-all-confirm"
+          onclick={() => { startBulkShare($pets); showShareAllConfirm = false; }}
+        >🌐 Share all</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
 <style>
   .my-pets { position: relative; flex: 1; min-width: 0; height: 100%; display: flex; flex-direction: column; overflow: hidden; }
 
@@ -346,6 +397,12 @@ function handleBulkShareResult(result: DialogResult): void {
   .act-btn:hover:not(:disabled) { color: var(--accent-text, var(--accent)); border-color: var(--accent); }
   .act-btn:disabled { opacity: 0.5; cursor: default; }
   .act-btn.ghost { border-color: transparent; color: var(--text-tertiary); }
+  /* Share-all sits with the add-actions, pushed to the right of the strip. */
+  .share-all-btn { margin-left: auto; }
+  .share-all-btn ~ .mp-selection { margin-left: 0; }
+
+  .share-all-dialog { max-width: 460px; }
+  .dialog-desc { font-size: 14px; color: var(--text-secondary); margin: 0; line-height: 1.5; }
 
   .mp-add { display: flex; align-items: center; gap: 8px; }
   .upload-btn {

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -207,9 +207,31 @@ export interface UploadPetsOptions {
   /** Abort early when this returns true (e.g. a user-cancelled dialog). */
   shouldCancel?: () => boolean;
   db?: Firestore;
+  /**
+   * Pause between pets, in ms, to stay under Firestore's per-second write
+   * quota on large stables (Spark plan). Default 0 (no pause). The delay is
+   * applied after each pet that did a network write, never after the last.
+   */
+  interRequestDelayMs?: number;
+  /**
+   * When an upload trips a quota / `resource-exhausted` error, retry that pet
+   * up to this many times with exponential backoff before giving up and
+   * marking it `failed`. Default 0 (no retry). Backoff is
+   * `quotaBackoffBaseMs * 2 ** attempt`.
+   */
+  maxQuotaRetries?: number;
+  /** Base delay for quota backoff, in ms. Default 1000. */
+  quotaBackoffBaseMs?: number;
   /** Injectable seams for testing. */
   upload?: (pet: Pet, db?: Firestore) => Promise<UploadResult>;
   loadGenomeText?: (petId: number) => Promise<string | null>;
+  /** Injectable sleep, for deterministic throttle/backoff tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Firestore signals a quota / rate breach with code `resource-exhausted`. */
+function isResourceExhausted(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: unknown }).code === 'resource-exhausted';
 }
 
 /**
@@ -228,12 +250,18 @@ export interface UploadPetsOptions {
 export async function uploadPets(pets: Pet[], options: UploadPetsOptions = {}): Promise<BulkUploadSummary> {
   const upload = options.upload ?? uploadPet;
   const loadGenomeText = options.loadGenomeText ?? getPetGenomeText;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const interRequestDelayMs = options.interRequestDelayMs ?? 0;
+  const maxQuotaRetries = options.maxQuotaRetries ?? 0;
+  const quotaBackoffBaseMs = options.quotaBackoffBaseMs ?? 1000;
   const items: BulkUploadItemResult[] = [];
   let done = 0;
 
-  for (const pet of pets) {
+  for (let index = 0; index < pets.length; index++) {
+    const pet = pets[index];
     if (options.shouldCancel?.()) break;
     const petName = pet.name ?? `Pet ${pet.id}`;
+    let didNetworkWrite = false;
     try {
       // `genome_text` isn't on the list-projected pet; load it on demand.
       const genomeText = pet.genome_text ?? (await loadGenomeText(pet.id)) ?? undefined;
@@ -246,18 +274,40 @@ export async function uploadPets(pets: Pet[], options: UploadPetsOptions = {}): 
         });
         continue;
       }
-      const result = await upload({ ...pet, genome_text: genomeText }, options.db);
-      items.push({
-        petId: pet.id,
-        petName,
-        status: result.status === 'created' ? 'created' : 'already-shared',
-        contentHash: result.contentHash,
-      });
+      didNetworkWrite = true;
+      // Retry only on quota / resource-exhausted, backing off exponentially —
+      // that's the recoverable "slow down" signal. Any other error (corruption,
+      // permission) fails the pet immediately so the batch keeps moving.
+      let attempt = 0;
+      for (;;) {
+        try {
+          const result = await upload({ ...pet, genome_text: genomeText }, options.db);
+          items.push({
+            petId: pet.id,
+            petName,
+            status: result.status === 'created' ? 'created' : 'already-shared',
+            contentHash: result.contentHash,
+          });
+          break;
+        } catch (err) {
+          if (isResourceExhausted(err) && attempt < maxQuotaRetries && !options.shouldCancel?.()) {
+            await sleep(quotaBackoffBaseMs * 2 ** attempt);
+            attempt++;
+            continue;
+          }
+          throw err;
+        }
+      }
     } catch (err) {
       items.push({ petId: pet.id, petName, status: 'failed', error: errorText(err) });
     } finally {
       done++;
       options.onProgress?.(done, pets.length);
+    }
+    // Throttle between network writes to ease per-second quota pressure; never
+    // after the last pet, and skip when nothing was written (skipped pet).
+    if (interRequestDelayMs > 0 && didNetworkWrite && index < pets.length - 1 && !options.shouldCancel?.()) {
+      await sleep(interRequestDelayMs);
     }
   }
 

--- a/src/lib/stores/bulkShare.svelte.ts
+++ b/src/lib/stores/bulkShare.svelte.ts
@@ -1,0 +1,91 @@
+/**
+ * Background bulk-share job — the "Share all pets" flow.
+ *
+ * Runs `shareService.uploadPets` fire-and-forget so the app stays interactive
+ * while a (potentially large) stable uploads. State is module-scoped, so it
+ * survives tab switches and component unmounts; the global BulkShareProgress
+ * component renders it wherever the user navigates.
+ *
+ * Throttled by default (inter-request delay + exponential backoff on Firestore
+ * `resource-exhausted`) so a few-hundred-pet share doesn't trip the Spark-plan
+ * per-second write quota.
+ */
+import { isPlaceholderConfig } from '$lib/firebase.js';
+import { type BulkUploadSummary, uploadPets } from '$lib/services/shareService.js';
+import type { Pet } from '$lib/types/index.js';
+
+/** Pause between pets. Conservative: ~6–7 writes/s keeps clear of Spark limits. */
+const SHARE_ALL_DELAY_MS = 150;
+/** Retries per pet on a quota breach before it's marked failed. */
+const SHARE_ALL_QUOTA_RETRIES = 5;
+
+export type BulkShareStatus = 'idle' | 'running' | 'done';
+
+export const bulkShareJob = $state({
+  status: 'idle' as BulkShareStatus,
+  total: 0,
+  done: 0,
+  summary: null as BulkUploadSummary | null,
+  /** Batch-wide failure (e.g. genome loader threw); per-pet errors live in `summary`. */
+  error: null as string | null,
+});
+
+let cancelRequested = false;
+
+/** Fraction complete, 0–100. */
+export function bulkSharePercent(): number {
+  return bulkShareJob.total > 0 ? Math.round((bulkShareJob.done / bulkShareJob.total) * 100) : 0;
+}
+
+/**
+ * Start sharing `pets` in the background. No-op when a job is already running,
+ * the list is empty, or this build can't reach the catalogue. Does NOT await the
+ * upload — returns once the job is kicked off; callers read `bulkShareJob`.
+ */
+export function startBulkShare(pets: Pet[]): void {
+  if (bulkShareJob.status === 'running' || pets.length === 0 || isPlaceholderConfig) return;
+
+  cancelRequested = false;
+  bulkShareJob.status = 'running';
+  bulkShareJob.total = pets.length;
+  bulkShareJob.done = 0;
+  bulkShareJob.summary = null;
+  bulkShareJob.error = null;
+
+  // Notes are intentionally dropped from bulk shares — there's no per-pet
+  // review step, so the local notes field is never published (mirrors
+  // BulkSharePetDialog). Per-pet sharing remains the way to opt notes in.
+  const petsToShare = pets.map((p) => ({ ...p, notes: '' }));
+
+  void (async () => {
+    try {
+      bulkShareJob.summary = await uploadPets(petsToShare, {
+        interRequestDelayMs: SHARE_ALL_DELAY_MS,
+        maxQuotaRetries: SHARE_ALL_QUOTA_RETRIES,
+        onProgress: (d) => {
+          bulkShareJob.done = d;
+        },
+        shouldCancel: () => cancelRequested,
+      });
+    } catch (err) {
+      bulkShareJob.error = err instanceof Error ? err.message : String(err);
+    } finally {
+      bulkShareJob.status = 'done';
+    }
+  })();
+}
+
+/** Request cancellation; pets already uploaded stay shared. */
+export function cancelBulkShare(): void {
+  cancelRequested = true;
+}
+
+/** Clear a finished job's banner. No-op while running. */
+export function dismissBulkShare(): void {
+  if (bulkShareJob.status !== 'done') return;
+  bulkShareJob.status = 'idle';
+  bulkShareJob.summary = null;
+  bulkShareJob.error = null;
+  bulkShareJob.total = 0;
+  bulkShareJob.done = 0;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 import '../app.css';
 import { onDestroy, onMount, type Snippet } from 'svelte';
 import AuthWrapper from '$lib/components/AuthWrapper.svelte';
+import BulkShareProgress from '$lib/components/community/BulkShareProgress.svelte';
 import TopBar from '$lib/components/layout/TopBar.svelte';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { applyFontScale, clampScale, getFontScale, STEP } from '$lib/utils/fontScale.js';
@@ -70,6 +71,7 @@ $effect(() => {
             </main>
         </div>
     </div>
+    <BulkShareProgress />
 </AuthWrapper>
 
 <style>

--- a/tests/e2e/shareAll.spec.ts
+++ b/tests/e2e/shareAll.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+import { blockFirestore, gotoDestination, waitForPets } from './helpers.js';
+
+// "Share all pets" — the background bulk-share flow. Firestore is blocked so no
+// real writes happen; we assert the trigger, confirm gate, and the global,
+// non-blocking progress widget (which lives at the layout root so it survives
+// navigation). Actual upload success is covered by unit tests.
+
+test.describe('Share all pets', () => {
+  test.beforeEach(async ({ page }) => {
+    await blockFirestore(page);
+    await page.goto('/');
+    await waitForPets(page);
+  });
+
+  test('button opens a confirm dialog that Cancel dismisses without sharing', async ({ page }) => {
+    await page.locator('[data-testid="mypets-share-all"]').click();
+    const dialog = page.locator('[data-testid="share-all-dialog"]');
+    await expect(dialog).toBeVisible();
+    // Confirm copy spells out "every pet", not the Stabled subset.
+    await expect(dialog).toContainText('every pet in your collection');
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).not.toBeVisible();
+    await expect(page.locator('[data-testid="bulk-share-progress-global"]')).toHaveCount(0);
+  });
+
+  test('confirming starts a non-blocking job whose progress survives navigation', async ({ page }) => {
+    await page.locator('[data-testid="mypets-share-all"]').click();
+    await page.locator('[data-testid="share-all-confirm"]').click();
+
+    // Global, non-modal progress widget appears with a progress bar.
+    const progress = page.locator('[data-testid="bulk-share-progress-global"]');
+    await expect(progress).toBeVisible();
+    await expect(progress.locator('[role="progressbar"]')).toBeVisible();
+
+    // The app stays interactive while it runs: switch destinations and back.
+    // The widget lives at the layout root, so it persists across navigation —
+    // the defining property of a background job.
+    await gotoDestination(page, 'Community');
+    await expect(progress).toBeVisible();
+    await gotoDestination(page, 'My Pets');
+    await expect(progress).toBeVisible();
+  });
+});

--- a/tests/unit/bulkShare.test.ts
+++ b/tests/unit/bulkShare.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pet } from '$lib/types/index.js';
+
+const h = vi.hoisted(() => ({ placeholder: false }));
+
+vi.mock('$lib/firebase.js', () => ({
+  get isPlaceholderConfig() {
+    return h.placeholder;
+  },
+}));
+vi.mock('$lib/services/shareService.js', () => ({ uploadPets: vi.fn() }));
+
+import { uploadPets } from '$lib/services/shareService.js';
+import {
+  bulkShareJob,
+  bulkSharePercent,
+  cancelBulkShare,
+  dismissBulkShare,
+  startBulkShare,
+} from '$lib/stores/bulkShare.svelte.js';
+
+const uploadPetsMock = vi.mocked(uploadPets);
+const pet = (id: number, notes = `note-${id}`) => ({ id, name: `Pet ${id}`, notes }) as unknown as Pet;
+const summary = (over = {}) => ({ created: 0, alreadyShared: 0, skipped: 0, failed: 0, items: [], ...over }) as never;
+
+function resetJob() {
+  bulkShareJob.status = 'idle';
+  bulkShareJob.total = 0;
+  bulkShareJob.done = 0;
+  bulkShareJob.summary = null;
+  bulkShareJob.error = null;
+}
+
+describe('bulkShare store', () => {
+  beforeEach(() => {
+    uploadPetsMock.mockReset();
+    uploadPetsMock.mockResolvedValue(summary({ created: 1 }));
+    h.placeholder = false;
+    resetJob();
+  });
+
+  it('starts a background job: running synchronously, then done with summary', async () => {
+    uploadPetsMock.mockImplementation(async (pets, opts) => {
+      opts?.onProgress?.(pets.length, pets.length);
+      return summary({ created: pets.length });
+    });
+
+    startBulkShare([pet(1), pet(2)]);
+    // Synchronously running before the upload promise settles.
+    expect(bulkShareJob.status).toBe('running');
+    expect(bulkShareJob.total).toBe(2);
+
+    await vi.waitFor(() => expect(bulkShareJob.status).toBe('done'));
+    expect(bulkShareJob.done).toBe(2);
+    expect(bulkShareJob.summary).toEqual(summary({ created: 2 }));
+  });
+
+  it('strips notes and passes throttle options', async () => {
+    startBulkShare([pet(1, 'secret'), pet(2, 'also secret')]);
+    await vi.waitFor(() => expect(bulkShareJob.status).toBe('done'));
+
+    const [petsArg, opts] = uploadPetsMock.mock.calls[0];
+    expect(petsArg.every((p) => p.notes === '')).toBe(true);
+    expect(opts?.interRequestDelayMs).toBeGreaterThan(0);
+    expect(opts?.maxQuotaRetries).toBeGreaterThan(0);
+  });
+
+  it('is a no-op when Firebase is not configured', () => {
+    h.placeholder = true;
+    startBulkShare([pet(1)]);
+    expect(bulkShareJob.status).toBe('idle');
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for an empty list', () => {
+    startBulkShare([]);
+    expect(bulkShareJob.status).toBe('idle');
+    expect(uploadPetsMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a second start while one is already running', async () => {
+    let release!: () => void;
+    uploadPetsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(summary());
+        }),
+    );
+    startBulkShare([pet(1)]);
+    startBulkShare([pet(2)]); // should be ignored
+    expect(uploadPetsMock).toHaveBeenCalledTimes(1);
+    release();
+    await vi.waitFor(() => expect(bulkShareJob.status).toBe('done'));
+  });
+
+  it('cancel sets shouldCancel true for the running job', async () => {
+    let captured: (() => boolean) | undefined;
+    uploadPetsMock.mockImplementation(async (_pets, opts) => {
+      captured = opts?.shouldCancel;
+      return summary();
+    });
+    startBulkShare([pet(1)]);
+    await vi.waitFor(() => expect(captured).toBeDefined());
+    cancelBulkShare();
+    expect(captured?.()).toBe(true);
+  });
+
+  it('records a batch-wide failure', async () => {
+    uploadPetsMock.mockRejectedValue(new Error('loader exploded'));
+    startBulkShare([pet(1)]);
+    await vi.waitFor(() => expect(bulkShareJob.status).toBe('done'));
+    expect(bulkShareJob.error).toBe('loader exploded');
+  });
+
+  it('dismiss resets a finished job, but not a running one', async () => {
+    let release!: () => void;
+    uploadPetsMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(summary());
+        }),
+    );
+    startBulkShare([pet(1)]);
+    dismissBulkShare(); // running → ignored
+    expect(bulkShareJob.status).toBe('running');
+    release();
+    await vi.waitFor(() => expect(bulkShareJob.status).toBe('done'));
+    dismissBulkShare();
+    expect(bulkShareJob.status).toBe('idle');
+    expect(bulkShareJob.summary).toBeNull();
+  });
+
+  it('bulkSharePercent reflects progress', () => {
+    bulkShareJob.total = 4;
+    bulkShareJob.done = 1;
+    expect(bulkSharePercent()).toBe(25);
+    bulkShareJob.total = 0;
+    expect(bulkSharePercent()).toBe(0);
+  });
+});

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -890,4 +890,86 @@ describe('shareService.uploadPets', () => {
     expect(summary.items).toHaveLength(2);
     expect(upload).toHaveBeenCalledTimes(2);
   });
+
+  // Quota / throttle behaviour. `sleep` is injected so these are instant and
+  // can assert the exact delays the throttle/backoff would have waited.
+  const quotaError = () => Object.assign(new Error('quota exceeded'), { code: 'resource-exhausted' });
+
+  it('throttles between network writes but never after the last pet', async () => {
+    const pets = [pet(1), pet(2), pet(3)];
+    const sleeps: number[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      sleeps.push(ms);
+    });
+
+    await uploadPets(pets, { upload: fakeUpload({}), loadGenomeText: vi.fn(), interRequestDelayMs: 50, sleep });
+
+    expect(sleeps).toEqual([50, 50]); // after pets 1 and 2, not 3
+  });
+
+  it('does not throttle after a skipped pet (no network write)', async () => {
+    const pets = [pet(1, { genome_text: undefined }), pet(2)];
+    const sleep = vi.fn(async () => {});
+    // pet 1 has no genome text → skipped → no throttle; pet 2 is last → no throttle.
+    await uploadPets(pets, {
+      upload: fakeUpload({}),
+      loadGenomeText: vi.fn().mockResolvedValue(''),
+      interRequestDelayMs: 50,
+      sleep,
+    });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('retries a quota error with exponential backoff, then succeeds', async () => {
+    const sleeps: number[] = [];
+    const sleep = vi.fn(async (ms: number) => {
+      sleeps.push(ms);
+    });
+    const upload = vi
+      .fn<(p: Pet) => Promise<UploadResult>>()
+      .mockRejectedValueOnce(quotaError())
+      .mockRejectedValueOnce(quotaError())
+      .mockResolvedValueOnce({ status: 'created', contentHash: 'h1' });
+
+    const summary = await uploadPets([pet(1)], {
+      upload,
+      loadGenomeText: vi.fn(),
+      maxQuotaRetries: 5,
+      quotaBackoffBaseMs: 1000,
+      sleep,
+    });
+
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(sleeps).toEqual([1000, 2000]); // 1000 * 2**0, 1000 * 2**1
+    expect(summary.created).toBe(1);
+    expect(summary.failed).toBe(0);
+  });
+
+  it('gives up after maxQuotaRetries and marks the pet failed', async () => {
+    const sleep = vi.fn(async () => {});
+    const upload = vi.fn<(p: Pet) => Promise<UploadResult>>().mockRejectedValue(quotaError());
+
+    const summary = await uploadPets([pet(1)], {
+      upload,
+      loadGenomeText: vi.fn(),
+      maxQuotaRetries: 2,
+      quotaBackoffBaseMs: 1000,
+      sleep,
+    });
+
+    expect(upload).toHaveBeenCalledTimes(3); // initial + 2 retries
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(summary.failed).toBe(1);
+  });
+
+  it('does not retry a non-quota error', async () => {
+    const sleep = vi.fn(async () => {});
+    const upload = vi.fn<(p: Pet) => Promise<UploadResult>>().mockRejectedValue(new Error('corrupt row'));
+
+    const summary = await uploadPets([pet(1)], { upload, loadGenomeText: vi.fn(), maxQuotaRetries: 5, sleep });
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(summary.failed).toBe(1);
+  });
 });


### PR DESCRIPTION
Follow-up to #363/#364 — the deferred "share my existing stable" action. Per the clarification, **"all" means every pet, not the Stabled subset**; the button label and confirm copy spell that out to avoid conflating it with the Stabled flag.

## What

- **`🌐 Share all`** button in the My Pets footer → confirm dialog ("Share all N pets… every pet in your collection, not just stabled ones") → starts a background bulk share of `$pets`.
- **Background, non-blocking**: a `bulkShare` store runs `uploadPets` fire-and-forget; the app stays fully interactive.
- **Global progress widget** (`BulkShareProgress`) mounted at the layout root, so it persists across destination switches. Shows count + progress bar + Cancel while running, then a dismissible summary (created / already-shared / skipped / failed).
- **Throttling for quota**: `uploadPets` gains `interRequestDelayMs` (paced writes) and `maxQuotaRetries` + exponential backoff on Firestore `resource-exhausted`. The job applies both by default (150ms spacing, 5 retries) to stay under the Spark per-second write quota on large stables.

Reuses the existing `uploadPets` path, so it inherits per-pet error isolation, `content_hash` dedupe (already-shared), and legacy-genome skip. Notes are dropped from bulk shares (mirrors `BulkSharePetDialog`).

## Tests

- `shareService.test.ts`: throttle spacing (between writes, never after the last, skipped pets don't pace); quota backoff retries then succeeds; gives up after `maxQuotaRetries` → failed; non-quota errors aren't retried.
- `bulkShare.test.ts`: running→done lifecycle, notes stripped + throttle options passed, no-op when not configured / empty / already running, cancel wiring, batch-failure capture, dismiss semantics, percent.
- `shareAll.spec.ts` (e2e): confirm gate + Cancel; confirming starts the job and the global progress widget survives navigation between destinations (proving it's non-blocking).

Full unit suite (751) green; `svelte-check` and `lint:ci` clean.

## Note

Independent of #364 (no file overlap) — both branch off the epic and merge cleanly. If #364 merges first, this is unaffected.

Known limitation: if a single pet's write hangs while offline, Cancel can't interrupt that in-flight request until the SDK settles it (same behaviour as the existing bulk-share dialog). The SDK does eventually reject with `unavailable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)