### PR TITLE
Adopt shared BreedSelector in the genome grids

### DIFF
--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
 import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
 import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
@@ -81,15 +82,22 @@ const appearanceItems = $derived<FilterPillItem[]>(
     </div>
     {#if isHorse}
         <div class="breed-filter">
-            <span class="breed-label">Breed:</span>
             {#if petsHaveKnownBreed}
-                <button class="breed-btn auto-btn" class:active={autoBreed} onclick={onAutoBreedToggle} title={petsShareBreed ? "Auto-select pets' breed" : "Pets have different breeds"}>Auto</button>
-                <span class="breed-divider"></span>
+                <button
+                    type="button"
+                    class="auto-btn"
+                    class:active={autoBreed}
+                    aria-pressed={autoBreed}
+                    onclick={onAutoBreedToggle}
+                    title={petsShareBreed ? "Auto-select pets' breed" : 'Pets have different breeds'}
+                >Auto</button>
             {/if}
-            <button class="breed-btn" class:active={(!autoBreed || !petsHaveKnownBreed) && breedFilter === ''} disabled={autoBreed && petsHaveKnownBreed} onclick={() => onBreedChange('')}>All</button>
-            {#each Object.entries(HORSE_BREEDS) as [name, abbrev]}
-                <button class="breed-btn" class:active={(!autoBreed || !petsHaveKnownBreed) && breedFilter === name} disabled={autoBreed && petsHaveKnownBreed} onclick={() => onBreedChange(name)} title={name}>{abbrev}</button>
-            {/each}
+            <BreedSelector
+                value={breedFilter}
+                breeds={HORSE_BREEDS}
+                disabled={autoBreed && petsHaveKnownBreed}
+                onChange={onBreedChange}
+            />
         </div>
     {/if}
     {#if currentView === 'attribute'}
@@ -130,14 +138,12 @@ const appearanceItems = $derived<FilterPillItem[]>(
     .view-btn:hover { color: var(--text-secondary); }
     .view-btn.active { background: var(--accent); color: white; }
 
-    .breed-filter { display: flex; align-items: center; gap: 3px; padding: 0 4px; }
-    .breed-label { font-size: 11px; font-weight: 600; color: var(--text-tertiary); margin-right: 4px; }
-    .breed-btn { padding: 3px 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
-    .breed-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
-    .breed-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
-    .breed-btn:disabled { opacity: 0.4; cursor: default; pointer-events: none; }
+    .breed-filter { display: flex; align-items: center; gap: 6px; padding: 0 4px; }
+    /* Auto = Compare-only mode toggle that owns the breed; the breed picker
+       itself is the shared BreedSelector popover. */
+    .auto-btn { padding: 3px 8px; border: 1px solid var(--border-primary); border-radius: 4px; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
+    .auto-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
     .auto-btn.active { background: #22c55e; border-color: #22c55e; color: var(--bg-primary); }
-    .breed-divider { width: 1px; height: 16px; background: var(--border-primary); margin: 0 2px; }
 
     /* Attribute / appearance tri-state pills now live in GeneFilterPills. */
 

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -388,7 +388,7 @@ function handleCellLeave() {
             {appearanceDisplayInfo}
             {currentView}
             onViewChange={(v) => { currentView = v; }}
-            onBreedChange={(name) => { breedFilter = breedFilter === name ? '' : name; }}
+            onBreedChange={(name) => { breedFilter = name; }}
             onAutoBreedToggle={() => {
                 manualBreedOverride = true;
                 autoBreed = !autoBreed;

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { onDestroy, onMount, untrack } from 'svelte';
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
 import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
@@ -21,7 +22,6 @@ interface Props {
 const { father, mother, offspringBreed = '' }: Props = $props();
 
 const isHorse = $derived(normalizeSpecies(father.species) === 'horse');
-const horseBreeds = Object.entries(HORSE_BREEDS);
 
 let loading = $state(false);
 let error = $state<string | null>(null);
@@ -139,22 +139,12 @@ function parentTitle(cell: GeneCell | null, label: string) {
         <div class="trio-filters">
             {#if isHorse}
                 <div class="breed-filter" data-testid="trio-breed-filter">
-                    <span class="breed-label">Breed:</span>
-                    <button
-                        type="button"
-                        class="breed-btn"
-                        class:active={selectedBreed === ''}
-                        onclick={() => { selectedBreed = ''; }}
-                    >All</button>
-                    {#each horseBreeds as [name, abbrev] (name)}
-                        <button
-                            type="button"
-                            class="breed-btn"
-                            class:active={selectedBreed === name}
-                            onclick={() => { selectedBreed = name; }}
-                            title={name}
-                        >{abbrev}</button>
-                    {/each}
+                    <BreedSelector
+                        value={selectedBreed}
+                        breeds={HORSE_BREEDS}
+                        label="Offspring breed"
+                        onChange={(v) => { selectedBreed = v; }}
+                    />
                 </div>
             {/if}
             {#if attributeItems.length > 0}
@@ -281,34 +271,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
         margin-bottom: 12px;
         flex-shrink: 0;
     }
-    /* Attribute tri-state pills now live in GeneFilterPills. */
-    .breed-filter {
-        display: flex;
-        align-items: center;
-        gap: 3px;
-        flex-wrap: wrap;
-        padding: 0 4px;
-    }
-    .breed-label {
-        font-size: 11px;
-        font-weight: 600;
-        color: var(--text-tertiary);
-        margin-right: 4px;
-    }
-    .breed-btn {
-        padding: 3px 8px;
-        border: 1px solid var(--border-primary);
-        border-radius: 4px;
-        background: var(--bg-primary);
-        color: var(--text-tertiary);
-        font-size: 11px;
-        font-weight: 500;
-        cursor: pointer;
-        transition: all 0.15s;
-        white-space: nowrap;
-    }
-    .breed-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
-    .breed-btn.active { background: var(--accent); border-color: var(--accent); color: white; }
+    /* Attribute pills → GeneFilterPills; breed picker → shared BreedSelector. */
+    .breed-filter { display: flex; padding: 0 4px; }
 
     .trio-summary {
         display: flex;

--- a/src/lib/components/shared/BreedSelector.svelte
+++ b/src/lib/components/shared/BreedSelector.svelte
@@ -21,10 +21,13 @@ interface Props {
   label?: string;
   /** Label for the "no filter" option. */
   allLabel?: string;
+  /** Greys out the trigger and suppresses the popover (e.g. Compare's Auto
+   *  mode owns the breed). The current value still shows on the trigger. */
+  disabled?: boolean;
   onChange: (value: string) => void;
 }
 
-const { value, breeds, label = 'Breed', allLabel = 'All', onChange }: Props = $props();
+const { value, breeds, label = 'Breed', allLabel = 'All', disabled = false, onChange }: Props = $props();
 
 let open = $state(false);
 let root = $state<HTMLDivElement | undefined>();
@@ -66,7 +69,8 @@ onDestroy(() => {
     data-testid="breed-selector-trigger"
     aria-haspopup="true"
     aria-expanded={open}
-    onclick={(e) => { e.stopPropagation(); open = !open; }}
+    {disabled}
+    onclick={(e) => { if (disabled) return; e.stopPropagation(); open = !open; }}
   >
     <span class="bs-label">{label}:</span>
     <strong class="bs-value">{currentLabel}</strong>
@@ -120,7 +124,8 @@ onDestroy(() => {
     font-weight: 600;
     cursor: pointer;
   }
-  .bs-trigger:hover { border-color: var(--border-secondary); }
+  .bs-trigger:hover:not(:disabled) { border-color: var(--border-secondary); }
+  .bs-trigger:disabled { opacity: 0.5; cursor: default; }
 
   .bs-label { color: var(--text-tertiary); }
   .bs-value { color: var(--text-secondary); }

--- a/src/lib/components/shared/BreedSelector.svelte
+++ b/src/lib/components/shared/BreedSelector.svelte
@@ -35,6 +35,12 @@ let root = $state<HTMLDivElement | undefined>();
 const entries = $derived(Object.entries(breeds));
 const currentLabel = $derived(value === '' ? allLabel : value);
 
+// If the parent disables the control while the popover is open (e.g. Compare
+// flips Auto on), force it shut so the UI/ARIA state can't drift.
+$effect(() => {
+  if (disabled) open = false;
+});
+
 function choose(next: string): void {
   open = false;
   if (next !== value) onChange(next);

--- a/tests/unit/breedSelector.test.ts
+++ b/tests/unit/breedSelector.test.ts
@@ -86,6 +86,17 @@ describe('BreedSelector', () => {
     expect(opt(container, '').getAttribute('aria-pressed')).toBe('false');
   });
 
+  it('when disabled, the trigger is disabled and the popover never opens', async () => {
+    const { container, onChange } = mount({ value: 'Kurbone', disabled: true });
+    const t = trigger(container);
+    expect(t.disabled).toBe(true);
+    // Still shows the current value (e.g. Compare's auto-selected breed).
+    expect(t.querySelector('.bs-value')?.textContent).toBe('Kurbone');
+    await fireEvent.click(t);
+    expect(pop(container)).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('closes on Escape', async () => {
     const { container } = mount();
     await fireEvent.click(trigger(container));

--- a/tests/unit/breedSelector.test.ts
+++ b/tests/unit/breedSelector.test.ts
@@ -97,6 +97,14 @@ describe('BreedSelector', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('force-closes an open popover when disabled flips to true', async () => {
+    const { container, rerender } = mount({ value: 'Kurbone' });
+    await fireEvent.click(trigger(container));
+    expect(pop(container)).not.toBeNull();
+    await rerender({ value: 'Kurbone', breeds: BREEDS, disabled: true } as never);
+    expect(pop(container)).toBeNull();
+  });
+
   it('closes on Escape', async () => {
     const { container } = mount();
     await fireEvent.click(trigger(container));


### PR DESCRIPTION
## What

Follow-up to #371 (and the §3/§4.1 component-unification in `docs/design/redesign-library-workspace-v1.md`). Retires the bespoke breed button rows in the Compare diff controls and the Trio view for the shared `BreedSelector` popover — one breed control across the app (already used in the My Pets filter bar).

- `BreedSelector` gains a `disabled` prop: greys the trigger and suppresses the popover while still showing the current value. Used for Compare's **Auto-breed** mode (Auto owns the breed, so the manual picker is disabled — same as the old disabled button row).
- `GenomeDiffControls` (Compare): breed button row → `BreedSelector`; the Auto toggle stays as a standalone pill beside it. Parent handler simplified to set the value directly (the old toggle-to-clear is redundant now that the popover has an explicit "All").
- `GenomeGridTrio` (Trio): breed button row → `BreedSelector` labelled **"Offspring breed"** (selecting re-runs the offspring projection, as before). Dead breed CSS removed from both.

## Why

§4.1: "one `BreedSelector` used in the filter bar and in lenses (Trio offspring breed, Compare breed filter)… retires the dropdown and the 11-wide button row."

## Verification

- New unit test for the `disabled` prop (trigger disabled, popover never opens, value still shown); full suite **777 passing**; `svelte-check` 0 errors; Biome clean.
- Drove the app:
  - **Trio** — "Offspring breed" popover; selecting Standardbred re-runs the projection (summary 249→81 gains). No button row.
  - **Compare** — Auto active → selector disabled; toggling Auto off enables it; selecting a breed applies the diff breed-filter CSS. No button row.

This completes the "converge the grid control surfaces" follow-up (filter pills in #371, breed control here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)