### PR TITLE
Community: add-only attribute/tag corrections for shared pets

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -41,55 +41,93 @@ service cloud.firestore {
         && (tags.size() < 30 || (tags[29] is string && tags[29].size() <= 64));
     }
 
-    // Pet *metadata* only — name, tags, attribution, schema/version stamps,
-    // and the server-side upload timestamp. The genome text itself lives in
-    // `/genomes/{contentHash}` (see below) so the catalogue list view can
-    // page metadata without dragging 64 KiB-cap genome strings over the
-    // wire. Document ID is the SHA-256 hex of the genome — the same ID is
-    // used in both collections to bind a metadata row to its genome.
+    // Validate the nested `attributes` map: the eight attribute columns,
+    // each an integer in the 0–100 range published by the client (matching
+    // the in-app editor bound and the structured-name parser's own cap).
+    function isValidAttributes(a) {
+      return a is map
+        && a.intelligence is int && a.intelligence >= 0 && a.intelligence <= 100
+        && a.toughness    is int && a.toughness    >= 0 && a.toughness    <= 100
+        && a.friendliness is int && a.friendliness >= 0 && a.friendliness <= 100
+        && a.ruggedness   is int && a.ruggedness   >= 0 && a.ruggedness   <= 100
+        && a.enthusiasm   is int && a.enthusiasm   >= 0 && a.enthusiasm   <= 100
+        && a.virility     is int && a.virility     >= 0 && a.virility     <= 100
+        && a.ferocity     is int && a.ferocity     >= 0 && a.ferocity     <= 100
+        && a.temperament  is int && a.temperament  >= 0 && a.temperament  <= 100;
+    }
+
+    // Field-level validation shared by first-share and correction writes.
+    // The doc-ID / hash-binding differ between the two (see below); the
+    // metadata body does not.
+    function isValidPetMeta(data) {
+      return data.name is string
+        && data.name.size() > 0
+        && data.name.size() <= 100
+        && data.character is string
+        && data.character.size() <= 100
+        && data.species in ['Horse', 'BeeWasp']
+        && data.gender in ['Male', 'Female']
+        && data.breed is string
+        && data.breed.size() <= 100
+        && data.breeder is string
+        && data.breeder.size() <= 100
+        && data.notes is string
+        && data.notes.size() <= 4096
+        && isValidTagList(data.tags)
+        && isValidAttributes(data.attributes)
+        && data.schemaVersion is int
+        && data.appVersion is string
+        && data.appVersion.size() <= 32
+        && data.uploadedAt is timestamp
+        && data.uploadedAt == request.time
+        && data.uploaderUid == null;
+    }
+
+    // Pet *metadata* only — name, tags, attributes, attribution, schema/
+    // version stamps, and the server-side upload timestamp. The genome text
+    // itself lives in `/genomes/{contentHash}` (see below) so the catalogue
+    // list view can page metadata without dragging 64 KiB-cap genome strings
+    // over the wire.
     //
-    // `existsAfter()` ties the two collections together: a /pets create is
-    // only accepted if /genomes/{hash} ALSO exists after the same
-    // transaction. The client `writeBatch` writes both atomically, so the
-    // pair lands together. This blocks single-collection writes that
-    // would otherwise create orphan metadata rows pointing at no genome.
-    match /pets/{contentHash} {
+    // The catalogue is ADD-ONLY (no auth, no mutation). Two write shapes:
+    //
+    //  1. First share — doc ID IS the genome's SHA-256 hex; no `contentHash`
+    //     field. `existsAfter()` ties it to /genomes/{hash}: the create is
+    //     only accepted if the genome blob ALSO exists after the same
+    //     transaction (the client `writeBatch` writes both atomically),
+    //     blocking orphan metadata pointing at no genome.
+    //
+    //  2. Correction — an auto-ID doc carrying a `contentHash` field that
+    //     points back at an already-published genome. Lets a user append a
+    //     superseding metadata entry (corrected attributes/tags) without
+    //     mutating the original; reads resolve a hash to its latest entry
+    //     by `uploadedAt`. Requires the genome to already exist, so a
+    //     correction can never precede a first share.
+    //
+    // update/delete stay denied — corrections are appends, never edits.
+    match /pets/{docId} {
       allow read: if true;
 
-      allow create: if request.resource.data.keys().hasAll([
-                        'name', 'character', 'species', 'gender',
-                        'breed', 'breeder', 'notes', 'tags',
-                        'schemaVersion', 'appVersion',
-                        'uploadedAt', 'uploaderUid'
-                      ])
+      allow create: if isValidPetMeta(request.resource.data)
                  && request.resource.data.keys().hasOnly([
                         'name', 'character', 'species', 'gender',
-                        'breed', 'breeder', 'notes', 'tags',
+                        'breed', 'breeder', 'notes', 'tags', 'attributes',
                         'schemaVersion', 'appVersion',
                         'uploadedAt', 'uploaderUid'
                       ])
-                 && request.resource.data.name is string
-                 && request.resource.data.name.size() > 0
-                 && request.resource.data.name.size() <= 100
-                 && request.resource.data.character is string
-                 && request.resource.data.character.size() <= 100
-                 && request.resource.data.species in ['Horse', 'BeeWasp']
-                 && request.resource.data.gender in ['Male', 'Female']
-                 && request.resource.data.breed is string
-                 && request.resource.data.breed.size() <= 100
-                 && request.resource.data.breeder is string
-                 && request.resource.data.breeder.size() <= 100
-                 && request.resource.data.notes is string
-                 && request.resource.data.notes.size() <= 4096
-                 && isValidTagList(request.resource.data.tags)
-                 && request.resource.data.schemaVersion is int
-                 && request.resource.data.appVersion is string
-                 && request.resource.data.appVersion.size() <= 32
-                 && contentHash.matches('^[a-f0-9]{64}$')
-                 && request.resource.data.uploadedAt is timestamp
-                 && request.resource.data.uploadedAt == request.time
-                 && request.resource.data.uploaderUid == null
-                 && existsAfter(/databases/$(db)/documents/genomes/$(contentHash));
+                 && docId.matches('^[a-f0-9]{64}$')
+                 && existsAfter(/databases/$(db)/documents/genomes/$(docId));
+
+      allow create: if isValidPetMeta(request.resource.data)
+                 && request.resource.data.keys().hasOnly([
+                        'name', 'character', 'species', 'gender',
+                        'breed', 'breeder', 'notes', 'tags', 'attributes',
+                        'schemaVersion', 'appVersion',
+                        'uploadedAt', 'uploaderUid', 'contentHash'
+                      ])
+                 && request.resource.data.contentHash is string
+                 && request.resource.data.contentHash.matches('^[a-f0-9]{64}$')
+                 && existsAfter(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash));
 
       allow update, delete: if false;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -135,7 +135,11 @@ service cloud.firestore {
                         || (
                           request.resource.data.contentHash is string
                           && request.resource.data.contentHash.matches('^[a-f0-9]{64}$')
-                          && existsAfter(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash))
+                          // `exists` (already committed), not `existsAfter`: a
+                          // correction may only follow a first share that has
+                          // already published the genome — it cannot bootstrap
+                          // the genome in its own batch.
+                          && exists(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash))
                         )
                     );
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -108,16 +108,17 @@ service cloud.firestore {
     match /pets/{docId} {
       allow read: if true;
 
-      allow create: if isValidPetMeta(request.resource.data)
-                 && request.resource.data.keys().hasOnly([
-                        'name', 'character', 'species', 'gender',
-                        'breed', 'breeder', 'notes', 'tags', 'attributes',
-                        'schemaVersion', 'appVersion',
-                        'uploadedAt', 'uploaderUid'
-                      ])
-                 && docId.matches('^[a-f0-9]{64}$')
-                 && existsAfter(/databases/$(db)/documents/genomes/$(docId));
-
+      // A single create rule spanning both shapes. Kept as ONE statement (not
+      // two `allow create`s) so `isValidPetMeta`/`hasOnly` are evaluated once:
+      // Firestore caps a rule at 1000 evaluated expressions, and the unrolled
+      // `isValidTagList` makes a second evaluation blow the budget.
+      //
+      // `hasOnly([...base, 'contentHash'])` admits both shapes (contentHash
+      // optional); the OR below is what actually distinguishes them:
+      //   • first share — doc ID IS the hash, no `contentHash` field, paired
+      //     with /genomes/{docId} via existsAfter().
+      //   • correction — auto-ID doc carrying `contentHash` pointing at an
+      //     already-published genome.
       allow create: if isValidPetMeta(request.resource.data)
                  && request.resource.data.keys().hasOnly([
                         'name', 'character', 'species', 'gender',
@@ -125,9 +126,18 @@ service cloud.firestore {
                         'schemaVersion', 'appVersion',
                         'uploadedAt', 'uploaderUid', 'contentHash'
                       ])
-                 && request.resource.data.contentHash is string
-                 && request.resource.data.contentHash.matches('^[a-f0-9]{64}$')
-                 && existsAfter(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash));
+                 && (
+                        (
+                          !('contentHash' in request.resource.data)
+                          && docId.matches('^[a-f0-9]{64}$')
+                          && existsAfter(/databases/$(db)/documents/genomes/$(docId))
+                        )
+                        || (
+                          request.resource.data.contentHash is string
+                          && request.resource.data.contentHash.matches('^[a-f0-9]{64}$')
+                          && existsAfter(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash))
+                        )
+                    );
 
       allow update, delete: if false;
     }

