### PR TITLE
Extract shared GeneFilterPills for the genome grids

### DIFF
--- a/src/lib/components/breeding/TrioView.svelte
+++ b/src/lib/components/breeding/TrioView.svelte
@@ -34,7 +34,7 @@ const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
     {/if}
   {/snippet}
 
-  <div class="trio-scroll">
+  <div class="trio-body">
     <GenomeGridTrio {father} {mother} {offspringBreed} />
   </div>
 </DetailOverlay>
@@ -55,11 +55,13 @@ const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
     white-space: nowrap;
   }
 
-  /* The wide grid scrolls on its own inside the overlay body. */
-  .trio-scroll {
+  /* Fill the overlay body; the grid itself owns the single scroll region so the
+     filters / summary stay pinned above it (no nested double scrollbar). */
+  .trio-body {
     flex: 1;
     min-height: 0;
-    overflow: auto;
+    display: flex;
+    flex-direction: column;
     padding: 16px 20px;
   }
 </style>

--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
 import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 
@@ -51,6 +52,18 @@ const {
   onResetAppearances,
   onViewChange,
 }: Props = $props();
+
+const attributeItems = $derived<FilterPillItem[]>(
+  attributeDisplayInfo.map((a) => ({ key: a.key, name: a.name, icon: a.icon })),
+);
+const appearanceItems = $derived<FilterPillItem[]>(
+  appearanceDisplayInfo.map((a) => ({
+    key: a.key,
+    name: a.name,
+    swatch: a.color_indicator,
+    title: a.examples ? `${a.name} — ${a.examples}` : a.name,
+  })),
+);
 </script>
 
 <div class="diff-controls">
@@ -80,35 +93,24 @@ const {
         </div>
     {/if}
     {#if currentView === 'attribute'}
-        <div class="attribute-filter">
-            <span class="attr-filter-label">Attribute:</span>
-            <button class="attr-filter-btn" class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0} onclick={onResetAttributes}>All</button>
-            {#each attributeDisplayInfo as attr (attr.key)}
-                <button
-                    class="attr-filter-btn"
-                    class:active={selectedAttributes.includes(attr.key)}
-                    class:hidden-attr={hiddenAttributes.includes(attr.key)}
-                    onclick={(e) => onAttributeToggle(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
-                    title="{attr.name}"
-                >{attr.icon} {attr.name}</button>
-            {/each}
-        </div>
+        <GeneFilterPills
+            label="Attribute"
+            items={attributeItems}
+            selected={selectedAttributes}
+            hidden={hiddenAttributes}
+            onToggle={onAttributeToggle}
+            onReset={onResetAttributes}
+        />
     {/if}
-    {#if currentView === 'appearance' && appearanceDisplayInfo.length > 0}
-        <div class="attribute-filter appearance-filter">
-            <span class="attr-filter-label">Appearance:</span>
-            <button class="attr-filter-btn" class:active={selectedAppearances.length === 0 && hiddenAppearances.length === 0} onclick={onResetAppearances}>All</button>
-            {#each appearanceDisplayInfo as ap (ap.key)}
-                <button
-                    class="attr-filter-btn appearance-btn"
-                    class:active={selectedAppearances.includes(ap.key)}
-                    class:hidden-attr={hiddenAppearances.includes(ap.key)}
-                    style:--ap-color={ap.color_indicator}
-                    onclick={(e) => onAppearanceToggle(ap.key, e.ctrlKey || e.metaKey, e.altKey)}
-                    title="{ap.name}{ap.examples ? ' — ' + ap.examples : ''}"
-                ><span class="ap-swatch"></span>{ap.name}</button>
-            {/each}
-        </div>
+    {#if currentView === 'appearance' && appearanceItems.length > 0}
+        <GeneFilterPills
+            label="Appearance"
+            items={appearanceItems}
+            selected={selectedAppearances}
+            hidden={hiddenAppearances}
+            onToggle={onAppearanceToggle}
+            onReset={onResetAppearances}
+        />
     {/if}
 </div>
 
@@ -137,16 +139,7 @@ const {
     .auto-btn.active { background: #22c55e; border-color: #22c55e; color: var(--bg-primary); }
     .breed-divider { width: 1px; height: 16px; background: var(--border-primary); margin: 0 2px; }
 
-    .attribute-filter { display: flex; align-items: center; gap: 3px; flex-wrap: wrap; padding: 0 4px; }
-    .attr-filter-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
-    .attr-filter-btn { padding: 3px 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; white-space: nowrap; }
-    .attr-filter-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
-    .attr-filter-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
-    .attr-filter-btn.hidden-attr { background: var(--error-bg); border-color: var(--error-border); color: var(--error-text); text-decoration: line-through; }
-
-    .appearance-filter { margin-top: 2px; }
-    .appearance-btn { display: inline-flex; align-items: center; gap: 5px; }
-    .ap-swatch { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: var(--ap-color, #6b7280); border: 1px solid rgba(0, 0, 0, 0.2); }
+    /* Attribute / appearance tri-state pills now live in GeneFilterPills. */
 
     .grid-instructions { font-size: 11px; color: var(--text-tertiary); margin-bottom: 6px; font-style: italic; padding: 0 4px; }
 </style>

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -270,13 +270,16 @@ function parentTitle(cell: GeneCell | null, label: string) {
 </div>
 
 <style>
-    .genome-grid-trio { width: 100%; }
+    /* Flex column so the grid-container can be the single scroll region while
+       the filters + summary stay pinned above it. */
+    .genome-grid-trio { width: 100%; height: 100%; display: flex; flex-direction: column; min-height: 0; }
 
     .trio-filters {
         display: flex;
         flex-direction: column;
         gap: 6px;
         margin-bottom: 12px;
+        flex-shrink: 0;
     }
     /* Attribute tri-state pills now live in GeneFilterPills. */
     .breed-filter {
@@ -313,6 +316,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
         gap: 8px;
         margin-bottom: 10px;
         flex-wrap: wrap;
+        flex-shrink: 0;
     }
     .chip {
         font-size: 12px;
@@ -331,6 +335,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
     .swatch-risk { border: 2px solid var(--gene-negative); }
 
     .grid-container {
+        flex: 1;
+        min-height: 0;
         overflow: auto;
         border: 1px solid var(--border-primary);
         border-radius: 6px;

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount, untrack } from 'svelte';
+import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
@@ -27,6 +28,9 @@ let error = $state<string | null>(null);
 let grid = $state<TrioGrid | null>(null);
 let summary = $state<OffspringTrioResult['summary'] | null>(null);
 let attributeDisplayInfo = $state<AttributeInfo[]>([]);
+const attributeItems = $derived<FilterPillItem[]>(
+  attributeDisplayInfo.map((a) => ({ key: a.key, name: a.name, icon: a.icon })),
+);
 
 // Breed re-runs the projection (the service drops loci locked to other breeds,
 // keeping the trio consistent with the breeding ranking). Attribute is a visual
@@ -153,27 +157,17 @@ function parentTitle(cell: GeneCell | null, label: string) {
                     {/each}
                 </div>
             {/if}
-            {#if attributeDisplayInfo.length > 0}
-                <div class="attribute-filter" data-testid="trio-attribute-filter">
-                    <span class="attr-filter-label">Attribute:</span>
-                    <button
-                        type="button"
-                        class="attr-filter-btn"
-                        class:active={selectedAttributes.length === 0 && hiddenAttributes.length === 0}
-                        onclick={() => { selectedAttributes = []; hiddenAttributes = []; }}
-                    >All</button>
-                    {#each attributeDisplayInfo as attr (attr.key)}
-                        <button
-                            type="button"
-                            class="attr-filter-btn"
-                            class:active={selectedAttributes.includes(attr.key)}
-                            class:hidden-attr={hiddenAttributes.includes(attr.key)}
-                            onclick={(e) => toggleAttributeFilter(attr.key, e.ctrlKey || e.metaKey, e.altKey)}
-                            title={attr.name}
-                        >{attr.icon} {attr.name}</button>
-                    {/each}
-                </div>
-                <span class="filter-hint">Click to focus · Ctrl+click multi-select · Alt+click hide</span>
+            {#if attributeItems.length > 0}
+                <GeneFilterPills
+                    label="Attribute"
+                    items={attributeItems}
+                    selected={selectedAttributes}
+                    hidden={hiddenAttributes}
+                    onToggle={toggleAttributeFilter}
+                    onReset={() => { selectedAttributes = []; hiddenAttributes = []; }}
+                    hint="Click to focus · Ctrl+click multi-select · Alt+click hide"
+                    testid="trio-attribute-filter"
+                />
             {/if}
         </div>
     {/if}
@@ -284,23 +278,21 @@ function parentTitle(cell: GeneCell | null, label: string) {
         gap: 6px;
         margin-bottom: 12px;
     }
-    .breed-filter,
-    .attribute-filter {
+    /* Attribute tri-state pills now live in GeneFilterPills. */
+    .breed-filter {
         display: flex;
         align-items: center;
         gap: 3px;
         flex-wrap: wrap;
         padding: 0 4px;
     }
-    .breed-label,
-    .attr-filter-label {
+    .breed-label {
         font-size: 11px;
         font-weight: 600;
         color: var(--text-tertiary);
         margin-right: 4px;
     }
-    .breed-btn,
-    .attr-filter-btn {
+    .breed-btn {
         padding: 3px 8px;
         border: 1px solid var(--border-primary);
         border-radius: 4px;
@@ -312,17 +304,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
         transition: all 0.15s;
         white-space: nowrap;
     }
-    .breed-btn:hover,
-    .attr-filter-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
-    .breed-btn.active,
-    .attr-filter-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
-    .attr-filter-btn.hidden-attr {
-        background: var(--error-bg);
-        border-color: var(--error-border);
-        color: var(--error-text);
-        text-decoration: line-through;
-    }
-    .filter-hint { font-size: 11px; color: var(--text-tertiary); font-style: italic; padding: 0 4px; }
+    .breed-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
+    .breed-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
 
     .trio-summary {
         display: flex;

--- a/src/lib/components/shared/GeneFilterPills.svelte
+++ b/src/lib/components/shared/GeneFilterPills.svelte
@@ -1,0 +1,105 @@
+<script lang="ts" module>
+export interface FilterPillItem {
+  /** Stable key used by the tri-state filter (attribute/appearance key). */
+  key: string;
+  /** Visible label. */
+  name: string;
+  /** Emoji/icon shown before the name (attributes). */
+  icon?: string;
+  /** Colour swatch shown before the name (appearances). */
+  swatch?: string;
+  /** Tooltip; defaults to `name`. */
+  title?: string;
+}
+</script>
+
+<script lang="ts">
+/**
+ * One tri-state focus/hide filter row for the genome grids. A reset ("All")
+ * pill plus one pill per category: click to focus, Ctrl/⌘+click to multi-select,
+ * Alt+click to hide. The pill set previously lived (identically) in both the
+ * Compare diff controls and the Trio view; this is the single shared surface.
+ * See docs/design/redesign-library-workspace-v1.md (§3, component unification).
+ *
+ * Presentational only — the caller owns the selected/hidden arrays and the
+ * triStateToggle logic, so the same row serves attributes (icon) and
+ * appearances (colour swatch).
+ */
+interface Props {
+  /** Row label, e.g. "Attribute" or "Appearance". */
+  label: string;
+  items: FilterPillItem[];
+  selected: string[];
+  hidden: string[];
+  onToggle: (key: string, ctrlKey: boolean, altKey: boolean) => void;
+  onReset: () => void;
+  /** Optional interaction hint rendered under the row. */
+  hint?: string;
+  testid?: string;
+}
+
+const { label, items, selected, hidden, onToggle, onReset, hint, testid }: Props = $props();
+
+const allActive = $derived(selected.length === 0 && hidden.length === 0);
+</script>
+
+<div class="gfp" data-testid={testid}>
+  <div class="gfp-row">
+    <span class="gfp-label">{label}:</span>
+    <button type="button" class="gfp-btn" class:active={allActive} onclick={onReset}>All</button>
+    {#each items as item (item.key)}
+      <button
+        type="button"
+        class="gfp-btn"
+        class:active={selected.includes(item.key)}
+        class:hidden-pill={hidden.includes(item.key)}
+        style:--swatch-color={item.swatch ?? undefined}
+        onclick={(e) => onToggle(item.key, e.ctrlKey || e.metaKey, e.altKey)}
+        title={item.title ?? item.name}
+      >
+        {#if item.swatch}<span class="gfp-swatch"></span>{:else if item.icon}{item.icon}&nbsp;{/if}{item.name}
+      </button>
+    {/each}
+  </div>
+  {#if hint}
+    <span class="gfp-hint">{hint}</span>
+  {/if}
+</div>
+
+<style>
+  .gfp { display: flex; flex-direction: column; gap: 4px; }
+  .gfp-row { display: flex; align-items: center; gap: 3px; flex-wrap: wrap; padding: 0 4px; }
+  .gfp-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
+  .gfp-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 8px;
+    border: 1px solid var(--border-primary);
+    border-radius: 4px;
+    background: var(--bg-primary);
+    color: var(--text-tertiary);
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+    white-space: nowrap;
+  }
+  .gfp-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
+  .gfp-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
+  .gfp-btn.hidden-pill {
+    background: var(--error-bg);
+    border-color: var(--error-border);
+    color: var(--error-text);
+    text-decoration: line-through;
+  }
+  .gfp-swatch {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--swatch-color, #6b7280);
+    border: 1px solid rgba(0, 0, 0, 0.2);
+  }
+  .gfp-hint { font-size: 11px; color: var(--text-tertiary); font-style: italic; padding: 0 4px; }
+</style>

--- a/src/lib/components/shared/GeneFilterPills.svelte
+++ b/src/lib/components/shared/GeneFilterPills.svelte
@@ -44,15 +44,16 @@ const allActive = $derived(selected.length === 0 && hidden.length === 0);
 </script>
 
 <div class="gfp" data-testid={testid}>
-  <div class="gfp-row">
+  <div class="gfp-row" role="group" aria-label={label}>
     <span class="gfp-label">{label}:</span>
-    <button type="button" class="gfp-btn" class:active={allActive} onclick={onReset}>All</button>
+    <button type="button" class="gfp-btn" class:active={allActive} aria-pressed={allActive} onclick={onReset}>All</button>
     {#each items as item (item.key)}
       <button
         type="button"
         class="gfp-btn"
         class:active={selected.includes(item.key)}
         class:hidden-pill={hidden.includes(item.key)}
+        aria-pressed={hidden.includes(item.key) ? 'mixed' : selected.includes(item.key)}
         style:--swatch-color={item.swatch}
         onclick={(e) => onToggle(item.key, e.ctrlKey || e.metaKey, e.altKey)}
         title={item.title ?? item.name}

--- a/src/lib/components/shared/GeneFilterPills.svelte
+++ b/src/lib/components/shared/GeneFilterPills.svelte
@@ -53,11 +53,14 @@ const allActive = $derived(selected.length === 0 && hidden.length === 0);
         class="gfp-btn"
         class:active={selected.includes(item.key)}
         class:hidden-pill={hidden.includes(item.key)}
-        style:--swatch-color={item.swatch ?? undefined}
+        style:--swatch-color={item.swatch}
         onclick={(e) => onToggle(item.key, e.ctrlKey || e.metaKey, e.altKey)}
         title={item.title ?? item.name}
       >
-        {#if item.swatch}<span class="gfp-swatch"></span>{:else if item.icon}{item.icon}&nbsp;{/if}{item.name}
+        <!-- Swatch wins when defined (incl. ""→grey fallback, matching the
+             appearance grid); otherwise an icon. Both are their own flex item so
+             the row gap spaces them from the label identically. -->
+        {#if item.swatch != null}<span class="gfp-swatch"></span>{:else if item.icon}<span class="gfp-icon" aria-hidden="true">{item.icon}</span>{/if}{item.name}
       </button>
     {/each}
   </div>

--- a/tests/unit/geneFilterPills.test.ts
+++ b/tests/unit/geneFilterPills.test.ts
@@ -105,6 +105,25 @@ describe('GeneFilterPills', () => {
     expect(pill(container, 'Coat').querySelector('.gfp-swatch')).toBeInTheDocument();
   });
 
+  it('exposes tri-state via aria-pressed (true=focus, mixed=hidden, false=neither)', () => {
+    const { container } = setup({ selected: ['toughness'], hidden: ['intelligence'] });
+    expect(pill(container, 'Toughness')).toHaveAttribute('aria-pressed', 'true');
+    expect(pill(container, 'Intelligence')).toHaveAttribute('aria-pressed', 'mixed');
+  });
+
+  it('marks a neutral pill aria-pressed=false and All pressed when nothing is filtered', () => {
+    const { container } = setup();
+    expect(pill(container, 'Toughness')).toHaveAttribute('aria-pressed', 'false');
+    expect(pill(container, 'All')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('groups the row as a labelled ARIA group', () => {
+    const { container } = setup();
+    const row = container.querySelector('.gfp-row');
+    expect(row).toHaveAttribute('role', 'group');
+    expect(row).toHaveAttribute('aria-label', 'Attribute');
+  });
+
   it('renders the interaction hint when provided', () => {
     const { container } = setup({ hint: 'Click to focus' });
     expect(container.querySelector('.gfp-hint')?.textContent).toContain('Click to focus');

--- a/tests/unit/geneFilterPills.test.ts
+++ b/tests/unit/geneFilterPills.test.ts
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
+
+// The shared tri-state focus/hide filter row used by the Compare diff controls
+// (attributes + appearances) and the Trio view (attributes). Click = focus,
+// Ctrl/⌘+click = multi-select, Alt+click = hide. The component is
+// presentational; the caller owns selected/hidden + the toggle logic.
+
+const ITEMS: FilterPillItem[] = [
+  { key: 'toughness', name: 'Toughness', icon: '💪' },
+  { key: 'intelligence', name: 'Intelligence', icon: '🧠' },
+];
+
+const APPEARANCE_ITEMS: FilterPillItem[] = [{ key: 'coat', name: 'Coat', swatch: '#e74c3c' }];
+
+function setup(overrides: Record<string, unknown> = {}) {
+  const onToggle = vi.fn();
+  const onReset = vi.fn();
+  const { container } = render(GeneFilterPills, {
+    label: 'Attribute',
+    items: ITEMS,
+    selected: [],
+    hidden: [],
+    onToggle,
+    onReset,
+    ...overrides,
+  } as never);
+  return { container, onToggle, onReset };
+}
+
+const pills = (c: HTMLElement) => [...c.querySelectorAll('.gfp-btn')] as HTMLButtonElement[];
+const pill = (c: HTMLElement, name: string) => pills(c).find((b) => b.textContent?.includes(name)) as HTMLButtonElement;
+
+afterEach(cleanup);
+
+describe('GeneFilterPills', () => {
+  it('renders an All reset pill plus one pill per item', () => {
+    const { container } = setup();
+    const labels = pills(container).map((b) => b.textContent?.trim());
+    expect(labels[0]).toBe('All');
+    expect(labels.some((l) => l?.includes('Toughness'))).toBe(true);
+    expect(labels.some((l) => l?.includes('Intelligence'))).toBe(true);
+    expect(pills(container)).toHaveLength(3);
+  });
+
+  it('plain click focuses (no modifier flags)', async () => {
+    const { container, onToggle } = setup();
+    await fireEvent.click(pill(container, 'Toughness'));
+    expect(onToggle).toHaveBeenCalledWith('toughness', false, false);
+  });
+
+  it('Ctrl/⌘+click multi-selects', async () => {
+    const { container, onToggle } = setup();
+    await fireEvent.click(pill(container, 'Intelligence'), { ctrlKey: true });
+    expect(onToggle).toHaveBeenCalledWith('intelligence', true, false);
+    await fireEvent.click(pill(container, 'Intelligence'), { metaKey: true });
+    expect(onToggle).toHaveBeenLastCalledWith('intelligence', true, false);
+  });
+
+  it('Alt+click hides', async () => {
+    const { container, onToggle } = setup();
+    await fireEvent.click(pill(container, 'Toughness'), { altKey: true });
+    expect(onToggle).toHaveBeenCalledWith('toughness', false, true);
+  });
+
+  it('clicking All calls onReset, not onToggle', async () => {
+    const { container, onToggle, onReset } = setup();
+    await fireEvent.click(pill(container, 'All'));
+    expect(onReset).toHaveBeenCalledOnce();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('reflects selected/hidden as active / hidden-pill classes', () => {
+    const { container } = setup({ selected: ['toughness'], hidden: ['intelligence'] });
+    expect(pill(container, 'Toughness')).toHaveClass('active');
+    expect(pill(container, 'Intelligence')).toHaveClass('hidden-pill');
+    // With a selection active, the All pill is no longer the active one.
+    expect(pill(container, 'All')).not.toHaveClass('active');
+  });
+
+  it('All is active only when nothing is selected or hidden', () => {
+    const { container } = setup();
+    expect(pill(container, 'All')).toHaveClass('active');
+  });
+
+  it('renders a colour swatch for appearance-style items', () => {
+    const { container } = setup({ label: 'Appearance', items: APPEARANCE_ITEMS });
+    const coat = pill(container, 'Coat');
+    expect(coat.querySelector('.gfp-swatch')).toBeInTheDocument();
+    // The colour var is set on the pill; the swatch span reads it via var().
+    expect(coat.style.getPropertyValue('--swatch-color')).toBe('#e74c3c');
+  });
+
+  it('renders the interaction hint when provided', () => {
+    const { container } = setup({ hint: 'Click to focus' });
+    expect(container.querySelector('.gfp-hint')?.textContent).toContain('Click to focus');
+  });
+});

--- a/tests/unit/geneFilterPills.test.ts
+++ b/tests/unit/geneFilterPills.test.ts
@@ -93,6 +93,18 @@ describe('GeneFilterPills', () => {
     expect(coat.style.getPropertyValue('--swatch-color')).toBe('#e74c3c');
   });
 
+  it('renders the icon as its own element so the row gap spaces it from the label', () => {
+    const { container } = setup();
+    const icon = pill(container, 'Toughness').querySelector('.gfp-icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon?.textContent).toBe('💪');
+  });
+
+  it('still renders a swatch for an empty colour (grey fallback, matching the grid)', () => {
+    const { container } = setup({ label: 'Appearance', items: [{ key: 'coat', name: 'Coat', swatch: '' }] });
+    expect(pill(container, 'Coat').querySelector('.gfp-swatch')).toBeInTheDocument();
+  });
+
   it('renders the interaction hint when provided', () => {
     const { container } = setup({ hint: 'Click to focus' });
     expect(container.querySelector('.gfp-hint')?.textContent).toContain('Click to focus');


### PR DESCRIPTION
## What

Follow-up to #370. The genome grids each re-implemented the same tri-state focus/hide filter row (click = focus, Ctrl/⌘+click = multi-select, Alt+click = hide) — identical markup *and* CSS in the Compare diff controls and the Trio view.

- New `shared/GeneFilterPills.svelte` — one presentational tri-state pill row. Generic item shape (`{ key, name, icon?, swatch?, title? }`) serves both the icon variant (attributes) and the colour-swatch variant (appearances). Optional interaction `hint`.
- `GenomeDiffControls` (Compare) now renders its Attribute and Appearance rows through it; dead pill CSS removed.
- `GenomeGridTrio` renders its Attribute row through it (keeps the `trio-attribute-filter` testid + hint); dead pill CSS removed. The trio breed button-row is untouched here.

Filter logic is unchanged — the caller still owns `selected`/`hidden` and `triStateToggle`, and the dynamic grid-dimming CSS (`buildFilterCSS`/`attributeFilterCSS`) is untouched.

## Also fixed (separate commit)

Double scrollbar in the Trio view (a #370 regression): the overlay wrapped `GenomeGridTrio` in an `overflow:auto` body while the grid's own `.grid-container` also scrolled. Made the grid-container the sole scroller via a flex height-chain — filters + summary now stay pinned, only the grid scrolls.

## Why

§3 component-unification in `docs/design/redesign-library-workspace-v1.md`. This is the filter-row half of the "converge the grid control surfaces" follow-up.

## Verification

- New unit test `geneFilterPills.test.ts` (9 cases: reset vs toggle, modifier flags, active/hidden classes, swatch, hint). Full suite 771 passing; `svelte-check` 0 errors; Biome clean.
- Drove the app: Trio attribute pills filter the grid (e.g. Toughness → non-Toughness cells dim); Compare attribute pills render; Compare appearance pills render with the correct per-category colour swatches. Confirmed the Trio now shows a single scroll region with the filters/summary pinned.

## Next follow-up (separate PR)

Adopt the shared `BreedSelector` popover in both grids to retire the breed button rows (doc §4.1). Held back here because it's UX-visible and needs a `disabled` state for Compare's Auto-breed interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)