### PR TITLE
Fix: dimming genes flattens their fill (single-pet view)

### DIFF
--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -273,14 +273,16 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
         border-color: #d0d0d6 !important;
     }
 
+    /* De-emphasise a gene the current filter/selection excludes. Only fade
+       and desaturate — do NOT override background/border, or a recessive
+       (transparent centre) and mixed (half gradient) gene would redraw as a
+       solid fill. Matches the trio grid, which dims locked loci with opacity
+       alone. Keeping the fill also avoids the flicker from the base
+       `.gene-cell { transition: all }` animating a background swap. */
     :global(.gene-filtered-out) {
         opacity: 0.25 !important;
-        filter: grayscale(1) blur(0.5px);
+        filter: grayscale(1);
         pointer-events: none !important;
-        background: #f9fafb !important;
-        border-color: #b0b4ba !important;
-        color: #b0b4ba !important;
-        transition: opacity 0.2s;
     }
 
     /* Appearance-based gene colors */

--- a/tests/e2e/redesign-mypets.spec.ts
+++ b/tests/e2e/redesign-mypets.spec.ts
@@ -57,6 +57,42 @@ test.describe('Redesign — My Pets (table-first)', () => {
     await expect(page.locator('[data-testid="roster"]')).toBeVisible();
   });
 
+  test('dimming a gene (chromosome select) preserves its fill, only fading it', async ({ page }) => {
+    // Regression: `.gene-filtered-out` used to force a solid background + grey
+    // border, so a dimmed recessive (hollow) or mixed (half-gradient) gene
+    // redrew as a solid square (visible flicker + wrong shape). Dimming must
+    // only fade/desaturate and keep the original fill, like the trio grid.
+    await openMyPets(page);
+    await page.locator('button[data-testid="roster-open"]:has-text("Sample Horse")').click();
+    await expect(page.locator('.pet-visualization')).toBeVisible();
+
+    // Select a single chromosome — every gene on other chromosomes dims.
+    await page.locator('.pet-visualization .chromosome-label[data-chromosome="01"]').click();
+
+    const dimmedRecessive = page.locator('.pet-visualization .gene-cell.gene-filtered-out.gene-recessive').first();
+    await expect(dimmedRecessive).toBeAttached();
+    // Poll opacity — the fade transitions from 1 over 0.2s, so a bare read can
+    // catch it mid-animation.
+    await expect
+      .poll(() => dimmedRecessive.evaluate((el) => Number(getComputedStyle(el).opacity)))
+      .toBeLessThan(1);
+    const recessive = await dimmedRecessive.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return { bg: cs.backgroundColor, borderWidth: cs.borderWidth };
+    });
+    // Recessive keeps its translucent centre + thick border (not the old solid
+    // rgb(249,250,251) fill).
+    expect(recessive.borderWidth).toBe('4px');
+    expect(recessive.bg).not.toBe('rgb(249, 250, 251)');
+
+    const dimmedMixed = page.locator('.pet-visualization .gene-cell.gene-filtered-out.gene-mixed').first();
+    if (await dimmedMixed.count()) {
+      const bgImage = await dimmedMixed.evaluate((el) => getComputedStyle(el).backgroundImage);
+      // Mixed keeps its half-fill gradient rather than a flat fill.
+      expect(bgImage).toContain('linear-gradient');
+    }
+  });
+
   test('a roster row can edit and delete a pet', async ({ page }) => {
     await openMyPets(page);
     const rows = page.locator('[data-testid="roster"] tbody tr');

--- a/tests/e2e/redesign-mypets.spec.ts
+++ b/tests/e2e/redesign-mypets.spec.ts
@@ -71,11 +71,12 @@ test.describe('Redesign — My Pets (table-first)', () => {
 
     const dimmedRecessive = page.locator('.pet-visualization .gene-cell.gene-filtered-out.gene-recessive').first();
     await expect(dimmedRecessive).toBeAttached();
-    // Poll opacity — the fade transitions from 1 over 0.2s, so a bare read can
-    // catch it mid-animation.
+    // Poll until the fade settles at the CSS value (0.25). Polling both rides
+    // out the 0.2s transition and pins the exact target, so a regression to a
+    // barely-dimmed value (e.g. 0.9) still fails.
     await expect
       .poll(() => dimmedRecessive.evaluate((el) => Number(getComputedStyle(el).opacity)))
-      .toBeLessThan(1);
+      .toBeCloseTo(0.25, 2);
     const recessive = await dimmedRecessive.evaluate((el) => {
       const cs = getComputedStyle(el);
       return { bg: cs.backgroundColor, borderWidth: cs.borderWidth };


### PR DESCRIPTION
## Problem
In the single-pet view, selecting an attribute (or a single chromosome) dims the excluded genes. `.gene-filtered-out` forced `background: #f9fafb` and a grey border, so a dimmed **recessive** (transparent centre + thick border) or **mixed** (half gradient) gene redrew as a solid square. Two symptoms:
- **Wrong**: the fill no longer reflects the gene's dominant/recessive/mixed value.
- **Flicker**: the base `.gene-cell { transition: all 0.2s }` animated the background swap on every selection.

The trio view doesn't have this — it dims with `opacity` alone.

## Fix
`.gene-filtered-out` now only fades + desaturates (`opacity: 0.25; filter: grayscale(1)`) and no longer overrides `background`/`border-color`/`color`. The original fill is preserved; only shading changes — matching the trio grid.

## Verification
Drove the app (Sample Horse → select chromosome 01) and confirmed via computed styles: dimmed recessive keeps its translucent 0.15-alpha background + 4px border, mixed keeps its `linear-gradient`, dominant stays solid — all at `opacity 0.25`. Before the fix all three were solid `rgb(249,250,251)`.

Added an e2e regression test (`redesign-mypets.spec.ts`) asserting a dimmed recessive keeps its fill (translucent bg, 4px border, faded) and a dimmed mixed keeps its gradient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)