--- a/src/lib/services/autoShare.ts
+++ b/src/lib/services/autoShare.ts
@@ -11,11 +11,21 @@
  * dedupe on `content_hash` (`already-shared`), and skipping legacy rows that
  * have no shareable genome text. Failures never throw out of here — the caller's
  * import must succeed regardless of whether the share did.
+ *
+ * Attribute gate: a freshly-imported pet only has correct attributes when they
+ * were parsed from a structured name (Horse only); otherwise `petService`
+ * stores all-50 defaults that the user must hand-edit. Auto-sharing those would
+ * publish wrong data with no review, so auto-share only publishes pets whose
+ * name parses structurally. Everything else (all BeeWasp, unstructured Horses)
+ * is held back for a manual, reviewed share. The catalogue is add-only, so a
+ * user who later corrects a manually-shared pet's attributes re-shares to
+ * append a superseding entry.
  */
 import { get } from 'svelte/store';
 import { isPlaceholderConfig } from '$lib/firebase.js';
 import { pets } from '$lib/stores/pets.js';
 import { settings } from '$lib/stores/settings.js';
+import { parseStructuredPetName } from './nameParser.js';
 import { type BulkUploadSummary, uploadPets } from './shareService.js';
 
 /** Settings key for the opt-in toggle. */
@@ -43,6 +53,9 @@ export async function autoShareImportedPets(petIds: number[]): Promise<BulkUploa
   // field. Opting notes in stays exclusive to per-pet sharing (SharePetDialog).
   const toShare = get(pets)
     .filter((p) => wanted.has(p.id))
+    // Only pets with known-good (structured-name-parsed) attributes; skip the
+    // rest so we never auto-publish default-50 placeholders.
+    .filter((p) => parseStructuredPetName(p.name, p.species) !== null)
     .map((p) => ({ ...p, notes: '' }));
   if (toShare.length === 0) return null;
 

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -775,6 +775,11 @@ const strOrNull = (v: unknown): string | null => (typeof v === 'string' ? v : nu
  * for legacy entries that predate attribute publishing, or any doc whose
  * map is incomplete/tampered — callers then fall back to genome-derived
  * attributes, exactly as before this field existed.
+ *
+ * Enforces the same 0–100 integer contract as the rules/publish path: a
+ * float or out-of-range value (only reachable via a pre-rule or admin write)
+ * is treated as invalid so `applyImportMetadata` never writes a garbage
+ * attribute onto a local pet — it falls back to genome-derived values.
  */
 function readAttributes(raw: unknown): Record<string, number> | undefined {
   if (typeof raw !== 'object' || raw === null) return undefined;
@@ -782,7 +787,7 @@ function readAttributes(raw: unknown): Record<string, number> | undefined {
   const out: Record<string, number> = {};
   for (const k of ATTRIBUTE_KEYS) {
     const v = src[k];
-    if (typeof v !== 'number' || !Number.isFinite(v)) return undefined;
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 0 || v > 100) return undefined;
     out[k] = v;
   }
   return out;

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -14,9 +14,21 @@
  * without having to mock module-level state. Production callers omit the
  * argument and get the singleton from `$lib/firebase`.
  *
+ * The catalogue is **add-only**. There is no auth and nothing is ever
+ * mutated: the *first* share of a genome writes `/pets/{hash}` (metadata)
+ * and `/genomes/{hash}` (blob) atomically. When a user later corrects the
+ * attributes or tags of that same genome and re-shares, a *new* metadata
+ * doc is appended under an auto-ID carrying a `contentHash` field pointing
+ * back at the hash; the genome blob is never rewritten. Reads resolve a
+ * hash to its **latest** metadata entry (by `uploadedAt`). Because the
+ * breeder's `Character=` name is part of the hashed genome text, a hash is
+ * intrinsically tied to one breeder — spoofing a different name changes the
+ * hash and forks a separate entry rather than overwriting anyone's.
+ *
  * Wire-format vs interface conversions are owned here:
- *  - the upload payload does NOT carry `contentHash` (the doc ID is the
- *    hash; `firestore.rules` rejects a payload `contentHash` field).
+ *  - the *first-share* payload has no `contentHash` field (the doc ID is
+ *    the hash). *Correction* payloads carry `contentHash` since their doc
+ *    ID is an auto-ID. `firestore.rules` validates both shapes.
  *  - `uploadedAt` is sent as `serverTimestamp()` on write and converted
  *    from Firestore `Timestamp` to JS `Date` on read.
  *  - `tags` is sanitized on read to defend against pre-rule documents or
@@ -35,8 +47,10 @@ import {
   query,
   limit as queryLimit,
   serverTimestamp,
+  setDoc,
   startAfter,
   Timestamp,
+  where,
   writeBatch,
 } from 'firebase/firestore';
 
@@ -62,6 +76,31 @@ const TAG_CAP = 30;
 const TAG_MAX_LEN = 64;
 /** Default local tag applied to pets imported from the community catalogue. */
 const COMMUNITY_TAG = 'community';
+
+/** The eight attribute columns published as a nested `attributes` map. */
+const ATTRIBUTE_KEYS = [
+  'intelligence',
+  'toughness',
+  'friendliness',
+  'ruggedness',
+  'enthusiasm',
+  'virility',
+  'ferocity',
+  'temperament',
+] as const;
+
+/** Clamp a stored attribute to the published 0–100 integer range. */
+function clampAttribute(v: unknown): number {
+  const n = typeof v === 'number' && Number.isFinite(v) ? Math.round(v) : 0;
+  return Math.max(0, Math.min(100, n));
+}
+
+/** Build the nested attribute map for the wire payload from a local pet. */
+function buildAttributes(pet: Pet): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const k of ATTRIBUTE_KEYS) out[k] = clampAttribute((pet as unknown as Record<string, unknown>)[k]);
+  return out;
+}
 
 export type UploadStatus = 'created' | 'already-shared';
 
@@ -116,49 +155,75 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
 
   const metaRef = doc(db, META_COLLECTION, pet.content_hash);
   const genomeRef = doc(db, GENOME_COLLECTION, pet.content_hash);
+  const payload = buildMetadataPayload(pet);
 
