### PR TITLE
fix(gene-grid): scale genome cells to fill container width

### DIFF
--- a/src/lib/components/gene/GeneCell.svelte
+++ b/src/lib/components/gene/GeneCell.svelte
@@ -130,9 +130,12 @@ const cssClass = $derived(computeCssClass(gene, geneAnalysis, currentView, isVis
 <style>
     /* Gene colors defined as --gene-* CSS vars in :root in src/app.css */
 
+    /* Size derives from --cell-size (set by the responsive grid container) so
+       the genome grid scales to fill its panel. Falls back to 14px wherever
+       --cell-size is unset (legend, comparison views, appearance summary). */
     :global(.gene-cell) {
-        width: 14px;
-        height: 14px;
+        width: calc(var(--cell-size, 16px) - 2px);
+        height: calc(var(--cell-size, 16px) - 2px);
         margin: 0px;
         border-radius: 3px;
         border: 2px solid;

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -24,6 +24,7 @@ import {
   type ParsedGene,
 } from '$lib/utils/geneAnalysis.js';
 import { type GeneEffectLookup, type GeneFilterState, isGeneVisible } from '$lib/utils/geneFilter.js';
+import { computeGeneCellSize } from '$lib/utils/geneGridCells.js';
 import {
   updateStats as accumulateStats,
   initializeStats as buildEmptyStats,
@@ -167,6 +168,38 @@ let tooltipPotentialEffects = $state<string[]>([]);
 // Parsed gene data
 let headerStructure = $state<HeaderStructure | null>(null);
 let chromosomeData = $state<ChromosomeRow[]>([]);
+
+// Responsive cell sizing — scale the fixed-cell grid to fill its container
+// width instead of leaving a large dead zone (wide window) or overflowing
+// with a scrollbar (narrow window / stats drawer open). A ResizeObserver
+// tracks the live container width; cell size is clamped for readability.
+let gridContainerEl = $state<HTMLDivElement>();
+let gridContainerWidth = $state(0);
+const totalGeneColumns = $derived.by(() => {
+  const hs = headerStructure;
+  if (!hs) return 0;
+  let total = 0;
+  for (const block of hs.sortedBlocks) total += hs.blockMaxGenes.get(block) ?? 0;
+  return total;
+});
+const cellSize = $derived(
+  computeGeneCellSize({
+    containerWidth: gridContainerWidth,
+    totalColumns: totalGeneColumns,
+    blockCount: headerStructure?.sortedBlocks.length ?? 0,
+  }),
+);
+
+$effect(() => {
+  const el = gridContainerEl;
+  if (!el) return;
+  const ro = new ResizeObserver((entries) => {
+    for (const entry of entries) gridContainerWidth = entry.contentRect.width;
+  });
+  ro.observe(el);
+  gridContainerWidth = el.clientWidth;
+  return () => ro.disconnect();
+});
 
 // Global gene effects database - persists across pet selections
 let globalGeneEffectsDB: Record<string, Record<string, GeneEffectData>> = {};
@@ -1370,7 +1403,12 @@ export function getStatsData() {
 
                 <!-- Gene Grid -->
                 <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div class="gene-grid-container" onkeydown={handleGridKeydown}>
+                <div
+                    class="gene-grid-container"
+                    bind:this={gridContainerEl}
+                    style="--cell-size: {cellSize}px"
+                    onkeydown={handleGridKeydown}
+                >
                     {#if headerStructure && chromosomeData.length > 0}
                         <!-- Optimized dynamic rendering -->
                         {#key currentSpeciesTemplate ? currentSpeciesTemplate.species + "_" + currentSpeciesTemplate.chromosomeCount + "_" + currentSpeciesTemplate.blockCount : "initial"}
@@ -1645,9 +1683,9 @@ export function getStatsData() {
     }
 
     .position-header {
-        width: 16px;
-        min-width: 16px;
-        max-width: 16px;
+        width: var(--cell-size, 16px);
+        min-width: var(--cell-size, 16px);
+        max-width: var(--cell-size, 16px);
         font-weight: normal;
     }
 
@@ -1717,7 +1755,7 @@ export function getStatsData() {
         text-align: center;
         vertical-align: middle;
         position: relative;
-        width: 16px;
+        width: var(--cell-size, 16px);
     }
 
     .gene-cell-container.empty {

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1727,6 +1727,7 @@ export function getStatsData() {
         cursor: pointer;
         transition: background-color 0.2s ease;
         user-select: none;
+        /* KEEP IN SYNC with CHR_COL_WIDTH in utils/geneGridCells.ts */
         width: 28px;
         min-width: 28px;
         max-width: 28px;
@@ -1763,6 +1764,7 @@ export function getStatsData() {
     }
 
     .gene-cell-container.block-start {
+        /* KEEP IN SYNC with BLOCK_GAP in utils/geneGridCells.ts */
         padding-left: 8px;
     }
 

--- a/src/lib/utils/geneGridCells.ts
+++ b/src/lib/utils/geneGridCells.ts
@@ -53,7 +53,14 @@ export const GENE_CELL_MIN = 12;
 export const GENE_CELL_MAX = 34;
 export const GENE_CELL_DEFAULT = 16;
 
-/** Fixed chromosome-label column width and per-block left padding (px). */
+/**
+ * Fixed chromosome-label column width and per-block left padding (px).
+ *
+ * KEEP IN SYNC with GeneVisualizer.svelte CSS: `.chromosome-label` /
+ * `.chromosome-header` width (CHR_COL_WIDTH) and `.gene-cell-container.block-start`
+ * padding-left (BLOCK_GAP). If those change, this width budget under- or
+ * over-estimates and reintroduces dead space or a horizontal scrollbar.
+ */
 const CHR_COL_WIDTH = 28;
 const BLOCK_GAP = 8;
 

--- a/src/lib/utils/geneGridCells.ts
+++ b/src/lib/utils/geneGridCells.ts
@@ -48,6 +48,40 @@ export interface GeneCell {
   effect: string;
 }
 
+/** Smallest / largest / fallback gene-cell edge (px) for the responsive grid. */
+export const GENE_CELL_MIN = 12;
+export const GENE_CELL_MAX = 34;
+export const GENE_CELL_DEFAULT = 16;
+
+/** Fixed chromosome-label column width and per-block left padding (px). */
+const CHR_COL_WIDTH = 28;
+const BLOCK_GAP = 8;
+
+/**
+ * Compute the gene-cell edge (px) so the fixed-cell genome grid fills the
+ * width of its container instead of leaving a dead zone (wide window) or
+ * overflowing with a scrollbar (narrow window / stats drawer open).
+ *
+ * The width budget reserves the chromosome-label column, the per-block left
+ * padding, and a small rounding margin. The result is clamped to
+ * [GENE_CELL_MIN, GENE_CELL_MAX] for readability, and falls back to
+ * GENE_CELL_DEFAULT before the container has been measured.
+ */
+export function computeGeneCellSize({
+  containerWidth,
+  totalColumns,
+  blockCount,
+}: {
+  containerWidth: number;
+  totalColumns: number;
+  blockCount: number;
+}): number {
+  if (!containerWidth || totalColumns <= 0) return GENE_CELL_DEFAULT;
+  const available = containerWidth - CHR_COL_WIDTH - blockCount * BLOCK_GAP - 4;
+  const raw = Math.floor(available / totalColumns);
+  return Math.max(GENE_CELL_MIN, Math.min(GENE_CELL_MAX, raw));
+}
+
 /** Build the `appearance name → key` lookup for a species. */
 export function buildAppearanceLookup(species: string): Map<string, string> {
   const attrs = getAppearanceAttributes(species);

--- a/tests/unit/geneGridCells.test.ts
+++ b/tests/unit/geneGridCells.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { getAppearanceAttributes } from '$lib/services/configService.js';
-import { buildAppearanceLookup, createGeneCellBuilder } from '$lib/utils/geneGridCells.js';
+import {
+  buildAppearanceLookup,
+  computeGeneCellSize,
+  createGeneCellBuilder,
+  GENE_CELL_DEFAULT,
+  GENE_CELL_MAX,
+  GENE_CELL_MIN,
+} from '$lib/utils/geneGridCells.js';
 
 const effectsDB = {
   // dominant positive
@@ -90,6 +97,44 @@ describe('createGeneCellBuilder.makeCell', () => {
   it('falls back to appearance-neutral when no appearance matches', () => {
     const cell = makeCell({ id: '01A1', type: 'D' });
     expect(cell.appearanceCls).toBe('gene-cell gene-appearance-neutral gene-dominant');
+  });
+});
+
+describe('computeGeneCellSize', () => {
+  // 48 gene columns across 12 blocks — the horse chr01 shape.
+  const shape = { totalColumns: 48, blockCount: 12 };
+
+  it('falls back to the default before the container is measured', () => {
+    expect(computeGeneCellSize({ containerWidth: 0, ...shape })).toBe(GENE_CELL_DEFAULT);
+  });
+
+  it('falls back to the default when there are no columns', () => {
+    expect(computeGeneCellSize({ containerWidth: 1200, totalColumns: 0, blockCount: 0 })).toBe(GENE_CELL_DEFAULT);
+  });
+
+  it('scales cells up to fill a wide container', () => {
+    // 1334 wide: (1334 - 28 - 96 - 4) / 48 = 25.1 → 25
+    expect(computeGeneCellSize({ containerWidth: 1334, ...shape })).toBe(25);
+  });
+
+  it('shrinks cells to fit a narrow container (stats drawer open)', () => {
+    // 862 wide: (862 - 28 - 96 - 4) / 48 = 15.3 → 15
+    expect(computeGeneCellSize({ containerWidth: 862, ...shape })).toBe(15);
+  });
+
+  it('never produces a size that overflows the width budget', () => {
+    for (const containerWidth of [400, 700, 862, 1000, 1200, 1334, 1920, 3000]) {
+      const size = computeGeneCellSize({ containerWidth, ...shape });
+      const consumed = 28 + shape.blockCount * 8 + shape.totalColumns * size;
+      // Only assert the fit when cells are not pinned to the min (a container
+      // too small for MIN_CELL legitimately overflows and scrolls).
+      if (size > GENE_CELL_MIN) expect(consumed).toBeLessThanOrEqual(containerWidth);
+    }
+  });
+
+  it('clamps to the readable min and max bounds', () => {
+    expect(computeGeneCellSize({ containerWidth: 100, ...shape })).toBe(GENE_CELL_MIN);
+    expect(computeGeneCellSize({ containerWidth: 100000, ...shape })).toBe(GENE_CELL_MAX);
   });
 });
 


### PR DESCRIPTION
## Problem
The pet-detail genome grid (`GeneVisualizer`, used by both the Attributes and Appearance views) rendered fixed 14px cells in a `flex: 1` container. Result:
- ~40% width + ~35% height dead gray zone on a wide window.
- Horizontal scrollbar on the default 1200×800 window once the Stats drawer opened.

Root cause: cells never responded to container size.

## Change
- New pure `computeGeneCellSize()` in `utils/geneGridCells.ts` — clamps cell edge to 12–34px of `(containerWidth − chromosome col − per-block padding) ÷ column count`.
- `GeneVisualizer` tracks live container width via `ResizeObserver` and drives a `--cell-size` CSS var.
- `GeneCell` square derives from `--cell-size` with a 16px fallback, so legend / comparison / appearance-summary usages are unchanged.

The width budget is column-count based; column count is built from the full `pet.grid` regardless of the breed filter, so full and breed-filtered views scale identically (the filter only changes visible rows and cell dimming).

## Verification
- Attributes + Appearance, 1440 wide: cells scale to 25px, grid fills width, no dead zone.
- 1200 default with Stats drawer open: cells shrink to 15px, fits with no horizontal scrollbar.
- `pnpm run check` 0 errors, `lint:ci` clean, 807/807 unit tests pass (6 new for `computeGeneCellSize`).

## Known limit
A residual gap remains below the grid: it's wide-and-short (~48 cols × 12 square rows), so filling width fully still leaves vertical slack — filling both while keeping cells square would overflow the width. Width-fill was prioritized as it removes the worse dead zone and enlarges cells for readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)