### PR TITLE
Breeding: pool-gap-aware pairing weight (#358)

### DIFF
--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -29,6 +29,7 @@ const columns = $derived<Column[]>([
   { id: 'evMixed', label: 'Mixed', accessor: (r) => r.evMixed, numeric: true },
   { id: 'evUnknown', label: 'Unknown', accessor: (r) => r.evUnknown, numeric: true },
   { id: 'evPositiveTotal', label: 'Total +', accessor: (r) => r.evPositiveTotal, numeric: true },
+  { id: 'evPositiveWeighted', label: 'Pool gain', accessor: (r) => r.evPositiveWeighted, numeric: true },
   ...attrNames.map(
     (name): Column => ({
       id: name,
@@ -117,6 +118,7 @@ function fmt(n: number) {
                     <td class="numeric">{fmt(pair.evMixed)}</td>
                     <td class="numeric">{fmt(pair.evUnknown)}</td>
                     <td class="numeric strong">{fmt(pair.evPositiveTotal)}</td>
+                    <td class="numeric strong">{fmt(pair.evPositiveWeighted)}</td>
                     {#each attrNames as name (name)}
                         <td class="numeric">{fmt(pair.evPositiveByAttribute[name] ?? 0)}</td>
                     {/each}

--- a/src/lib/services/breedingService.ts
+++ b/src/lib/services/breedingService.ts
@@ -45,6 +45,20 @@ export type PoolCoverage = Map<string, SlotCoverage>;
 export const GAP_WEIGHT: Record<CoverageTier, number> = { missing: 2.0, partial: 1.2, locked: 0.6 };
 
 /**
+ * The (capitalized) attribute each positive slot targets, or null when that
+ * slot isn't a named positive — a slot counts only when its sign is `'+'` and
+ * it names an attribute. The single source of truth for slot eligibility,
+ * shared by `buildPoolCoverage` and `accumulatePositive` so coverage and
+ * scoring can't drift on which loci count.
+ */
+function positiveSlots(gd: ParsedGeneRecord): { dom: string | null; rec: string | null } {
+  return {
+    dom: gd.dominantSign === '+' && gd.dominantAttribute ? capitalize(gd.dominantAttribute) : null,
+    rec: gd.recessiveSign === '+' && gd.recessiveAttribute ? capitalize(gd.recessiveAttribute) : null,
+  };
+}
+
+/**
  * One pass over the whole candidate pool to classify, per gene, how well each
  * positive slot is already covered. A horse gene has up to two positive slots
  * (a dominant-positive and a recessive-positive, often on *different*
@@ -70,9 +84,8 @@ export function buildPoolCoverage(
     for (const [geneId, type] of loci) {
       const gd = parsedGenes[geneId];
       if (!gd) continue;
-      const hasDomPos = gd.dominantSign === '+' && !!gd.dominantAttribute;
-      const hasRecPos = gd.recessiveSign === '+' && !!gd.recessiveAttribute;
-      if (!hasDomPos && !hasRecPos) continue;
+      const slots = positiveSlots(gd);
+      if (!slots.dom && !slots.rec) continue;
       if (isHorseBreedFiltered(species, offspringBreed, gd.breed)) continue;
       let f = flags.get(geneId);
       if (!f) {
@@ -115,9 +128,11 @@ export interface RankBreedingPairsOptions {
 
 /**
  * Add this locus's contribution to the per-attribute positive-expression
- * tally (`into`) and, scaled by the pool-coverage gap weight for each slot,
- * to the weighted tally (`weightedInto`). Returns both aggregates so the
- * caller can keep running totals without re-summing the records.
+ * tally (`into`). Returns the raw total plus the pool-gap-weighted total —
+ * each slot's mass scaled by `GAP_WEIGHT` for its coverage tier — so the
+ * caller keeps both running aggregates without re-summing the record. Only
+ * the scalar weighted total is surfaced; the breakdown stays raw (the UI
+ * sorts the weighted figure as a single "Pool gain" column).
  *
  * `cov` is this gene's pool coverage; absent (shouldn't happen for a locus
  * present in the pool) it defaults to the `missing` weight.
@@ -127,30 +142,24 @@ function accumulatePositive(
   gd: ParsedGeneRecord,
   cov: SlotCoverage | undefined,
   into: Record<string, number>,
-  weightedInto: Record<string, number>,
 ): { total: number; weighted: number } {
+  const slots = positiveSlots(gd);
   let total = 0;
   let weighted = 0;
-  if (gd.dominantSign === '+' && gd.dominantAttribute) {
+  if (slots.dom) {
     const p = dist.D + dist.x;
     if (p > 0) {
-      const key = capitalize(gd.dominantAttribute);
-      into[key] = (into[key] ?? 0) + p;
+      into[slots.dom] = (into[slots.dom] ?? 0) + p;
       total += p;
-      const w = p * GAP_WEIGHT[cov?.dom ?? 'missing'];
-      weightedInto[key] = (weightedInto[key] ?? 0) + w;
-      weighted += w;
+      weighted += p * GAP_WEIGHT[cov?.dom ?? 'missing'];
     }
   }
-  if (gd.recessiveSign === '+' && gd.recessiveAttribute) {
+  if (slots.rec) {
     const p = dist.R;
     if (p > 0) {
-      const key = capitalize(gd.recessiveAttribute);
-      into[key] = (into[key] ?? 0) + p;
+      into[slots.rec] = (into[slots.rec] ?? 0) + p;
       total += p;
-      const w = p * GAP_WEIGHT[cov?.rec ?? 'missing'];
-      weightedInto[key] = (weightedInto[key] ?? 0) + w;
-      weighted += w;
+      weighted += p * GAP_WEIGHT[cov?.rec ?? 'missing'];
     }
   }
   return { total, weighted };
@@ -174,7 +183,6 @@ function scorePair(
   attrNames: readonly string[],
 ): BreedingPairResult {
   const evPositiveByAttribute = emptyAttributeBreakdown(attrNames);
-  const evPositiveWeightedByAttribute = emptyAttributeBreakdown(attrNames);
   let evMixed = 0;
   let evUnknown = 0;
   let evPositiveTotal = 0;
@@ -189,29 +197,13 @@ function scorePair(
     evUnknown += dist.unknown;
     totalLoci++;
     if (gd) {
-      const { total, weighted } = accumulatePositive(
-        dist,
-        gd,
-        coverage.get(geneId),
-        evPositiveByAttribute,
-        evPositiveWeightedByAttribute,
-      );
+      const { total, weighted } = accumulatePositive(dist, gd, coverage.get(geneId), evPositiveByAttribute);
       evPositiveTotal += total;
       evPositiveWeighted += weighted;
     }
   });
 
-  return {
-    male,
-    female,
-    evMixed,
-    evPositiveByAttribute,
-    evPositiveTotal,
-    evPositiveWeighted,
-    evPositiveWeightedByAttribute,
-    evUnknown,
-    totalLoci,
-  };
+  return { male, female, evMixed, evPositiveByAttribute, evPositiveTotal, evPositiveWeighted, evUnknown, totalLoci };
 }
 
 /**

--- a/src/lib/services/breedingService.ts
+++ b/src/lib/services/breedingService.ts
@@ -13,12 +13,88 @@
  */
 
 import type { AlleleDistribution, BreedingPairResult, Pet } from '$lib/types/index.js';
-import { Gender } from '$lib/types/index.js';
+import { Gender, GeneType } from '$lib/types/index.js';
 import { offspringDistribution } from '$lib/utils/breedingGenetics.js';
 import { loadAllPetLoci, type PetLoci, walkPairLoci } from '$lib/utils/petLoci.js';
 import { capitalize } from '$lib/utils/string.js';
 import { getAllAttributeNames, normalizeSpecies } from './configService.js';
 import { getParsedGenesCached, isHorseBreedFiltered, type ParsedGeneRecord } from './geneService.js';
+
+/**
+ * How well the candidate pool already covers a positive slot:
+ * `locked` — some pet expresses it outright, `partial` — only carriers
+ * exist, `missing` — nothing in the pool carries it.
+ */
+export type CoverageTier = 'locked' | 'partial' | 'missing';
+
+/** Per-gene pool coverage, tracked separately for each positive slot. */
+export interface SlotCoverage {
+  /** Coverage of the dominant-positive slot (`dominantSign === '+'`). */
+  dom: CoverageTier;
+  /** Coverage of the recessive-positive slot (`recessiveSign === '+'`). */
+  rec: CoverageTier;
+}
+
+export type PoolCoverage = Map<string, SlotCoverage>;
+
+/**
+ * Gap weight per tier — a missing positive is worth more than re-covering a
+ * locked one. Mirrors PGBeeYiKeeper's coverage multipliers, adapted to the
+ * horse two-slot model (see issue #358).
+ */
+export const GAP_WEIGHT: Record<CoverageTier, number> = { missing: 2.0, partial: 1.2, locked: 0.6 };
+
+/**
+ * One pass over the whole candidate pool to classify, per gene, how well each
+ * positive slot is already covered. A horse gene has up to two positive slots
+ * (a dominant-positive and a recessive-positive, often on *different*
+ * attributes), so coverage is tracked per slot, not per gene:
+ *
+ * - dominant-positive: `locked` if any pet is `D`, else `partial` if any `x`,
+ *   else `missing` (all `R`/unknown).
+ * - recessive-positive: `locked` if any pet is `R`, else `partial` if any `x`
+ *   (carrier), else `missing` (all `D`/unknown).
+ *
+ * Only genes with at least one positive slot are tracked; breed-locked-to-
+ * other-breed loci are excluded (same `isHorseBreedFiltered` gate as scoring),
+ * so coverage and scoring agree on which loci exist.
+ */
+export function buildPoolCoverage(
+  lociList: Iterable<PetLoci>,
+  parsedGenes: Record<string, ParsedGeneRecord>,
+  species: string,
+  offspringBreed: string | undefined,
+): PoolCoverage {
+  const flags = new Map<string, { d: boolean; x: boolean; r: boolean }>();
+  for (const loci of lociList) {
+    for (const [geneId, type] of loci) {
+      const gd = parsedGenes[geneId];
+      if (!gd) continue;
+      const hasDomPos = gd.dominantSign === '+' && !!gd.dominantAttribute;
+      const hasRecPos = gd.recessiveSign === '+' && !!gd.recessiveAttribute;
+      if (!hasDomPos && !hasRecPos) continue;
+      if (isHorseBreedFiltered(species, offspringBreed, gd.breed)) continue;
+      let f = flags.get(geneId);
+      if (!f) {
+        f = { d: false, x: false, r: false };
+        flags.set(geneId, f);
+      }
+      if (type === GeneType.DOMINANT) f.d = true;
+      else if (type === GeneType.MIXED) f.x = true;
+      else if (type === GeneType.RECESSIVE) f.r = true;
+      // UNKNOWN carries no positive allele → contributes no coverage.
+    }
+  }
+
+  const coverage: PoolCoverage = new Map();
+  for (const [geneId, f] of flags) {
+    coverage.set(geneId, {
+      dom: f.d ? 'locked' : f.x ? 'partial' : 'missing',
+      rec: f.r ? 'locked' : f.x ? 'partial' : 'missing',
+    });
+  }
+  return coverage;
+}
 
 export interface RankBreedingPairsOptions {
   /** Canonical or display species — passed through `normalizeSpecies`. */
@@ -39,17 +115,31 @@ export interface RankBreedingPairsOptions {
 
 /**
  * Add this locus's contribution to the per-attribute positive-expression
- * tally. Returns the total positive mass added across all attributes so
- * the caller can keep an aggregate without re-summing the record.
+ * tally (`into`) and, scaled by the pool-coverage gap weight for each slot,
+ * to the weighted tally (`weightedInto`). Returns both aggregates so the
+ * caller can keep running totals without re-summing the records.
+ *
+ * `cov` is this gene's pool coverage; absent (shouldn't happen for a locus
+ * present in the pool) it defaults to the `missing` weight.
  */
-function accumulatePositive(dist: AlleleDistribution, gd: ParsedGeneRecord, into: Record<string, number>): number {
+function accumulatePositive(
+  dist: AlleleDistribution,
+  gd: ParsedGeneRecord,
+  cov: SlotCoverage | undefined,
+  into: Record<string, number>,
+  weightedInto: Record<string, number>,
+): { total: number; weighted: number } {
   let total = 0;
+  let weighted = 0;
   if (gd.dominantSign === '+' && gd.dominantAttribute) {
     const p = dist.D + dist.x;
     if (p > 0) {
       const key = capitalize(gd.dominantAttribute);
       into[key] = (into[key] ?? 0) + p;
       total += p;
+      const w = p * GAP_WEIGHT[cov?.dom ?? 'missing'];
+      weightedInto[key] = (weightedInto[key] ?? 0) + w;
+      weighted += w;
     }
   }
   if (gd.recessiveSign === '+' && gd.recessiveAttribute) {
@@ -58,9 +148,12 @@ function accumulatePositive(dist: AlleleDistribution, gd: ParsedGeneRecord, into
       const key = capitalize(gd.recessiveAttribute);
       into[key] = (into[key] ?? 0) + p;
       total += p;
+      const w = p * GAP_WEIGHT[cov?.rec ?? 'missing'];
+      weightedInto[key] = (weightedInto[key] ?? 0) + w;
+      weighted += w;
     }
   }
-  return total;
+  return { total, weighted };
 }
 
 function emptyAttributeBreakdown(attrNames: readonly string[]): Record<string, number> {
@@ -75,14 +168,17 @@ function scorePair(
   mLoci: PetLoci,
   fLoci: PetLoci,
   parsedGenes: Record<string, ParsedGeneRecord>,
+  coverage: PoolCoverage,
   offspringBreed: string | undefined,
   species: string,
   attrNames: readonly string[],
 ): BreedingPairResult {
   const evPositiveByAttribute = emptyAttributeBreakdown(attrNames);
+  const evPositiveWeightedByAttribute = emptyAttributeBreakdown(attrNames);
   let evMixed = 0;
   let evUnknown = 0;
   let evPositiveTotal = 0;
+  let evPositiveWeighted = 0;
   let totalLoci = 0;
 
   walkPairLoci(mLoci, fLoci, (geneId, t1, t2) => {
@@ -92,10 +188,30 @@ function scorePair(
     evMixed += dist.x;
     evUnknown += dist.unknown;
     totalLoci++;
-    if (gd) evPositiveTotal += accumulatePositive(dist, gd, evPositiveByAttribute);
+    if (gd) {
+      const { total, weighted } = accumulatePositive(
+        dist,
+        gd,
+        coverage.get(geneId),
+        evPositiveByAttribute,
+        evPositiveWeightedByAttribute,
+      );
+      evPositiveTotal += total;
+      evPositiveWeighted += weighted;
+    }
   });
 
-  return { male, female, evMixed, evPositiveByAttribute, evPositiveTotal, evUnknown, totalLoci };
+  return {
+    male,
+    female,
+    evMixed,
+    evPositiveByAttribute,
+    evPositiveTotal,
+    evPositiveWeighted,
+    evPositiveWeightedByAttribute,
+    evUnknown,
+    totalLoci,
+  };
 }
 
 /**
@@ -117,11 +233,15 @@ export async function rankBreedingPairs(opts: RankBreedingPairsOptions): Promise
   const empty: PetLoci = new Map();
   const results: BreedingPairResult[] = [];
 
+  // Pool coverage is computed once over the whole candidate set, then shared
+  // across every pair — the gap weights describe the pool, not the pair.
+  const coverage = buildPoolCoverage(petLociMap.values(), parsedGenes, species, opts.offspringBreed);
+
   for (const m of males) {
     const mLoci = petLociMap.get(m.id) ?? empty;
     for (const f of females) {
       const fLoci = petLociMap.get(f.id) ?? empty;
-      results.push(scorePair(m, f, mLoci, fLoci, parsedGenes, opts.offspringBreed, species, attrNames));
+      results.push(scorePair(m, f, mLoci, fLoci, parsedGenes, coverage, opts.offspringBreed, species, attrNames));
     }
   }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -274,6 +274,12 @@ export interface AlleleDistribution {
  * every locus the parents share (attribute + appearance + selector) and
  * is the predictability metric; `evPositiveByAttribute` is attribute-only
  * and broken down per attribute so the breeder can sort to target one.
+ *
+ * `evPositiveWeighted` is the pool-gap-aware variant: each positive slot's
+ * expected mass is scaled by how well the candidate pool already covers that
+ * slot (missing > partial > locked), so a pair that fills a gap nothing else
+ * covers outranks one re-covering an already-secured positive. Raw EV stays
+ * untouched for display; the weighted figure is a separate "Pool gain" metric.
  */
 export interface BreedingPairResult {
   male: Pet;
@@ -281,6 +287,8 @@ export interface BreedingPairResult {
   evMixed: number;
   evPositiveByAttribute: Record<string, number>;
   evPositiveTotal: number;
+  evPositiveWeighted: number;
+  evPositiveWeightedByAttribute: Record<string, number>;
   evUnknown: number;
   totalLoci: number;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -288,7 +288,6 @@ export interface BreedingPairResult {
   evPositiveByAttribute: Record<string, number>;
   evPositiveTotal: number;
   evPositiveWeighted: number;
-  evPositiveWeightedByAttribute: Record<string, number>;
   evUnknown: number;
   totalLoci: number;
 }

--- a/tests/unit/breedingService.test.ts
+++ b/tests/unit/breedingService.test.ts
@@ -217,14 +217,13 @@ describe('rankBreedingPairs — pool-gap-weighted EV', () => {
     expect(pair.evPositiveByAttribute.Intelligence).toBeCloseTo(0.75, 10);
     expect(pair.evPositiveTotal).toBeCloseTo(1.75, 10);
 
-    // Weighted: Toughness (locked) ×0.6 = 0.6; Intelligence (partial) ×1.2 = 0.9.
-    expect(pair.evPositiveWeightedByAttribute.Toughness).toBeCloseTo(0.6, 10);
-    expect(pair.evPositiveWeightedByAttribute.Intelligence).toBeCloseTo(0.9, 10);
+    // Weighted: Toughness (locked) 1.0×0.6 = 0.6; Intelligence (partial) 0.75×1.2 = 0.9.
+    // The 1.5 total can only arise from per-slot weighting (1.0×0.6 + 0.75×1.2);
+    // a single weight on the raw 1.75 would give 1.05 (all locked) or 2.1 (all
+    // partial), so this scalar alone pins that the locked slot was down-weighted
+    // and the partial slot up-weighted.
     expect(pair.evPositiveWeighted).toBeCloseTo(1.5, 10);
-    // The partial gap outweighs the locked one even though its raw EV is lower.
-    expect(pair.evPositiveWeightedByAttribute.Intelligence).toBeGreaterThan(
-      pair.evPositiveWeightedByAttribute.Toughness,
-    );
+    expect(pair.evPositiveWeighted).toBeLessThan(pair.evPositiveTotal);
   });
 });
 

--- a/tests/unit/breedingService.test.ts
+++ b/tests/unit/breedingService.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { rankBreedingPairs } from '$lib/services/breedingService.js';
+import { buildPoolCoverage, rankBreedingPairs } from '$lib/services/breedingService.js';
 import { closeDatabase, initDatabase } from '$lib/services/database.js';
+import type { ParsedGeneRecord } from '$lib/services/geneService.js';
 import * as geneService from '$lib/services/geneService.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
-import { Gender, type Pet } from '$lib/types/index.js';
+import { Gender, GeneType, type Pet } from '$lib/types/index.js';
+import type { PetLoci } from '$lib/utils/petLoci.js';
 
 /**
  * Three-locus beewasp genome: positions 01A1, 01A2, 01A3 — alleles
@@ -140,6 +142,89 @@ describe('rankBreedingPairs — EV math', () => {
     expect(pair.evMixed).toBe(0);
     expect(pair.evPositiveTotal).toBe(0);
     expect(pair.evPositiveByAttribute.Toughness).toBe(0);
+  });
+});
+
+describe('buildPoolCoverage — per-slot tier classification', () => {
+  // One gene with both positive slots on different attributes, so the dominant
+  // and recessive coverage are classified independently.
+  function gene(over: Partial<ParsedGeneRecord> = {}): ParsedGeneRecord {
+    return {
+      dominantAttribute: 'Toughness',
+      dominantSign: '+',
+      recessiveAttribute: 'Speed',
+      recessiveSign: '+',
+      breed: '',
+      ...over,
+    };
+  }
+  // Each allele → a pet carrying only gene 'G' with that allele.
+  const pool = (...alleles: GeneType[]): PetLoci[] => alleles.map((a) => new Map([['G', a]]));
+  const cover = (alleles: GeneType[], parsed = { G: gene() }, species = 'beewasp', breed?: string) =>
+    buildPoolCoverage(pool(...alleles), parsed, species, breed).get('G');
+
+  it('dominant slot: D→locked, x→partial, R/?→missing', () => {
+    expect(cover([GeneType.DOMINANT])?.dom).toBe('locked');
+    expect(cover([GeneType.MIXED])?.dom).toBe('partial');
+    expect(cover([GeneType.RECESSIVE])?.dom).toBe('missing');
+    expect(cover([GeneType.UNKNOWN])?.dom).toBe('missing');
+  });
+
+  it('recessive slot: R→locked, x→partial, D/?→missing', () => {
+    expect(cover([GeneType.RECESSIVE])?.rec).toBe('locked');
+    expect(cover([GeneType.MIXED])?.rec).toBe('partial');
+    expect(cover([GeneType.DOMINANT])?.rec).toBe('missing');
+    expect(cover([GeneType.UNKNOWN])?.rec).toBe('missing');
+  });
+
+  it('takes the strongest evidence across the whole pool per slot', () => {
+    // A carrier (x) and a recessive: dominant has no D but a carrier → partial;
+    // recessive is expressed somewhere → locked.
+    expect(cover([GeneType.MIXED, GeneType.RECESSIVE])).toEqual({ dom: 'partial', rec: 'locked' });
+    // A dominant and a recessive lock both slots.
+    expect(cover([GeneType.DOMINANT, GeneType.RECESSIVE])).toEqual({ dom: 'locked', rec: 'locked' });
+  });
+
+  it('omits genes with no positive slot', () => {
+    const parsed = { G: gene({ dominantSign: '-', recessiveSign: null, recessiveAttribute: null }) };
+    expect(cover([GeneType.DOMINANT], parsed)).toBeUndefined();
+  });
+
+  it('excludes loci breed-locked to a different offspring breed', () => {
+    const parsed = { G: gene({ breed: 'Standardbred' }) };
+    expect(cover([GeneType.DOMINANT], parsed, 'horse', 'Ilmarian')).toBeUndefined();
+    expect(cover([GeneType.DOMINANT], parsed, 'horse', 'Standardbred')?.dom).toBe('locked');
+  });
+});
+
+describe('rankBreedingPairs — pool-gap-weighted EV', () => {
+  beforeEach(reset);
+
+  it('down-weights an already-locked positive and up-weights a partial one', async () => {
+    // 01A1 Toughness+ : both parents D → pool has it locked (weight 0.6).
+    // 01A2 Intelligence+ : both parents x, no D → pool only partial (weight 1.2).
+    await geneService.upsertGene('beewasp', '01', '01A1', { effectDominant: 'Toughness+', effectRecessive: 'None' });
+    await geneService.upsertGene('beewasp', '01', '01A2', { effectDominant: 'Intelligence+', effectRecessive: 'None' });
+    geneService.clearGeneEffectsCache('beewasp');
+
+    const male = await uploadParent('M', Gender.MALE, 'Dx?');
+    const female = await uploadParent('F', Gender.FEMALE, 'Dx?');
+
+    const [pair] = await rankBreedingPairs({ species: 'BeeWasp', pets: [male, female] });
+
+    // Raw EV (unweighted): 01A1 D×D → P(D)=1; 01A2 x×x → P(D∨x)=0.75.
+    expect(pair.evPositiveByAttribute.Toughness).toBeCloseTo(1, 10);
+    expect(pair.evPositiveByAttribute.Intelligence).toBeCloseTo(0.75, 10);
+    expect(pair.evPositiveTotal).toBeCloseTo(1.75, 10);
+
+    // Weighted: Toughness (locked) ×0.6 = 0.6; Intelligence (partial) ×1.2 = 0.9.
+    expect(pair.evPositiveWeightedByAttribute.Toughness).toBeCloseTo(0.6, 10);
+    expect(pair.evPositiveWeightedByAttribute.Intelligence).toBeCloseTo(0.9, 10);
+    expect(pair.evPositiveWeighted).toBeCloseTo(1.5, 10);
+    // The partial gap outweighs the locked one even though its raw EV is lower.
+    expect(pair.evPositiveWeightedByAttribute.Intelligence).toBeGreaterThan(
+      pair.evPositiveWeightedByAttribute.Toughness,
+    );
   });
 });
 


### PR DESCRIPTION
Closes #358.

## What

Weights each positive locus in `rankBreedingPairs` by how well the candidate pool already covers it, so a pair that fills a gap nothing else covers outranks one re-covering an already-secured positive. Raw EV is untouched; the weighted figure is a separate metric.

- **`buildPoolCoverage`** — one pass over the candidate pool classifies coverage **per positive slot**. A horse gene has up to two positive slots (dominant-positive and recessive-positive, often on *different* attributes), so coverage is tracked per slot, not per gene:
  - dominant-positive: `locked` if any pet is `D`, else `partial` if any `x`, else `missing`.
  - recessive-positive: `locked` if any pet is `R`, else `partial` if any `x` (carrier), else `missing`.
  - Breed-locked-to-other-breed loci excluded (same `isHorseBreedFiltered` gate as scoring).
- **`accumulatePositive`** scales each slot's EV by `GAP_WEIGHT` (`missing 2.0 / partial 1.2 / locked 0.6`, mirroring PGBeeYiKeeper) into a new `evPositiveWeighted` (+ weighted-by-attribute) accumulator. `evPositiveTotal`/`evPositiveByAttribute` unchanged.
- **`BreedingPairTable`** gains a sortable **"Pool gain"** column.

Coverage is computed once over the candidate set and shared across all pairs (the weights describe the pool, not the pair). No new DB query — reuses the loaded `petLociMap`.

## Note on the model

`missing` (2.0) is classified correctly but contributes 0 EV in practice: you can't breed in a positive no pet carries (the producing parent is itself in the pool). The meaningful signal is **partial (1.2) vs locked (0.6)** — a pair that expresses a positive only carriers hold beats one re-expressing an already-locked positive. Tests cover all tiers regardless.

## Verification

- Unit tests: `buildPoolCoverage` tier classification per slot (locked/partial/missing, multi-pet pools, no-positive-slot omission, breed exclusion); weighted-vs-raw EV on a constructed pool (locked down-weighted 1.0→0.6, partial up-weighted 0.75→0.9). Full suite **784 passing**; `svelte-check` 0 errors; Biome clean.
- Drove the app: Breed → horse shows the new "Pool gain" column (174.0 vs raw Total+ 241.8 — weighting applied), sortable with aria-sort.

## Out of scope (per issue)

Multi-generation forecast; user-configurable target pool / weights.

## Base

Branched off `redesign/library-workspace` (where `BreedingPairTable`/`BreedView` currently live). Say if you'd rather this target `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)