+  // Read the current catalogue state for this hash: the base metadata doc
+  // (ID == hash, written on first share), the genome blob, and any appended
+  // correction docs (auto-ID, carrying a `contentHash` field).
+  const [baseSnap, genomeSnap, corrSnap] = await Promise.all([
+    getDoc(metaRef),
+    getDoc(genomeRef),
+    getDocs(query(collection(db, META_COLLECTION), where('contentHash', '==', pet.content_hash))),
+  ]);
+
+  if (!baseSnap.exists()) {
+    // First share of this genome: metadata + blob written atomically.
+    return firstShare(pet, metaRef, genomeRef, payload, db);
+  }
+
+  // Base exists → the genome blob must too, or the entry is half-published
+  // and unimportable (rules deny repair). Surface it rather than piling a
+  // correction onto a broken row.
+  if (!genomeSnap.exists()) {
+    throw new Error(
+      `uploadPet: catalogue is half-published for hash ${pet.content_hash} (meta=true, genome=false). Contact an admin to repair.`,
+    );
+  }
+  await assertGenomeIntegrity(pet.content_hash, genomeSnap);
+
+  // Resolve the latest metadata across base + corrections. If it already
+  // matches what we're publishing, this is an idempotent no-op.
+  const latest = pickLatestSnapshot([baseSnap, ...corrSnap.docs]);
+  if (metadataMatches(toMetadataSharedPet(latest), pet)) {
+    return { status: 'already-shared', contentHash: pet.content_hash };
+  }
+
+  // Attributes/tags (or name/breed/…) differ from the latest entry: append
+  // a correction. The genome blob is unchanged, so this is a single metadata
+  // write under an auto-ID with a `contentHash` back-reference. Add-only —
+  // the prior entries stay, and reads resolve to this newest one.
+  const correctionRef = doc(collection(db, META_COLLECTION));
+  await setDoc(correctionRef, { ...payload, contentHash: pet.content_hash });
+  return { status: 'created', contentHash: pet.content_hash };
+}
+
+/**
+ * First-share path: write `/pets/{hash}` + `/genomes/{hash}` atomically.
+ * A concurrent first-share of the same hash trips permission-denied on the
+ * create; the recheck disambiguates an already-published entry (idempotent
+ * `already-shared`) from a half-published/corrupt one (surfaced as an error
+ * since rules deny repair). Duck-typed on `.code` because instanceof
+ * FirestoreError is fragile across module-graph re-instantiations.
+ */
+async function firstShare(
+  pet: Pet,
+  metaRef: ReturnType<typeof doc>,
+  genomeRef: ReturnType<typeof doc>,
+  payload: ReturnType<typeof buildMetadataPayload>,
+  db: Firestore,
+): Promise<UploadResult> {
   try {
     const batch = writeBatch(db);
-    batch.set(metaRef, buildMetadataPayload(pet));
+    batch.set(metaRef, payload);
     batch.set(genomeRef, { genomeData: pet.genome_text });
     await batch.commit();
     return { status: 'created', contentHash: pet.content_hash };
   } catch (err) {
-    // The only rules-allowed reason for permission-denied on this path is
-    // that one (or both) of the docs already exists (create is denied
-    // because it isn't a create; update/delete are denied unconditionally).
-    // A recheck disambiguates that from a genuinely misconfigured rules
-    // deploy. Duck-typed on `.code` because instanceof FirestoreError is
-    // fragile across module-graph re-instantiations (mocks, bundling).
     if (isPermissionDenied(err)) {
       try {
-        // Verify BOTH halves — a stale `/pets/{hash}` without its
-        // `/genomes/{hash}` twin (or vice versa) is a partial-publish
-        // state, not an idempotent already-shared. Returning
-        // already-shared in that case would mask a catalogue row that
-        // lists but cannot be imported, with no way for the client to
-        // repair (rules deny update/delete).
         const [metaSnap, genomeSnap] = await Promise.all([getDoc(metaRef), getDoc(genomeRef)]);
         if (metaSnap.exists() && genomeSnap.exists()) {
-          // Both docs exist — but Firestore rules only validate the doc
-          // ID shape, not that `genomeData` hashes to the ID. A corrupt
-          // (or maliciously-squatted) `/genomes/{hash}` doc would let
-          // listPets surface a row that fails every importer's
-          // `verifySharedPet`. Re-hash here so a legitimate uploader
-          // sees the corruption rather than thinking they've already
-          // published their pet.
-          const genomeData = (genomeSnap.data() as { genomeData?: unknown } | undefined)?.genomeData;
-          if (typeof genomeData !== 'string') {
-            throw new Error(
-              `uploadPet: catalogue entry ${pet.content_hash} is missing a genomeData field — contact an admin to repair.`,
-            );
-          }
-          const onWireHash = await sha256Hex(genomeData);
-          if (onWireHash !== pet.content_hash) {
-            throw new Error(
-              `uploadPet: catalogue entry ${pet.content_hash} is corrupt — sha256(genomeData on wire) = ${onWireHash}. Rules deny overwriting, so contact an admin to repair.`,
-            );
-          }
+          await assertGenomeIntegrity(pet.content_hash, genomeSnap);
           return { status: 'already-shared', contentHash: pet.content_hash };
         }
         if (metaSnap.exists() !== genomeSnap.exists()) {
@@ -167,11 +232,6 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
           );
         }
       } catch (recheckErr) {
-        // Re-throw any of the recheck-time integrity errors we raised
-        // above (half-publish / missing field / hash mismatch). For
-        // anything else (network hiccup, rules also denying reads,
-        // etc.), fall through and surface the original batch error —
-        // that's the one the caller can act on.
         if (recheckErr instanceof Error && recheckErr.message.startsWith('uploadPet: catalogue ')) {
           throw recheckErr;
         }
@@ -179,6 +239,69 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
     }
     throw err;
   }
+}
+
+/**
+ * Firestore rules validate only the doc-ID shape, not that a genome blob
+ * hashes to its ID. A corrupt (or maliciously-squatted) `/genomes/{hash}`
+ * would let the catalogue surface a row that fails every importer's
+ * `verifySharedPet`. Re-hash so a legitimate uploader sees the corruption
+ * rather than silently building on a broken entry.
+ */
+async function assertGenomeIntegrity(contentHash: string, genomeSnap: DocumentSnapshot<DocumentData>): Promise<void> {
+  const genomeData = (genomeSnap.data() as { genomeData?: unknown } | undefined)?.genomeData;
+  if (typeof genomeData !== 'string') {
+    throw new Error(
+      `uploadPet: catalogue entry ${contentHash} is missing a genomeData field — contact an admin to repair.`,
+    );
+  }
+  const onWireHash = await sha256Hex(genomeData);
+  if (onWireHash !== contentHash) {
+    throw new Error(
+      `uploadPet: catalogue entry ${contentHash} is corrupt — sha256(genomeData on wire) = ${onWireHash}. Rules deny overwriting, so contact an admin to repair.`,
+    );
+  }
+}
+
+/** Millis of a snapshot's `uploadedAt`, or 0 when absent/unwritten. */
+function snapshotMillis(snap: DocumentSnapshot<DocumentData>): number {
+  const ts = snap.data()?.uploadedAt;
+  return ts instanceof Timestamp ? ts.toMillis() : 0;
+}
+
+/** The most-recently-uploaded snapshot (latest-wins). Assumes a non-empty list. */
+function pickLatestSnapshot(snaps: DocumentSnapshot<DocumentData>[]): DocumentSnapshot<DocumentData> {
+  return snaps.reduce((a, b) => (snapshotMillis(b) >= snapshotMillis(a) ? b : a));
+}
+
+/**
+ * True when the already-published latest metadata equals what `pet` would
+ * publish now — the signal to skip an add-only correction. Compares only
+ * user-editable fields; `uploadedAt`/`appVersion`/`schemaVersion` are
+ * expected to drift and don't count as a change. A legacy entry with no
+ * attributes never matches a pet that now carries them, so re-sharing an
+ * old pet backfills its attributes via one correction.
+ */
+function metadataMatches(existing: SharedPet, pet: Pet): boolean {
+  if (existing.name !== pet.name) return false;
+  if (existing.gender !== pet.gender) return false;
+  if (existing.breed !== pet.breed) return false;
+  if ((existing.breeder ?? '') !== (pet.breeder ?? '')) return false;
+  if ((existing.notes ?? '') !== (pet.notes ?? '')) return false;
+  if (!sameStringSet(existing.tags, sanitizeTags(pet.tags))) return false;
+  return sameAttributes(existing.attributes, buildAttributes(pet));
+}
+
+function sameStringSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const sortedA = [...a].sort();
+  const sortedB = [...b].sort();
+  return sortedA.every((v, i) => v === sortedB[i]);
+}
+
+function sameAttributes(existing: Record<string, number> | undefined, next: Record<string, number>): boolean {
+  if (!existing) return false;
+  return ATTRIBUTE_KEYS.every((k) => existing[k] === next[k]);
 }
 
 /** Per-pet outcome of a bulk share. `skipped` = no shareable genome (legacy). */
@@ -357,13 +480,20 @@ export async function listPets(opts: ListPetsOpts = {}, db: Firestore = defaultF
  * to retry or treat as broken. The two reads run in parallel.
  */
 export async function getSharedPet(contentHash: string, db: Firestore = defaultFirestore): Promise<SharedPet | null> {
-  const [metaSnap, genomeSnap] = await Promise.all([
+  const [baseSnap, genomeSnap, corrSnap] = await Promise.all([
     getDoc(doc(db, META_COLLECTION, contentHash)),
     getDoc(doc(db, GENOME_COLLECTION, contentHash)),
+    // Correction docs carry the hash as a field (equality query, no
+    // composite index needed); the base doc's ID is the hash.
+    getDocs(query(collection(db, META_COLLECTION), where('contentHash', '==', contentHash))),
   ]);
-  if (!metaSnap.exists()) return null;
 
-  const pet = toMetadataSharedPet(metaSnap);
+  const metaSnaps = [...(baseSnap.exists() ? [baseSnap] : []), ...corrSnap.docs];
+  if (metaSnaps.length === 0) return null;
+
+  // Latest-wins: resolve the hash to its most recent metadata entry.
+  const pet = toMetadataSharedPet(pickLatestSnapshot(metaSnaps));
+  pet.contentHash = contentHash;
   const genomeData = genomeSnap.exists() ? (genomeSnap.data().genomeData as unknown) : undefined;
   pet.genomeData = typeof genomeData === 'string' ? genomeData : undefined;
   return pet;
@@ -574,6 +704,11 @@ async function applyImportMetadata(petId: number, shared: SharedPet): Promise<vo
   // apply when the uploader explicitly set one, so we don't clobber a
   // locally-parsed breed with empty.
   if (shared.breed) updates.breed = shared.breed;
+  // Corrected attributes published by the uploader supersede the values
+  // `petService.uploadPet` re-derived from the genome/name (which are the
+  // all-50 defaults when the name isn't structured). Absent on legacy
+  // entries — then the re-derived values stand, as before.
+  if (shared.attributes) updates.attributes = shared.attributes;
   if (Object.keys(updates).length === 0) return;
   try {
     await updatePet(petId, updates);
@@ -623,6 +758,7 @@ function buildMetadataPayload(pet: Pet) {
     breeder: pet.breeder,
     notes: pet.notes ?? '',
     tags: sanitizeTags(pet.tags),
+    attributes: buildAttributes(pet),
     schemaVersion: CURRENT_SCHEMA_VERSION,
     appVersion: APP_VERSION,
     uploadedAt: serverTimestamp(),
@@ -634,13 +770,33 @@ const str = (v: unknown, fallback = ''): string => (typeof v === 'string' ? v : 
 const num = (v: unknown, fallback = 0): number => (typeof v === 'number' ? v : fallback);
 const strOrNull = (v: unknown): string | null => (typeof v === 'string' ? v : null);
 
+/**
+ * Read the nested `attributes` map off a catalogue doc. Returns `undefined`
+ * for legacy entries that predate attribute publishing, or any doc whose
+ * map is incomplete/tampered — callers then fall back to genome-derived
+ * attributes, exactly as before this field existed.
+ */
+function readAttributes(raw: unknown): Record<string, number> | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const src = raw as Record<string, unknown>;
+  const out: Record<string, number> = {};
+  for (const k of ATTRIBUTE_KEYS) {
+    const v = src[k];
+    if (typeof v !== 'number' || !Number.isFinite(v)) return undefined;
+    out[k] = v;
+  }
+  return out;
+}
+
 function toMetadataSharedPet(snap: DocumentSnapshot<DocumentData>): SharedPet {
   const data = snap.data() ?? {};
   const uploadedAt = data.uploadedAt instanceof Timestamp ? data.uploadedAt.toDate() : new Date(0);
   const gender = data.gender === Gender.MALE || data.gender === Gender.FEMALE ? data.gender : Gender.MALE;
 
   return {
-    contentHash: snap.id,
+    // Correction docs carry the hash as a field (their doc ID is an
+    // auto-ID); the first-share doc's ID *is* the hash.
+    contentHash: typeof data.contentHash === 'string' ? data.contentHash : snap.id,
     name: str(data.name),
     character: str(data.character),
     species: str(data.species),
@@ -649,6 +805,7 @@ function toMetadataSharedPet(snap: DocumentSnapshot<DocumentData>): SharedPet {
     breeder: str(data.breeder),
     notes: str(data.notes),
     tags: sanitizeTags(data.tags),
+    attributes: readAttributes(data.attributes),
     schemaVersion: num(data.schemaVersion),
     appVersion: str(data.appVersion),
     // genomeData is intentionally absent on metadata-only reads.

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -21,6 +21,26 @@ import type { SharedPet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
 
 const PAGE_SIZE = 50;
+
+/**
+ * Collapse the add-only catalogue to one row per content hash, keeping the
+ * latest. `listPets` pages newest-first, and a correction always has a later
+ * `uploadedAt` than the base entry it supersedes, so the newest entry for a
+ * hash is always encountered first — keep-first-seen therefore keeps the
+ * latest and preserves the newest-first display order. Deduping the whole
+ * accumulated list (not just each page) also catches the case where a base
+ * entry and its correction straddle a page boundary.
+ */
+function dedupeLatest(pets: SharedPet[]): SharedPet[] {
+  const seen = new Set<string>();
+  const out: SharedPet[] = [];
+  for (const pet of pets) {
+    if (seen.has(pet.contentHash)) continue;
+    seen.add(pet.contentHash);
+    out.push(pet);
+  }
+  return out;
+}
 /**
  * How long a `loadInitial` result counts as fresh. Tab toggles within
  * this window reuse the cached page instead of refetching. Five minutes
@@ -121,8 +141,11 @@ export async function loadInitial(opts: { force?: boolean } = {}): Promise<void>
   try {
     const { pets, cursor } = await listPets({ limit: PAGE_SIZE });
     if (myGeneration !== loadGeneration) return;
-    communityView.pets = pets;
+    const deduped = dedupeLatest(pets);
+    communityView.pets = deduped;
     communityView.cursor = cursor;
+    // `hasMore` tracks the raw page size, not the deduped count: a full
+    // page means more docs remain to page through even if some collapsed.
     communityView.hasMore = pets.length === PAGE_SIZE;
     lastLoadedAt = Date.now();
     // If the previously-selected pet was paginated out of the new first
@@ -169,7 +192,7 @@ export async function loadMore(): Promise<void> {
   try {
     const { pets, cursor } = await listPets({ limit: PAGE_SIZE, after: communityView.cursor });
     if (myGeneration !== loadGeneration) return;
-    communityView.pets = [...communityView.pets, ...pets];
+    communityView.pets = dedupeLatest([...communityView.pets, ...pets]);
     communityView.cursor = cursor;
     communityView.hasMore = pets.length === PAGE_SIZE;
   } catch (err) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -477,6 +477,15 @@ export interface SharedPet {
   breeder: string;
   notes: string;
   tags: string[];
+  /**
+   * Corrected attribute values (0–100), keyed by the eight attribute
+   * columns. Present on entries shared by app versions that publish
+   * attributes; `undefined` on legacy entries, whose attributes the
+   * importer re-derives from the genome/name as before. Because the
+   * catalogue is add-only, a user correcting attributes publishes a new
+   * entry for the same content hash — reads resolve to the latest.
+   */
+  attributes?: Record<string, number>;
   schemaVersion: number;
   appVersion: string;
   genomeData?: string;

--- a/tests/integration/shareService.emulator.test.ts
+++ b/tests/integration/shareService.emulator.test.ts
@@ -146,6 +146,7 @@ describe('shareService end-to-end via emulator', () => {
         breeder: pet.breeder,
         notes: pet.notes,
         tags: pet.tags,
+        attributes: validAttributes(),
         schemaVersion: 1,
         appVersion: '0.6.3',
         uploadedAt: serverTimestamp(),
@@ -172,12 +173,52 @@ describe('shareService end-to-end via emulator', () => {
   it('getSharedPet returns null for an unknown hash', async () => {
     expect(await getSharedPet('0'.repeat(64), db)).toBeNull();
   });
+
+  it('re-sharing with corrected attributes appends a superseding entry (add-only)', async () => {
+    const pet = await freshPet('C1');
+    expect((await uploadPet(pet, db)).status).toBe('created');
+
+    // Same genome (same hash) but corrected attributes → a new metadata
+    // entry, not a mutation. Attributes aren't part of the hashed genome.
+    const corrected = { ...pet, intelligence: 99, toughness: 7 };
+    expect((await uploadPet(corrected, db)).status).toBe('created');
+
+    // getSharedPet resolves latest-wins.
+    const fetched = await getSharedPet(pet.content_hash, db);
+    expect(fetched?.attributes?.intelligence).toBe(99);
+    expect(fetched?.attributes?.toughness).toBe(7);
+    expect(fetched?.genomeData).toBe(pet.genome_text);
+
+    // Two metadata docs (base + correction), a single shared genome blob.
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(2);
+    expect((await getDocs(query(collection(db, GENOME_COLLECTION)))).size).toBe(1);
+  });
+
+  it('re-sharing an identical pet stays already-shared (no correction appended)', async () => {
+    const pet = await freshPet('C2');
+    await uploadPet(pet, db);
+    expect((await uploadPet(pet, db)).status).toBe('already-shared');
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(1);
+  });
 });
 
 // Any 64-char lowercase hex value passes the rule regex; the rules
 // can't verify hash agreement (the SHA-256 ↔ genomeData binding is
 // enforced client-side via verifySharedPet).
 const VALID_DOC_ID = 'a'.repeat(64);
+
+function validAttributes() {
+  return {
+    intelligence: 50,
+    toughness: 50,
+    friendliness: 50,
+    ruggedness: 50,
+    enthusiasm: 50,
+    virility: 50,
+    ferocity: 50,
+    temperament: 0,
+  };
+}
 
 function validMetadata() {
   return {
@@ -189,6 +230,7 @@ function validMetadata() {
     breeder: 'PlayerOne',
     notes: '',
     tags: ['fast'],
+    attributes: validAttributes(),
     schemaVersion: 1,
     appVersion: '0.6.3',
     // Rules require `uploadedAt == request.time`, so the only way to
@@ -258,6 +300,11 @@ describe('firestore.rules — /pets metadata schema', () => {
     ['non-string entry in tags', { tags: ['ok', 42] }],
     ['over-long tag entry (>64 chars)', { tags: ['x'.repeat(65)] }],
     ['uploaderUid != null', { uploaderUid: 'someone' }],
+    ['attribute above 100', { attributes: { ...validAttributes(), intelligence: 101 } }],
+    ['attribute below 0', { attributes: { ...validAttributes(), toughness: -1 } }],
+    ['non-integer attribute', { attributes: { ...validAttributes(), ferocity: 50.5 } }],
+    ['attributes missing a key', { attributes: { intelligence: 50 } }],
+    ['attributes not a map', { attributes: 'nope' }],
   ])('rejects %s', async (_label, override) => {
     await expectRejected(batchWrite(VALID_DOC_ID, override));
   });
@@ -312,6 +359,36 @@ describe('firestore.rules — existsAfter() bans orphan docs', () => {
 
   it('rejects a single-collection write to /genomes (no matching /pets)', async () => {
     await expectRejected(setDoc(doc(db, GENOME_COLLECTION, VALID_DOC_ID), validGenome()));
+  });
+});
+
+describe('firestore.rules — add-only corrections', () => {
+  // A correction is an auto-ID /pets doc carrying a `contentHash` field that
+  // points back at an already-published genome. It lets a user append a
+  // superseding metadata entry without mutating the immutable original.
+  function correctionMeta(hash: string, override = {}) {
+    return { ...validMetadata(), contentHash: hash, ...override };
+  }
+
+  it('accepts a correction doc referencing an existing genome', async () => {
+    await batchWrite(VALID_DOC_ID); // first share establishes the genome
+    await setDoc(doc(collection(db, META_COLLECTION)), correctionMeta(VALID_DOC_ID));
+    // Base + correction both present under the same content hash.
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(2);
+  });
+
+  it('rejects a correction whose contentHash points at a genome that does not exist', async () => {
+    await expectRejected(setDoc(doc(collection(db, META_COLLECTION)), correctionMeta('b'.repeat(64))));
+  });
+
+  it('rejects a correction with a malformed contentHash', async () => {
+    await batchWrite(VALID_DOC_ID);
+    await expectRejected(setDoc(doc(collection(db, META_COLLECTION)), correctionMeta('not-hex')));
+  });
+
+  it('rejects a correction carrying an unknown extra field', async () => {
+    await batchWrite(VALID_DOC_ID);
+    await expectRejected(setDoc(doc(collection(db, META_COLLECTION)), correctionMeta(VALID_DOC_ID, { nope: 1 })));
   });
 });
 

--- a/tests/unit/autoShare.test.ts
+++ b/tests/unit/autoShare.test.ts
@@ -19,7 +19,7 @@ const h = vi.hoisted(() => {
   return {
     placeholder: false,
     settings: makeStore<Record<string, unknown>>({}),
-    pets: makeStore<Array<{ id: number }>>([]),
+    pets: makeStore<Array<Record<string, unknown>>>([]),
   };
 });
 
@@ -42,21 +42,48 @@ function summary(over: Partial<Record<string, number>> = {}) {
   return { created: 0, alreadyShared: 0, skipped: 0, failed: 0, items: [], ...over } as never;
 }
 
+// Structured Horse names (breed + M/F + 7 attribute values) parse into
+// known-good attributes, so they clear the auto-share gate. Everything else
+// (unstructured names, all BeeWasp) is held back for a reviewed manual share.
+const STRUCTURED_1 = { id: 1, name: 'Sb M 50 50 50 50 50 50 50', species: 'Horse', notes: 'private-1' };
+const STRUCTURED_3 = { id: 3, name: 'Sb F 60 60 60 60 60 60 60', species: 'Horse', notes: 'private-3' };
+const UNSTRUCTURED_2 = { id: 2, name: 'Just A Name', species: 'Horse', notes: '' };
+
 describe('autoShareImportedPets', () => {
   beforeEach(() => {
     uploadPetsMock.mockReset();
     h.placeholder = false;
     h.settings.set({ [AUTO_SHARE_ON_IMPORT]: true });
-    h.pets.set([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    h.pets.set([STRUCTURED_1, UNSTRUCTURED_2, STRUCTURED_3]);
   });
 
-  it('shares the matching imported pets when enabled', async () => {
+  it('shares gated (structured-name) imported pets with notes stripped', async () => {
     uploadPetsMock.mockResolvedValue(summary({ created: 2 }));
     const result = await autoShareImportedPets([1, 3]);
 
     expect(uploadPetsMock).toHaveBeenCalledTimes(1);
-    expect(uploadPetsMock.mock.calls[0][0]).toEqual([{ id: 1 }, { id: 3 }]);
+    // Both structured pets go, but notes are cleared (no per-pet review).
+    expect(uploadPetsMock.mock.calls[0][0]).toEqual([
+      { ...STRUCTURED_1, notes: '' },
+      { ...STRUCTURED_3, notes: '' },
+    ]);
     expect(result).toEqual(summary({ created: 2 }));
+  });
+
+  it('skips pets whose attributes are not known-good (unstructured name)', async () => {
+    uploadPetsMock.mockResolvedValue(summary({ created: 1 }));
+    const result = await autoShareImportedPets([1, 2]);
+
+    expect(uploadPetsMock).toHaveBeenCalledTimes(1);
+    // Only the structured pet 1 is published; the unstructured pet 2 is held back.
+    expect(uploadPetsMock.mock.calls[0][0]).toEqual([{ ...STRUCTURED_1, notes: '' }]);
+    expect(result).toEqual(summary({ created: 1 }));
+  });
+
+  it('returns null (no upload) when every requested pet fails the attribute gate', async () => {
+    h.pets.set([UNSTRUCTURED_2, { id: 4, name: 'Buzz', species: 'BeeWasp', notes: '' }]);
+    expect(await autoShareImportedPets([2, 4])).toBeNull();
+    expect(uploadPetsMock).not.toHaveBeenCalled();
   });
 
   it('does nothing when the setting is off (default-safe)', async () => {

--- a/tests/unit/communityStore.test.ts
+++ b/tests/unit/communityStore.test.ts
@@ -407,3 +407,34 @@ describe('community.svelte.ts — selection helpers', () => {
     expect(communityView.selectedHash).toBeNull();
   });
 });
+
+describe('community.svelte.ts — add-only latest-per-hash dedup', () => {
+  it('keeps only the newest entry per content hash within a page (newest-first)', async () => {
+    // listPets pages newest-first, so a correction (newer) precedes the base
+    // it supersedes. Keep-first-seen therefore keeps the correction.
+    const correction = makeSharedPet('dup', { name: 'Corrected', uploadedAt: new Date('2026-06-01T00:00:00Z') });
+    const base = makeSharedPet('dup', { name: 'Original', uploadedAt: new Date('2026-05-01T00:00:00Z') });
+    listPets.mockResolvedValueOnce({ pets: [makeSharedPet('other'), correction, base], cursor: null });
+
+    await loadInitial();
+
+    expect(communityView.pets).toHaveLength(2);
+    const dup = communityView.pets.find((p) => p.contentHash === 'dup');
+    expect(dup?.name).toBe('Corrected');
+  });
+
+  it('collapses a base/correction pair that straddles a page boundary', async () => {
+    // Correction lands on page 1 (newer), its base on page 2 (older). The
+    // accumulated list must not show both.
+    const correction = makeSharedPet('dup', { name: 'Corrected', uploadedAt: new Date('2026-06-01T00:00:00Z') });
+    const base = makeSharedPet('dup', { name: 'Original', uploadedAt: new Date('2026-05-01T00:00:00Z') });
+    listPets.mockResolvedValueOnce({ pets: [correction], cursor: { __snap: 'c1' } });
+    await loadInitial();
+    listPets.mockResolvedValueOnce({ pets: [base], cursor: null });
+    await loadMore();
+
+    const dups = communityView.pets.filter((p) => p.contentHash === 'dup');
+    expect(dups).toHaveLength(1);
+    expect(dups[0].name).toBe('Corrected');
+  });
+});

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -33,17 +33,22 @@ vi.mock('firebase/firestore', async () => {
   const actual = await vi.importActual('firebase/firestore');
   return {
     ...actual,
-    getDoc: vi.fn(),
-    getDocs: vi.fn(),
+    // Default to "nothing published yet": a bare `getDoc`/`getDocs` reads as
+    // absent so the first-share path runs without per-test wiring. Tests that
+    // exercise already-shared / correction / recheck paths override with
+    // `mockResolvedValueOnce` (consumed before the default).
+    getDoc: vi.fn(async () => ({ exists: () => false })),
+    getDocs: vi.fn(async () => ({ docs: [] })),
     setDoc: vi.fn(),
     writeBatch: vi.fn(() => createBatch()),
     serverTimestamp: vi.fn(() => '__SENTINEL_SERVER_TIMESTAMP__'),
-    doc: vi.fn((db, col, id) => ({ __db: db, path: `${col}/${id}`, id, col })),
+    doc: vi.fn((db, col, id) => ({ __db: db, path: id ? `${col}/${id}` : `${col}/__auto__`, id, col })),
     collection: vi.fn((db, col) => ({ __db: db, path: col })),
     query: vi.fn((coll, ...constraints) => ({ __coll: coll, constraints })),
     orderBy: vi.fn((field, dir) => ({ __op: 'orderBy', field, dir })),
     limit: vi.fn((n) => ({ __op: 'limit', n })),
     startAfter: vi.fn((value) => ({ __op: 'startAfter', value })),
+    where: vi.fn((field, op, value) => ({ __op: 'where', field, op, value })),
   };
 });
 
@@ -59,7 +64,7 @@ vi.mock('$lib/services/petService.js', () => ({
   uploadPet: vi.fn(),
 }));
 
-import { getDoc, getDocs, orderBy, startAfter, Timestamp, writeBatch } from 'firebase/firestore';
+import { getDoc, getDocs, orderBy, setDoc, startAfter, Timestamp, writeBatch } from 'firebase/firestore';
 import { findPetByHash, getPet, updatePet, uploadPet as uploadPetLocally } from '$lib/services/petService.js';
 import type { UploadResult } from '$lib/services/shareService.js';
 import {
@@ -80,6 +85,7 @@ import { makePet, DEFAULT_RAW_TEXT as RAW_TEXT, DEFAULT_RAW_TEXT_HASH as RAW_TEX
 const writeBatchMock = vi.mocked(writeBatch);
 const getDocMock = vi.mocked(getDoc);
 const getDocsMock = vi.mocked(getDocs);
+const setDocMock = vi.mocked(setDoc);
 const startAfterMock = vi.mocked(startAfter);
 const findPetByHashMock = vi.mocked(findPetByHash);
 const getPetMock = vi.mocked(getPet);
@@ -116,12 +122,50 @@ function lastBatch(): BatchCall[] {
   return batch;
 }
 
-describe('shareService.uploadPet', () => {
+/** The eight attribute columns of the default fixture pet (all 50, temperament 0). */
+const FIXTURE_ATTRS = {
+  intelligence: 50,
+  toughness: 50,
+  friendliness: 50,
+  ruggedness: 50,
+  enthusiasm: 50,
+  virility: 50,
+  ferocity: 50,
+  temperament: 0,
+};
+
+/** Catalogue metadata that matches `makePet()` field-for-field (an idempotent re-share). */
+function matchingMeta(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'Buzz',
+    character: 'PlayerOne',
+    species: 'BeeWasp',
+    gender: Gender.FEMALE,
+    breed: '',
+    breeder: 'PlayerOne',
+    notes: '',
+    tags: ['fast', 'fierce'],
+    attributes: { ...FIXTURE_ATTRS },
+    schemaVersion: 1,
+    appVersion: '0.6.3',
+    uploadedAt: Timestamp.fromDate(new Date('2026-05-10T12:00:00Z')),
+    uploaderUid: null,
+    ...overrides,
+  };
+}
+
+/** A read snapshot double. `getDoc` reads: base then genome, in that call order. */
+function readSnap(data: unknown, { exists = true, id }: { exists?: boolean; id?: string } = {}) {
+  return { exists: () => exists, id, data: () => data } as never;
+}
+
+describe('shareService.uploadPet — first share', () => {
   it('writes metadata + raw genome text in a single batch with no contentHash field in metadata', async () => {
     const result = await uploadPet(makePet());
 
     expect(result.status).toBe('created');
     expect(writeBatch).toHaveBeenCalledTimes(1);
+    expect(setDoc).not.toHaveBeenCalled();
     const batch = lastBatch();
     expect(batch).toHaveLength(2);
 
@@ -134,6 +178,7 @@ describe('shareService.uploadPet', () => {
     expect(Object.keys(meta.payload).sort()).toEqual(
       [
         'appVersion',
+        'attributes',
         'breed',
         'breeder',
         'character',
@@ -152,6 +197,8 @@ describe('shareService.uploadPet', () => {
     expect(meta.payload).not.toHaveProperty('genomeData');
     expect(meta.payload.uploaderUid).toBeNull();
     expect(meta.payload.uploadedAt).toBe('__SENTINEL_SERVER_TIMESTAMP__');
+    // Attributes are published as a nested, clamped 0–100 int map.
+    expect(meta.payload.attributes).toEqual(FIXTURE_ATTRS);
 
     // Genome doc gets the raw genome_text, NOT the JSON-stringified
     // genome_data. content_hash is sha256(raw text).
@@ -164,75 +211,7 @@ describe('shareService.uploadPet', () => {
     expect(writeBatch).not.toHaveBeenCalled();
   });
 
-  it('returns already-shared when both metadata and genome docs exist and the on-wire genome hashes correctly', async () => {
-    const batch = createBatch();
-    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
-    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
-    // Recheck reads BOTH halves in parallel — must mock both, AND the
-    // genome doc must carry `genomeData` that hashes to the
-    // content_hash so the new integrity-recheck path passes.
-    getDocMock.mockResolvedValueOnce({ exists: () => true, data: () => ({}) } as never); // meta
-    getDocMock.mockResolvedValueOnce({ exists: () => true, data: () => ({ genomeData: RAW_TEXT }) } as never);
-
-    const result = await uploadPet(makePet());
-    expect(result.status).toBe('already-shared');
-    expect(result.contentHash).toBe(RAW_TEXT_HASH);
-  });
-
-  it('rejects on duplicate recheck when the catalogue genome doc is missing its genomeData field', async () => {
-    // A doc that exists but doesn't carry a `genomeData` string is
-    // structurally invalid (rules require it on create, but admin /
-    // schema-migrating writes can bypass that). Surface explicitly
-    // rather than masking as already-shared.
-    const batch = createBatch();
-    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
-    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
-    getDocMock.mockResolvedValueOnce({ exists: () => true, data: () => ({}) } as never);
-    getDocMock.mockResolvedValueOnce({ exists: () => true, data: () => ({}) } as never); // no genomeData
-    await expect(uploadPet(makePet())).rejects.toThrow(/missing a genomeData field/);
-  });
-
-  it('rejects on duplicate recheck when the on-wire genome does not hash to the content_hash', async () => {
-    // Detects a corrupt / squatted catalogue entry: the genome blob
-    // on the wire doesn't match the doc ID hash, so every importer's
-    // `verifySharedPet` would reject the row. Block the legitimate
-    // uploader from getting a misleading already-shared response.
-    const batch = createBatch();
-    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
-    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
-    getDocMock.mockResolvedValueOnce({ exists: () => true, data: () => ({}) } as never);
-    getDocMock.mockResolvedValueOnce({
-      exists: () => true,
-      data: () => ({ genomeData: 'TAMPERED — not the raw text whose sha256 matches content_hash' }),
-    } as never);
-    await expect(uploadPet(makePet())).rejects.toThrow(/corrupt/);
-  });
-
-  it('re-throws the permission-denied when neither half exists (rules misconfig, not a duplicate)', async () => {
-    const batch = createBatch();
-    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
-    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
-    getDocMock.mockResolvedValueOnce({ exists: () => false } as never);
-    getDocMock.mockResolvedValueOnce({ exists: () => false } as never);
-    await expect(uploadPet(makePet())).rejects.toThrow(/PERMISSION_DENIED/);
-  });
-
-  it('rejects half-published state when /pets exists but /genomes does not', async () => {
-    // Catching this here keeps a catalogue row from appearing in
-    // listPets that no importer can ever load (the genome doc is
-    // missing). Surfacing as an error gives the user actionable
-    // signal and lets ops repair before more entries pile up.
-    const batch = createBatch();
-    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
-    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
-    getDocMock.mockResolvedValueOnce({ exists: () => true } as never); // meta
-    getDocMock.mockResolvedValueOnce({ exists: () => false } as never); // genome missing
-    await expect(uploadPet(makePet())).rejects.toThrow(/half-published/);
-  });
-
   it('rejects local rows whose stored content_hash does not match sha256(genome_text)', async () => {
-    // Defends against stale/restored/corrupt rows publishing a row
-    // that would fail every importer's `verifySharedPet`.
     const broken = makePet({ content_hash: 'f'.repeat(64) });
     await expect(uploadPet(broken)).rejects.toThrow(/local row is corrupt/);
     expect(writeBatch).not.toHaveBeenCalled();
@@ -241,6 +220,156 @@ describe('shareService.uploadPet', () => {
   it('rejects when content_hash is missing', async () => {
     await expect(uploadPet(makePet({ content_hash: '' }))).rejects.toThrow(/content_hash/);
     expect(writeBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('shareService.uploadPet — concurrent first-share race (batch permission-denied → recheck)', () => {
+  // The upfront reads see nothing published, so uploadPet takes the
+  // first-share batch path. A racer creates the docs before commit, so
+  // commit trips permission-denied and the recheck runs. getDoc call order
+  // per attempt: [upfront base, upfront genome, recheck meta, recheck genome].
+  function racingBatch() {
+    const batch = createBatch();
+    writeBatchMock.mockReturnValueOnce(batch as unknown as ReturnType<typeof writeBatch>);
+    batch.commit.mockRejectedValueOnce(Object.assign(new Error('PERMISSION_DENIED'), { code: 'permission-denied' }));
+  }
+
+  it('returns already-shared when the recheck finds both halves and the genome hashes correctly', async () => {
+    racingBatch();
+    getDocMock
+      .mockResolvedValueOnce(readSnap(null, { exists: false })) // upfront base
+      .mockResolvedValueOnce(readSnap(null, { exists: false })) // upfront genome
+      .mockResolvedValueOnce(readSnap({})) // recheck meta
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT })); // recheck genome
+
+    const result = await uploadPet(makePet());
+    expect(result.status).toBe('already-shared');
+    expect(result.contentHash).toBe(RAW_TEXT_HASH);
+  });
+
+  it('rejects when the raced-in genome doc is missing its genomeData field', async () => {
+    racingBatch();
+    getDocMock
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap({}))
+      .mockResolvedValueOnce(readSnap({})); // exists but no genomeData
+    await expect(uploadPet(makePet())).rejects.toThrow(/missing a genomeData field/);
+  });
+
+  it('rejects when the raced-in genome does not hash to the content_hash', async () => {
+    racingBatch();
+    getDocMock
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap({}))
+      .mockResolvedValueOnce(readSnap({ genomeData: 'TAMPERED — not the raw text whose sha256 matches content_hash' }));
+    await expect(uploadPet(makePet())).rejects.toThrow(/corrupt/);
+  });
+
+  it('re-throws permission-denied when neither half exists on recheck (rules misconfig, not a race)', async () => {
+    racingBatch();
+    getDocMock
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }));
+    await expect(uploadPet(makePet())).rejects.toThrow(/PERMISSION_DENIED/);
+  });
+
+  it('rejects half-published state when the recheck finds /pets but not /genomes', async () => {
+    racingBatch();
+    getDocMock
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false }))
+      .mockResolvedValueOnce(readSnap({})) // meta exists
+      .mockResolvedValueOnce(readSnap(null, { exists: false })); // genome missing
+    await expect(uploadPet(makePet())).rejects.toThrow(/half-published/);
+  });
+});
+
+describe('shareService.uploadPet — add-only corrections', () => {
+  it('is an idempotent no-op when the latest entry already matches (no write)', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta(), { id: RAW_TEXT_HASH })) // base exists, matches
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT })); // genome valid
+    // corrections query → default empty
+
+    const result = await uploadPet(makePet());
+    expect(result.status).toBe('already-shared');
+    expect(result.contentHash).toBe(RAW_TEXT_HASH);
+    expect(writeBatch).not.toHaveBeenCalled();
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it('appends a correction doc (auto-ID, with contentHash back-reference) when attributes differ', async () => {
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ attributes: { ...FIXTURE_ATTRS, intelligence: 99 } }), { id: RAW_TEXT_HASH }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet());
+    expect(result.status).toBe('created');
+    // Add-only: a NEW metadata doc is set; the genome blob is untouched.
+    expect(writeBatch).not.toHaveBeenCalled();
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.contentHash).toBe(RAW_TEXT_HASH);
+    expect(payload.attributes).toEqual(FIXTURE_ATTRS);
+    expect(payload).not.toHaveProperty('genomeData');
+  });
+
+  it('appends a correction when only the tags differ', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ tags: ['fast'] }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet());
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the latest entry across base + corrections before deciding', async () => {
+    // Base (older) differs, but a correction (newer) already matches → no-op.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ tags: ['stale'], uploadedAt: Timestamp.fromDate(new Date('2026-05-01T00:00:00Z')) }), {
+          id: RAW_TEXT_HASH,
+        }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+    getDocsMock.mockResolvedValueOnce({
+      docs: [
+        readSnap(
+          matchingMeta({
+            contentHash: RAW_TEXT_HASH,
+            uploadedAt: Timestamp.fromDate(new Date('2026-06-01T00:00:00Z')),
+          }),
+          { id: 'auto-123' },
+        ),
+      ],
+    } as never);
+
+    const result = await uploadPet(makePet());
+    expect(result.status).toBe('already-shared');
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it('rejects a half-published entry (base exists, genome missing) rather than piling on a correction', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta(), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap(null, { exists: false })); // genome missing
+    await expect(uploadPet(makePet())).rejects.toThrow(/half-published/);
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the existing genome blob is corrupt (does not hash to its ID)', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta(), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: 'TAMPERED' }));
+    await expect(uploadPet(makePet())).rejects.toThrow(/corrupt/);
+    expect(setDoc).not.toHaveBeenCalled();
   });
 });
 
@@ -363,6 +492,47 @@ describe('shareService.getSharedPet', () => {
       .mockResolvedValueOnce({ exists: () => false } as never);
     const pet = await getSharedPet(RAW_TEXT_HASH);
     expect(pet?.genomeData).toBeUndefined();
+  });
+
+  it('resolves the latest correction over the base entry (latest-wins)', async () => {
+    // Base entry (older) + a correction doc (newer, carries the hash as a
+    // field). getSharedPet must return the newest.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ name: 'OldName', uploadedAt: Timestamp.fromDate(new Date('2026-05-01T00:00:00Z')) }), {
+          id: RAW_TEXT_HASH,
+        }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: 'GENOME-BODY' }));
+    getDocsMock.mockResolvedValueOnce({
+      docs: [
+        readSnap(
+          matchingMeta({
+            name: 'NewName',
+            contentHash: RAW_TEXT_HASH,
+            attributes: { ...FIXTURE_ATTRS, intelligence: 90 },
+            uploadedAt: Timestamp.fromDate(new Date('2026-06-01T00:00:00Z')),
+          }),
+          { id: 'auto-9' },
+        ),
+      ],
+    } as never);
+
+    const pet = await getSharedPet(RAW_TEXT_HASH);
+    expect(pet?.name).toBe('NewName');
+    expect(pet?.contentHash).toBe(RAW_TEXT_HASH);
+    expect(pet?.attributes).toEqual({ ...FIXTURE_ATTRS, intelligence: 90 });
+    expect(pet?.genomeData).toBe('GENOME-BODY');
+  });
+
+  it('reads a complete attribute map into SharedPet.attributes, undefined when incomplete', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ attributes: { intelligence: 10 } }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: 'X' }));
+    // Partial attribute maps are treated as absent so the importer falls back
+    // to genome-derived values.
+    const pet = await getSharedPet(RAW_TEXT_HASH);
+    expect(pet?.attributes).toBeUndefined();
   });
 });
 
@@ -624,6 +794,53 @@ describe('shareService.importCommunityPet', () => {
       breed: 'Kurbone',
       gender: Gender.MALE,
     });
+  });
+
+  it('applies corrected attributes from the shared entry after a fresh import', async () => {
+    // petService re-derives attributes from the genome/name (all-50 defaults
+    // for an unstructured name). When the catalogue entry carries corrected
+    // attributes, those must supersede the re-derived ones.
+    const shared = await makeShared('ATTR');
+    shared.attributes = {
+      intelligence: 88,
+      toughness: 12,
+      friendliness: 50,
+      ruggedness: 50,
+      enthusiasm: 50,
+      virility: 50,
+      ferocity: 73,
+      temperament: 0,
+    };
+    uploadPetLocallyMock.mockResolvedValueOnce({
+      status: 'success',
+      kind: 'created',
+      message: '',
+      pet_id: 61,
+      name: shared.name,
+    });
+    updatePetMock.mockResolvedValue(true);
+
+    await importCommunityPet(shared);
+
+    expect(updatePet).toHaveBeenCalledWith(61, expect.objectContaining({ attributes: shared.attributes }));
+  });
+
+  it('does not touch attributes when the shared entry is legacy (no attributes)', async () => {
+    const shared = await makeShared('LEGACY');
+    shared.name = 'Renamed';
+    // attributes intentionally left undefined (pre-attribute catalogue entry)
+    uploadPetLocallyMock.mockResolvedValueOnce({
+      status: 'success',
+      kind: 'created',
+      message: '',
+      pet_id: 62,
+      name: shared.name,
+    });
+    updatePetMock.mockResolvedValue(true);
+
+    await importCommunityPet(shared);
+
+    expect(updatePet).not.toHaveBeenCalledWith(62, expect.objectContaining({ attributes: expect.anything() }));
   });
 
   it('does NOT override metadata on a backfilled import (preserves user edits)', async () => {

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -534,6 +534,18 @@ describe('shareService.getSharedPet', () => {
     const pet = await getSharedPet(RAW_TEXT_HASH);
     expect(pet?.attributes).toBeUndefined();
   });
+
+  it.each([
+    ['a non-integer (float) attribute', { ...FIXTURE_ATTRS, intelligence: 50.5 }],
+    ['an out-of-range attribute (>100)', { ...FIXTURE_ATTRS, toughness: 101 }],
+    ['a negative attribute', { ...FIXTURE_ATTRS, ferocity: -1 }],
+  ])('treats %s as absent (tampered/pre-rule doc) so import falls back to genome-derived values', async (_label, attributes) => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ attributes }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: 'X' }));
+    const pet = await getSharedPet(RAW_TEXT_HASH);
+    expect(pet?.attributes).toBeUndefined();
+  });
 });
 
 describe('shareService.sanitizeTags', () => {


### PR DESCRIPTION
Branches off the redesign epic (#341) so it reviews as a focused, self-contained change.

## Problem
Auto-share (and manual share) publish a pet at import time, but a pet's attributes are the all-50 defaults unless its name uses the structured Horse format. The catalogue keyed each genome hash to one **immutable** doc (`allow update, delete: if false`), and attributes weren't in the schema at all — importers re-derived them from the genome/name, so wrong values propagated to everyone with no way to fix them.

## Approach
Add-only corrections, no auth required:

- **Attributes are published** as a nested `attributes` map (8 ints, 0–100).
- **The catalogue is add-only.** First share writes `/pets/{hash}` + `/genomes/{hash}` atomically as before. Re-sharing a pet whose attributes/tags (or name/breed/…) changed appends a *new* metadata doc (auto-ID, carrying a `contentHash` back-reference); the genome blob is never rewritten or duplicated. Reads resolve a hash to its **latest** entry by `uploadedAt`.
- **No auth needed.** The breeder `Character=` name is part of the hashed genome text, so a hash is intrinsically tied to one breeder. Spoofing a different name changes the hash and forks a separate entry rather than overwriting anyone's.
- **Import** applies the shared (corrected) attributes instead of re-deriving them; legacy entries without attributes fall back to the old behaviour.
- **Auto-share is gated** to pets with known-good (structured-name-parsed) attributes, so it never auto-publishes default-50 placeholders. This means BeeWasp and unstructured Horses are held back for a reviewed manual share.

## Rules
`firestore.rules` gains attribute validation and a second `/pets` create shape for corrections (auto-ID + `contentHash` field, bound to an existing genome via `existsAfter`). `update`/`delete` stay denied — corrections are appends, never edits.

## How a user corrects a shared pet
Edit attributes/tags locally (PetEditor), then share again. The re-share appends a correction; the catalogue shows the latest.

## Tests
- Unit (`vitest run`): 798 pass (+6). New coverage for the correction/no-op decision, latest-wins reads, attribute publish/read/import, the auto-share gate, and cross-page latest-per-hash dedup.
- Emulator/rules (`test:firestore`): attribute-range/shape rejection, correction accept/reject (missing genome, malformed hash, extra field), and an end-to-end corrected-attributes round-trip. Not run locally (no Java runtime) — runs in CI.

## Trade-offs
- Breeder name is attribution, not authentication (accepted — hash binds it).
- Metadata storage grows with corrections (genome blob is shared, not duplicated); append-only by design.
- Latest-per-hash dedup on read is client-side; fine at this catalogue's scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)