### PR TITLE
refactor(ui): move Settings and Pet Editor into the main app space

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -292,10 +292,16 @@ textarea {
 }
 
 /* --- Shared dialog styles --- */
+/* Bounded to the viewport with a scrollable body so tall dialogs (e.g.
+   Settings) never clip their header/footer on short windows. Header and
+   footer stay pinned; only .dialog-body scrolls. */
 .dialog {
   background: var(--bg-primary);
   border-radius: 12px;
   width: 90%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
   box-shadow: var(--shadow-lg);
   overflow: hidden;
 }
@@ -306,6 +312,7 @@ textarea {
   justify-content: space-between;
   padding: 16px 20px;
   border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
 }
 
 .dialog-header h3 {
@@ -316,6 +323,9 @@ textarea {
 
 .dialog-body {
   padding: 16px 20px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .dialog-footer {
@@ -325,6 +335,7 @@ textarea {
   padding: 14px 20px;
   border-top: 1px solid var(--border-primary);
   background: var(--bg-secondary);
+  flex-shrink: 0;
 }
 
 .close-btn {

--- a/src/lib/components/layout/SettingsView.svelte
+++ b/src/lib/components/layout/SettingsView.svelte
@@ -4,16 +4,20 @@ declare const __APP_VERSION__: string;
 
 <script lang="ts">
 import type { Update } from '@tauri-apps/plugin-updater';
+import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import { detectPlatform, getDefaultGameFolder } from '$lib/services/gameImport.js';
 import { settings, settingsActions } from '$lib/stores/settings.js';
 import { isTauri } from '$lib/utils/environment.js';
-import { focusTrap } from '$lib/utils/focusTrap.js';
 import { getFontScale as _getFontScale, clampScale, MAX_SCALE, MIN_SCALE } from '$lib/utils/fontScale.js';
 import { getThemePreference } from '$lib/utils/theme.js';
 
-type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'upToDate' | 'error';
+interface Props {
+  onClose: () => void;
+}
 
-let open = $state(false);
+const { onClose }: Props = $props();
+
+type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'upToDate' | 'error';
 
 let updateStatus = $state<UpdateStatus>('idle');
 let updateVersion = $state('');
@@ -50,14 +54,6 @@ function adjustFontScale(delta: number) {
 
 function setTheme(value: string) {
   settingsActions.update('display.theme', value);
-}
-
-function toggle() {
-  open = !open;
-}
-
-function close() {
-  open = false;
 }
 
 async function toggleSetting(key: string) {
@@ -102,29 +98,11 @@ async function installUpdate() {
 }
 </script>
 
-<button class="settings-toggle" onclick={toggle} title="Settings">
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
-    <circle cx="12" cy="12" r="3"/>
-  </svg>
-</button>
-
-{#if open}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="modal-backdrop" onclick={close} onkeydown={(e) => { if (e.key === 'Escape') close(); }} role="presentation">
-    <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="dialog settings-dialog" role="dialog" aria-label="Settings" aria-modal="true" tabindex="-1" use:focusTrap onclick={(e) => e.stopPropagation()} onkeydown={(e) => { if (e.key === 'Escape') close(); }}>
-      <div class="dialog-header">
-        <h3>Settings</h3>
-        <button class="close-btn" onclick={close} aria-label="Close settings">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"/>
-            <line x1="6" y1="6" x2="18" y2="18"/>
-          </svg>
-        </button>
-      </div>
-
-      <div class="dialog-body">
+<DetailOverlay onBack={onClose} backLabel="← Back" ariaLabel="Settings" testid="settings-view" backTestid="settings-back">
+  {#snippet title()}Settings{/snippet}
+  {#snippet children()}
+    <div class="settings-scroll">
+      <div class="settings-inner">
         <div class="settings-section">
           <h4>Horse Visualization</h4>
 
@@ -317,31 +295,20 @@ async function installUpdate() {
         </div>
       </div>
     </div>
-  </div>
-{/if}
+  {/snippet}
+</DetailOverlay>
 
 <style>
-  .settings-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border: none;
-    border-radius: 6px;
-    background: transparent;
-    color: var(--text-tertiary);
-    cursor: pointer;
-    transition: all 0.15s ease;
+  .settings-scroll {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
   }
 
-  .settings-toggle:hover {
-    background: var(--bg-tertiary);
-    color: var(--text-secondary);
-  }
-
-  .settings-dialog {
-    max-width: 480px;
+  .settings-inner {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 20px;
   }
 
   .settings-section h4 {
@@ -350,7 +317,7 @@ async function installUpdate() {
     color: var(--text-tertiary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .setting-row {
@@ -358,7 +325,7 @@ async function installUpdate() {
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    padding: 12px 0;
+    padding: 8px 0;
     cursor: pointer;
   }
 
@@ -414,8 +381,8 @@ async function installUpdate() {
   }
 
   .settings-section + .settings-section {
-    margin-top: 20px;
-    padding-top: 16px;
+    margin-top: 16px;
+    padding-top: 14px;
     border-top: 1px solid var(--border-primary);
   }
 

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -2,8 +2,8 @@
 import { ArrowLeft } from '@lucide/svelte';
 import logoImg from '$lib/assets/logo.png';
 import { activeTab, appState, canGoBack, type Tab } from '$lib/stores/pets.js';
+import { uiActions } from '$lib/stores/ui.js';
 import DataMenu from './DataMenu.svelte';
-import SettingsModal from './SettingsModal.svelte';
 
 function switchTab(tab: Tab) {
   appState.switchTab(tab);
@@ -80,7 +80,12 @@ function handleMouseUp(e: MouseEvent) {
         </button>
     </nav>
     <DataMenu />
-    <SettingsModal />
+    <button class="settings-toggle" onclick={() => uiActions.openSettings()} title="Settings" aria-label="Settings">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
+            <circle cx="12" cy="12" r="3"/>
+        </svg>
+    </button>
     </div>
 </header>
 
@@ -174,5 +179,24 @@ function handleMouseUp(e: MouseEvent) {
         background: var(--bg-primary);
         color: var(--text-primary);
         box-shadow: var(--shadow-sm);
+    }
+
+    .settings-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border: none;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--text-tertiary);
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .settings-toggle:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-secondary);
     }
 </style>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -80,8 +80,8 @@ function handleMouseUp(e: MouseEvent) {
         </button>
     </nav>
     <DataMenu />
-    <button class="settings-toggle" onclick={() => uiActions.openSettings()} title="Settings" aria-label="Settings">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <button type="button" class="settings-toggle" onclick={() => uiActions.openSettings()} title="Settings" aria-label="Settings">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
             <circle cx="12" cy="12" r="3"/>
         </svg>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -1,24 +1,23 @@
 <script lang="ts">
 import { House, PawPrint, Star } from '@lucide/svelte';
 import { untrack } from 'svelte';
+import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/configService.js';
 import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
 import type { AttributeInfo, Gender, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
-import { focusTrap } from '$lib/utils/focusTrap.js';
 import { computePetChanges } from '$lib/utils/petChanges.js';
 import TagInput from './TagInput.svelte';
 
 interface Props {
   pet: Pet;
-  open: boolean;
   onClose?: () => void;
   onSave?: (petId: number) => void;
 }
 
 const ALL_ATTRIBUTES: AttributeInfo[] = getAllAttributeDisplayInfo();
 
-let { pet, open = $bindable(), onClose, onSave }: Props = $props();
+let { pet, onClose, onSave }: Props = $props();
 
 const BREED_OPTIONS: Record<string, string[]> = {
   BeeWasp: ['Bee', 'Wasp'],
@@ -79,7 +78,6 @@ async function handleSave(): Promise<void> {
       await appState.updatePet(pet.id, updateData);
       onSave?.(pet.id);
     }
-    open = false;
     onClose?.();
   } catch (err) {
     saveError = (err as Error).message || 'Failed to save changes.';
@@ -88,16 +86,7 @@ async function handleSave(): Promise<void> {
 
 function handleCancel(): void {
   saveError = '';
-  open = false;
   onClose?.();
-}
-
-function handleBackdropClick(e: MouseEvent): void {
-  if (e.target === e.currentTarget) handleCancel();
-}
-
-function handleKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') handleCancel();
 }
 
 function updateAttribute(attrKey: string, value: string): void {
@@ -105,185 +94,149 @@ function updateAttribute(attrKey: string, value: string): void {
 }
 </script>
 
-{#if open}
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="modal-backdrop" onclick={handleBackdropClick} onkeydown={handleKeydown}>
-  <div class="modal-panel" role="dialog" aria-label="Edit Pet" aria-modal="true" use:focusTrap>
-    <div class="modal-header">
-      <h2>Edit Pet</h2>
-      <button class="modal-close" onclick={handleCancel}>×</button>
-    </div>
+<DetailOverlay onBack={handleCancel} backLabel="← Back" ariaLabel="Edit pet" testid="pet-editor" backTestid="pet-editor-back">
+  {#snippet title()}Edit Pet{/snippet}
+  {#snippet children()}
+    <div class="editor">
+      <div class="editor-scroll">
+        <div class="editor-inner">
+          {#if saveError}
+            <div class="save-error" role="alert">{saveError}</div>
+          {/if}
 
-    <div class="modal-body">
-      {#if saveError}
-        <div class="save-error" role="alert">{saveError}</div>
-      {/if}
-
-      <section class="form-section">
-        <h3>Basic Information</h3>
-        <div class="field">
-          <label for="petName">Pet Name</label>
-          <input id="petName" type="text" bind:value={editName} placeholder="Enter pet name" />
-        </div>
-        <div class="field-row">
-          <div class="field">
-            <label for="petSpecies">Species</label>
-            <input id="petSpecies" type="text" value={pet.species || 'Unknown'} disabled />
-          </div>
-          <div class="field">
-            <label for="petBreeder">Breeder</label>
-            <input id="petBreeder" type="text" value={pet.breeder || 'Unknown'} disabled />
-          </div>
-          <div class="field">
-            <label for="petGender">Gender</label>
-            <select id="petGender" bind:value={editGender}>
-              <option value="Male">Male</option>
-              <option value="Female">Female</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="petBreed">Breed</label>
-            <select id="petBreed" bind:value={editBreed}>
-              {#each breedOptions as breed}
-                <option value={breed}>{breed}</option>
-              {/each}
-            </select>
-          </div>
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h3>Tags</h3>
-        <TagInput tags={editTags} {allTags} onchange={(t) => { editTags = t; }} />
-      </section>
-
-      <section class="form-section">
-        <h3>Markers</h3>
-        <div class="markers">
-          <button
-            type="button"
-            class="marker star"
-            class:active={editStarred}
-            aria-pressed={editStarred}
-            onclick={() => { editStarred = !editStarred; }}
-          >
-            <Star size={16} fill={editStarred ? 'currentColor' : 'none'} />
-            <span>Starred</span>
-            <span class="marker-hint">favourites</span>
-          </button>
-          <button
-            type="button"
-            class="marker stable"
-            class:active={editStabled}
-            aria-pressed={editStabled}
-            onclick={() => { editStabled = !editStabled; }}
-          >
-            <House size={16} fill={editStabled ? 'currentColor' : 'none'} />
-            <span>Stabled</span>
-            <span class="marker-hint">available in your stables</span>
-          </button>
-          <button
-            type="button"
-            class="marker pet-quality"
-            class:active={editIsPetQuality}
-            aria-pressed={editIsPetQuality}
-            onclick={() => { editIsPetQuality = !editIsPetQuality; }}
-          >
-            <PawPrint size={16} fill={editIsPetQuality ? 'currentColor' : 'none'} />
-            <span>Pet quality</span>
-            <span class="marker-hint">not used for breeding</span>
-          </button>
-        </div>
-      </section>
-
-      <section class="form-section">
-        <h3>Attributes ({pet.species})</h3>
-        <div class="attributes-grid">
-          {#each filteredAttributeList as attr (attr.key)}
-            <div class="attr-field">
-              <label for="attr-{attr.key}">
-                <span class="attr-icon">{attr.icon}</span>
-                {attr.name}
-              </label>
-              <input
-                type="number"
-                id="attr-{attr.key}"
-                min="0"
-                max="100"
-                value={editAttributes[attr.key.toLowerCase()] ?? 50}
-                oninput={(e) => updateAttribute(attr.key.toLowerCase(), (e.currentTarget as HTMLInputElement).value)}
-              />
+          <section class="form-section">
+            <h3>Basic Information</h3>
+            <div class="field">
+              <label for="petName">Pet Name</label>
+              <input id="petName" type="text" bind:value={editName} placeholder="Enter pet name" />
             </div>
-          {/each}
-        </div>
-      </section>
-    </div>
+            <div class="field-row">
+              <div class="field">
+                <label for="petGender">Gender</label>
+                <select id="petGender" bind:value={editGender}>
+                  <option value="Male">Male</option>
+                  <option value="Female">Female</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="petBreed">Breed</label>
+                <select id="petBreed" bind:value={editBreed}>
+                  {#each breedOptions as breed}
+                    <option value={breed}>{breed}</option>
+                  {/each}
+                </select>
+              </div>
+            </div>
+            <p class="meta-line">
+              <span><span class="meta-label">Species</span> {pet.species || 'Unknown'}</span>
+              <span><span class="meta-label">Breeder</span> {pet.breeder || 'Unknown'}</span>
+            </p>
+          </section>
 
-    <div class="modal-footer">
-      <button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
-      <button class="btn btn-primary" onclick={handleSave}>Save Changes</button>
+          <section class="form-section">
+            <h3>Tags</h3>
+            <TagInput tags={editTags} {allTags} onchange={(t) => { editTags = t; }} />
+          </section>
+
+          <section class="form-section">
+            <h3>Markers</h3>
+            <div class="markers">
+              <button
+                type="button"
+                class="marker star"
+                class:active={editStarred}
+                aria-pressed={editStarred}
+                onclick={() => { editStarred = !editStarred; }}
+              >
+                <Star size={15} fill={editStarred ? 'currentColor' : 'none'} />
+                <span>Starred</span>
+                <span class="marker-hint">favourites</span>
+              </button>
+              <button
+                type="button"
+                class="marker stable"
+                class:active={editStabled}
+                aria-pressed={editStabled}
+                onclick={() => { editStabled = !editStabled; }}
+              >
+                <House size={15} fill={editStabled ? 'currentColor' : 'none'} />
+                <span>Stabled</span>
+                <span class="marker-hint">available in your stables</span>
+              </button>
+              <button
+                type="button"
+                class="marker pet-quality"
+                class:active={editIsPetQuality}
+                aria-pressed={editIsPetQuality}
+                onclick={() => { editIsPetQuality = !editIsPetQuality; }}
+              >
+                <PawPrint size={15} fill={editIsPetQuality ? 'currentColor' : 'none'} />
+                <span>Pet quality</span>
+                <span class="marker-hint">not used for breeding</span>
+              </button>
+            </div>
+          </section>
+
+          <section class="form-section">
+            <h3>Attributes ({pet.species})</h3>
+            <div class="attributes-grid">
+              {#each filteredAttributeList as attr (attr.key)}
+                <div class="attr-field">
+                  <label for="attr-{attr.key}">
+                    <span class="attr-icon">{attr.icon}</span>
+                    {attr.name}
+                  </label>
+                  <input
+                    type="number"
+                    id="attr-{attr.key}"
+                    min="0"
+                    max="100"
+                    value={editAttributes[attr.key.toLowerCase()] ?? 50}
+                    oninput={(e) => updateAttribute(attr.key.toLowerCase(), (e.currentTarget as HTMLInputElement).value)}
+                  />
+                </div>
+              {/each}
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <div class="editor-footer">
+        <button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
+        <button class="btn btn-primary" onclick={handleSave}>Save Changes</button>
+      </div>
     </div>
-  </div>
-</div>
-{/if}
+  {/snippet}
+</DetailOverlay>
 
 <style>
-  .modal-panel {
-    background: var(--bg-primary);
-    border-radius: 12px;
-    box-shadow: var(--shadow-xl);
-    width: 560px;
-    max-width: 90vw;
-    max-height: 85vh;
+  .editor {
+    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
   }
 
-  .modal-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 16px 20px;
-    border-bottom: 1px solid var(--border-primary);
-  }
-
-  .modal-header h2 {
-    margin: 0;
-    font-size: 16px;
-    font-weight: 700;
-    color: var(--text-primary);
-  }
-
-  .modal-close {
-    background: none;
-    border: none;
-    font-size: 20px;
-    color: var(--text-muted);
-    cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 4px;
-    line-height: 1;
-  }
-
-  .modal-close:hover {
-    background: var(--bg-tertiary);
-    color: var(--text-secondary);
-  }
-
-  .modal-body {
-    padding: 20px;
-    overflow-y: auto;
+  .editor-scroll {
     flex: 1;
+    min-height: 0;
+    overflow-y: auto;
   }
 
-  .modal-footer {
+  .editor-inner {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 20px;
+  }
+
+  .editor-footer {
     display: flex;
     justify-content: flex-end;
     gap: 8px;
     padding: 14px 20px;
     border-top: 1px solid var(--border-primary);
     background: var(--bg-secondary);
+    flex-shrink: 0;
   }
 
   .form-section {
@@ -335,15 +288,25 @@ function updateAttribute(attrKey: string, value: string): void {
     box-shadow: 0 0 0 2px var(--accent-soft);
   }
 
-  .field input:disabled {
-    background: var(--bg-secondary);
-    color: var(--text-muted);
-  }
-
   .field-row {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 12px;
+  }
+
+  /* Read-only provenance shown as plain text, not fake-editable inputs. */
+  .meta-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 20px;
+    margin: 4px 0 0 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+
+  .meta-label {
+    color: var(--text-muted);
+    margin-right: 4px;
   }
 
   .attributes-grid {

--- a/src/lib/components/shared/DetailOverlay.svelte
+++ b/src/lib/components/shared/DetailOverlay.svelte
@@ -10,9 +10,11 @@
  * These are deliberately *non-modal* in-tab lenses (you can still switch tabs),
  * not dialogs — so this is a `region` landmark, not `role="dialog"`. It still
  * manages keyboard affordances: focus lands inside on open and is restored to
- * the trigger on close, and Escape backs out. True modals layered on top
- * (PetEditor, delete-confirm) keep their own focus trap + Escape; the Escape
- * handler here defers to them so it can't double-close.
+ * the trigger on close, and Escape backs out. A true modal layered on top
+ * (the delete-confirm dialog) keeps its own focus trap + Escape; the Escape
+ * handler here defers to it so it can't double-close. (Settings and the pet
+ * editor are themselves in-space DetailOverlays mounted at the page root, not
+ * modals nested here.)
  *
  * Position: absolute/inset:0, so it covers its nearest positioned ancestor —
  * mount it inside a `position: relative` (or absolute) container.
@@ -78,7 +80,7 @@ onMount(() => {
 
 function handleKeydown(e: KeyboardEvent) {
   if (e.key !== 'Escape') return;
-  // Defer to a nested true-modal (PetEditor / delete-confirm): it owns its own
+  // Defer to a nested true-modal (the delete-confirm dialog): it owns its own
   // Escape, so don't also tear down the lens underneath it.
   if ((e.target as HTMLElement | null)?.closest?.('.modal-backdrop')) return;
   onBack();

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -10,8 +10,8 @@
  * `appState.deletePet`. See docs/design/redesign-library-workspace-v1.md §5.
  */
 
-import PetEditor from '$lib/components/pet/PetEditor.svelte';
 import { appState } from '$lib/stores/pets.js';
+import { uiActions } from '$lib/stores/ui.js';
 import type { Pet } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 
@@ -23,15 +23,10 @@ interface Props {
 
 const { pet, variant = 'icon' }: Props = $props();
 
-let showEditor = $state(false);
 let confirming = $state(false);
 
 function openEditor(): void {
-  showEditor = true;
-}
-
-function closeEditor(): void {
-  showEditor = false;
+  uiActions.openEditor(pet);
 }
 
 function confirmDelete(): void {
@@ -84,10 +79,6 @@ async function doDelete(): Promise<void> {
     data-pet-id={pet.id}
     onclick={confirmDelete}
   >Delete</button>
-{/if}
-
-{#if showEditor}
-  <PetEditor {pet} bind:open={showEditor} onClose={closeEditor} onSave={() => {}} />
 {/if}
 
 {#if confirming}

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,0 +1,18 @@
+import { writable } from 'svelte/store';
+import type { Pet } from '$lib/types/index.js';
+
+/**
+ * Global in-space overlays that live over the main workspace — Settings and the
+ * pet editor. These are full-view lenses (rendered via DetailOverlay), not
+ * modal dialogs, matching the redesign's Library/Workspace IA where the pet
+ * detail also lives in-space rather than in a popup.
+ */
+export const settingsOpen = writable(false);
+export const editingPet = writable<Pet | null>(null);
+
+export const uiActions = {
+  openSettings: () => settingsOpen.set(true),
+  closeSettings: () => settingsOpen.set(false),
+  openEditor: (pet: Pet) => editingPet.set(pet),
+  closeEditor: () => editingPet.set(null),
+};

--- a/src/lib/utils/fontScale.ts
+++ b/src/lib/utils/fontScale.ts
@@ -1,6 +1,6 @@
 /**
  * Shared font scale utilities.
- * Used by both +layout.svelte (global keyboard shortcuts) and SettingsModal (UI controls).
+ * Used by both +layout.svelte (global keyboard shortcuts) and SettingsView (UI controls).
  */
 
 export const MIN_SCALE = 75;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,8 +3,11 @@ import { onMount } from 'svelte';
 import BreedView from '$lib/components/breeding/BreedView.svelte';
 import CommunityTab from '$lib/components/community/CommunityTab.svelte';
 import ReferenceView from '$lib/components/gene/ReferenceView.svelte';
+import SettingsView from '$lib/components/layout/SettingsView.svelte';
 import MyPets from '$lib/components/library/MyPets.svelte';
+import PetEditor from '$lib/components/pet/PetEditor.svelte';
 import { activeTab, appState, error, loading } from '$lib/stores/pets.js';
+import { editingPet, settingsOpen, uiActions } from '$lib/stores/ui.js';
 
 onMount(async () => {
   await appState.loadPets();
@@ -32,6 +35,16 @@ onMount(async () => {
 		<CommunityTab />
 	{:else}
 		<MyPets />
+	{/if}
+
+	{#if $editingPet}
+		{#key $editingPet.id}
+			<PetEditor pet={$editingPet} onClose={uiActions.closeEditor} onSave={uiActions.closeEditor} />
+		{/key}
+	{/if}
+
+	{#if $settingsOpen}
+		<SettingsView onClose={uiActions.closeSettings} />
 	{/if}
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,27 +15,33 @@ onMount(async () => {
 </script>
 
 <div class="detail-content">
-	{#if $error}
-		<div class="error-banner" role="alert">
-			<div class="error-message">⚠️ {$error}</div>
-			<button class="error-close" onclick={() => appState.clearError()} aria-label="Dismiss error">×</button>
-		</div>
-	{/if}
+	<!-- The tab content is covered by the in-space overlays below. `inert` is
+	     bound reactively (not set once on mount by DetailOverlay's sibling
+	     logic) so that switching tabs while an overlay is open re-inerts the
+	     freshly-rendered tab content, keeping focus/AT out of the covered UI. -->
+	<div class="tab-layer" inert={$editingPet !== null || $settingsOpen}>
+		{#if $error}
+			<div class="error-banner" role="alert">
+				<div class="error-message">⚠️ {$error}</div>
+				<button class="error-close" onclick={() => appState.clearError()} aria-label="Dismiss error">×</button>
+			</div>
+		{/if}
 
-	{#if $loading}
-		<div class="center-state">
-			<div class="spinner"></div>
-			<p class="state-text">Loading...</p>
-		</div>
-	{:else if $activeTab === 'reference'}
-		<ReferenceView />
-	{:else if $activeTab === 'breed'}
-		<BreedView />
-	{:else if $activeTab === 'community'}
-		<CommunityTab />
-	{:else}
-		<MyPets />
-	{/if}
+		{#if $loading}
+			<div class="center-state">
+				<div class="spinner"></div>
+				<p class="state-text">Loading...</p>
+			</div>
+		{:else if $activeTab === 'reference'}
+			<ReferenceView />
+		{:else if $activeTab === 'breed'}
+			<BreedView />
+		{:else if $activeTab === 'community'}
+			<CommunityTab />
+		{:else}
+			<MyPets />
+		{/if}
+	</div>
 
 	{#if $editingPet}
 		{#key $editingPet.id}
@@ -54,6 +60,13 @@ onMount(async () => {
 		flex-direction: column;
 		position: absolute;
 		inset: 0;
+	}
+
+	.tab-layer {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
 	}
 
 	.error-banner {

--- a/tests/e2e/autoShare.spec.ts
+++ b/tests/e2e/autoShare.spec.ts
@@ -30,7 +30,7 @@ test.describe('Auto-share on import setting', () => {
     await expect(toggle).toHaveAttribute('aria-checked', 'true');
 
     await page.keyboard.press('Escape');
-    await expect(page.locator('.settings-dialog')).not.toBeVisible();
+    await expect(page.locator('[data-testid="settings-view"]')).not.toBeVisible();
     await page.locator('.settings-toggle').click();
     await expect(page.locator('[data-testid="setting-auto-share"]')).toHaveAttribute('aria-checked', 'true');
   });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -50,10 +50,10 @@ export async function openGeneEditor(page: Page) {
   await expect(page.locator('.gene-editing-view')).toBeVisible();
 }
 
-/** Open the edit modal for the first pet via its roster row action. */
+/** Open the in-space pet editor for the first pet via its roster row action. */
 export async function openEditor(page: Page) {
   await page.locator('[data-testid="roster"] tbody tr').first().locator('[data-testid="pet-edit-btn"]').click();
-  await expect(page.locator('.modal-panel')).toBeVisible();
+  await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
 }
 
 /**

--- a/tests/e2e/keyboard.spec.ts
+++ b/tests/e2e/keyboard.spec.ts
@@ -77,28 +77,30 @@ test.describe('Keyboard Navigation', () => {
     });
   });
 
-  test.describe('Settings Modal', () => {
-    test('Escape closes the modal', async ({ page }) => {
+  test.describe('Settings View', () => {
+    test('Escape closes the view', async ({ page }) => {
       await page.goto('/');
       await waitForAppReady(page);
 
       // Open settings
       await page.locator('.settings-toggle').click();
-      await expect(page.locator('.settings-dialog')).toBeVisible();
+      await expect(page.locator('[data-testid="settings-view"]')).toBeVisible();
 
       // Escape closes it
       await page.keyboard.press('Escape');
-      await expect(page.locator('.settings-dialog')).not.toBeVisible();
+      await expect(page.locator('[data-testid="settings-view"]')).not.toBeVisible();
     });
 
-    test('modal has aria-modal and focus trap', async ({ page }) => {
+    test('settings is a labelled in-space region', async ({ page }) => {
       await page.goto('/');
       await waitForAppReady(page);
 
+      // Settings is a non-modal in-space lens (DetailOverlay), so it's a
+      // labelled region landmark — not a role=dialog / aria-modal popup.
       await page.locator('.settings-toggle').click();
-      const dialog = page.locator('.settings-dialog');
-      await expect(dialog).toHaveAttribute('aria-modal', 'true');
-      await expect(dialog).toHaveAttribute('role', 'dialog');
+      const view = page.locator('[data-testid="settings-view"]');
+      await expect(view).toBeVisible();
+      await expect(view).toHaveAttribute('aria-label', 'Settings');
     });
 
     test('font scale controls are visible', async ({ page }) => {

--- a/tests/e2e/pet-crud.spec.ts
+++ b/tests/e2e/pet-crud.spec.ts
@@ -17,12 +17,12 @@ test.describe('Pet Editor – Save', () => {
     const originalName = (await firstRow.locator('[data-testid="roster-open"]').textContent())?.trim() ?? '';
 
     await firstRow.locator('[data-testid="pet-edit-btn"]').click();
-    await expect(page.locator('.modal-panel')).toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
     const newName = `Renamed-${Date.now()}`;
     await page.locator('#petName').fill(newName);
     await page.locator('.btn-primary').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // The renamed pet shows in the table (sort may move it).
@@ -34,7 +34,7 @@ test.describe('Pet Editor – Save', () => {
     await expect(page.locator('#petName')).toHaveValue(newName);
     await page.locator('#petName').fill(originalName);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saves gender change and persists it', async ({ page }) => {
@@ -48,7 +48,7 @@ test.describe('Pet Editor – Save', () => {
     await page.locator('.btn-primary').click();
 
     // Modal closes without error
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // Re-open and verify
@@ -58,7 +58,7 @@ test.describe('Pet Editor – Save', () => {
     // Restore
     await genderSelect.selectOption(originalGender);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saves breed change and persists it', async ({ page }) => {
@@ -76,7 +76,7 @@ test.describe('Pet Editor – Save', () => {
     await breedSelect.selectOption(newBreed);
 
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // Re-open and verify
@@ -86,7 +86,7 @@ test.describe('Pet Editor – Save', () => {
     // Restore
     await breedSelect.selectOption(originalBreed);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saves attribute changes and persists them', async ({ page }) => {
@@ -101,7 +101,7 @@ test.describe('Pet Editor – Save', () => {
     await page.locator('.btn-primary').click();
 
     // Modal closes without error — this is the exact scenario that was broken
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // Re-open and verify the attribute value persisted
@@ -111,7 +111,7 @@ test.describe('Pet Editor – Save', () => {
     // Restore
     await attrInput.fill(originalValue);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saves multiple attribute changes at once', async ({ page }) => {
@@ -134,7 +134,7 @@ test.describe('Pet Editor – Save', () => {
     }
 
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // Re-open and verify all values
@@ -148,7 +148,7 @@ test.describe('Pet Editor – Save', () => {
       await attrInputs.nth(i).fill(originals[i]);
     }
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saves combined name and attribute changes', async ({ page }) => {
@@ -166,7 +166,7 @@ test.describe('Pet Editor – Save', () => {
     await attrInput.fill(newAttr);
     await page.locator('.btn-primary').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
 
     // Verify both persisted
@@ -178,14 +178,14 @@ test.describe('Pet Editor – Save', () => {
     await nameInput.fill(originalName);
     await attrInput.fill(originalAttr);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
   });
 
   test('saving with no changes closes modal without error', async ({ page }) => {
     await openEditor(page);
     await page.locator('.btn-primary').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('.save-error')).toHaveCount(0);
   });
 });
@@ -207,7 +207,7 @@ test.describe('Pet Editor – Cancel', () => {
     await page.locator('#petName').fill('ShouldNotPersist');
     await page.locator('.btn-secondary').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);
   });
 
@@ -220,33 +220,33 @@ test.describe('Pet Editor – Cancel', () => {
     await attrInput.fill('0');
     await page.locator('.btn-secondary').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
 
     // Re-open and verify original value is intact
     await openEditor(page);
     await expect(page.locator('.attr-field input[type="number"]').first()).toHaveValue(originalValue);
-    await page.locator('.modal-close').click();
+    await page.locator('[data-testid="pet-editor-back"]').click();
   });
 
-  test('escape key closes modal without saving', async ({ page }) => {
+  test('escape key closes editor without saving', async ({ page }) => {
     const originalName = (await page.locator('[data-testid="roster-open"]').first().textContent()) ?? '';
 
     await openEditor(page);
     await page.locator('#petName').fill('EscapeShouldDiscard');
     await page.keyboard.press('Escape');
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);
   });
 
-  test('backdrop click closes modal without saving', async ({ page }) => {
+  test('back button closes editor without saving', async ({ page }) => {
     const originalName = (await page.locator('[data-testid="roster-open"]').first().textContent()) ?? '';
 
     await openEditor(page);
-    await page.locator('#petName').fill('BackdropShouldDiscard');
-    await page.locator('.modal-backdrop').click({ position: { x: 5, y: 5 } });
+    await page.locator('#petName').fill('BackShouldDiscard');
+    await page.locator('[data-testid="pet-editor-back"]').click();
 
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);
   });
 });
@@ -267,10 +267,15 @@ test.describe('Pet Editor – Initial Values', () => {
     await expect(page.locator('#petName')).toHaveValue(cardName);
   });
 
-  test('species and breeder fields are disabled', async ({ page }) => {
+  test('species and breeder shown as read-only metadata', async ({ page }) => {
     await openEditor(page);
-    await expect(page.locator('#petSpecies')).toBeDisabled();
-    await expect(page.locator('#petBreeder')).toBeDisabled();
+    // Provenance is not editable: shown as a static meta line, not inputs.
+    const meta = page.locator('.meta-line');
+    await expect(meta).toBeVisible();
+    await expect(meta).toContainText('Species');
+    await expect(meta).toContainText('Breeder');
+    await expect(page.locator('#petSpecies')).toHaveCount(0);
+    await expect(page.locator('#petBreeder')).toHaveCount(0);
   });
 
   test('attribute inputs have numeric values between 0-100', async ({ page }) => {
@@ -288,7 +293,8 @@ test.describe('Pet Editor – Initial Values', () => {
 
   test('shows species-appropriate attributes', async ({ page }) => {
     await openEditor(page);
-    const species = await page.locator('#petSpecies').inputValue();
+    const meta = (await page.locator('.meta-line').textContent()) ?? '';
+    const species = meta.includes('BeeWasp') ? 'BeeWasp' : meta.includes('Horse') ? 'Horse' : '';
     const labels = await page.locator('.attr-field label').allTextContents();
     const labelText = labels.join(' ').toLowerCase();
 

--- a/tests/e2e/redesign-mypets.spec.ts
+++ b/tests/e2e/redesign-mypets.spec.ts
@@ -101,10 +101,10 @@ test.describe('Redesign — My Pets (table-first)', () => {
     // Edit the first pet's name via its row action.
     const newName = `Renamed-${Date.now()}`;
     await rows.first().locator('[data-testid="pet-edit-btn"]').click();
-    await expect(page.locator('.modal-panel')).toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
     await page.locator('#petName').fill(newName);
     await page.locator('.btn-primary').click();
-    await expect(page.locator('.modal-panel')).not.toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').filter({ hasText: newName }).first()).toBeVisible();
 
     // Delete a pet via its row action.

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -99,7 +99,7 @@ test.describe('Theme Support', () => {
 
     // Close and reopen settings
     await page.keyboard.press('Escape');
-    await expect(page.locator('.settings-dialog')).not.toBeVisible();
+    await expect(page.locator('[data-testid="settings-view"]')).not.toBeVisible();
 
     await page.locator('.settings-toggle').click();
     const darkBtn = page.locator('.theme-btn').filter({ hasText: 'Dark' });

--- a/tests/fixtures/PetEditorStub.svelte
+++ b/tests/fixtures/PetEditorStub.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-// Lightweight stand-in for PetEditor so PetActions tests don't pull the real
-// editor's config/store dependencies. Mirrors the `open` prop it is bound to.
-const { open = false }: { open?: boolean } = $props();
-</script>
-
-{#if open}<div data-testid="pet-editor-stub">editor open</div>{/if}

--- a/tests/unit/petActions.test.ts
+++ b/tests/unit/petActions.test.ts
@@ -1,23 +1,22 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Pet } from '$lib/types/index.js';
 
 // PetActions is the redesign's edit/delete affordance (icon variant for library
-// rows, button variant for the workspace header). It owns the PetEditor modal
-// and the delete-confirm dialog, deleting via appState.deletePet. The real
-// editor is stubbed so this stays a focused unit; deletePet is spied on.
+// rows, button variant for the workspace header). Editing is a top-level
+// in-space view, so Edit sets the `editingPet` UI store (the +page overlay
+// renders the editor); PetActions itself only owns the delete-confirm dialog,
+// deleting via appState.deletePet (spied on here).
 
 const deletePet = vi.fn(async (_id: number) => {});
 vi.mock('$lib/stores/pets.js', () => ({
   appState: { deletePet: (id: number) => deletePet(id) },
 }));
 
-vi.mock('$lib/components/pet/PetEditor.svelte', async () => ({
-  default: (await import('../fixtures/PetEditorStub.svelte')).default,
-}));
-
 import PetActions from '$lib/components/shared/PetActions.svelte';
+import { editingPet } from '$lib/stores/ui.js';
 
 const pet = { id: 7, name: 'Dobbin' } as Pet;
 
@@ -26,6 +25,7 @@ const q = (c: HTMLElement, sel: string) => c.querySelector(sel) as HTMLElement |
 afterEach(() => {
   cleanup();
   deletePet.mockClear();
+  editingPet.set(null);
 });
 
 describe('PetActions', () => {
@@ -41,11 +41,11 @@ describe('PetActions', () => {
     expect(q(container, '[data-testid="pet-delete-btn"]')?.textContent).toBe('Delete');
   });
 
-  it('opens the editor when edit is clicked', async () => {
+  it('opens the editor (sets editingPet) when edit is clicked', async () => {
     const { container } = render(PetActions, { pet } as never);
-    expect(q(container, '[data-testid="pet-editor-stub"]')).toBeNull();
+    expect(get(editingPet)).toBeNull();
     await fireEvent.click(q(container, '[data-testid="pet-edit-btn"]') as HTMLElement);
-    await waitFor(() => expect(q(container, '[data-testid="pet-editor-stub"]')).not.toBeNull());
+    await waitFor(() => expect(get(editingPet)).toBe(pet));
   });
 
   it('shows a confirm dialog on delete and calls deletePet on confirm', async () => {


### PR DESCRIPTION
## Why
The Settings and Pet Edit modals were inconsistent with the redesign, which presents the pet detail (and other lenses) as in-space `DetailOverlay` views rather than popups. They also wasted space, and Settings **overflowed the default 1200×800 window** — its header/close and the Updates section were clipped and unreachable.

## Change
Both now live in the main app space as `DetailOverlay`-based lenses (`← Back` header, non-modal so tabs stay usable), driven by a small `ui` store:

- **New `stores/ui.ts`** — `settingsOpen` + `editingPet` with `uiActions`.
- **Settings**: `SettingsModal` → `SettingsView` (renders in a `DetailOverlay`); the gear moved to `TopBar` and calls `openSettings()`.
- **Pet Editor**: `PetEditor` renders in a `DetailOverlay` with a pinned Cancel/Save footer; `PetActions` sets `editingPet` instead of mounting a modal. Both overlays mount at the page root (`+page.svelte`) so the covered tab view goes inert.
- **Space**: Species/Breeder are now a compact static meta line, not fake-editable disabled inputs.

## Also
Hardened the shared `.dialog` in `app.css` (`max-height: 85vh` + scrollable body) so the remaining true dialogs (Share / Export / Import / BulkShare) are viewport-safe. Updated `DetailOverlay` docs (editor/settings are no longer nested modals).

## Verification
- Live (1200×800): Settings header no longer clipped, Updates reachable by scroll; editor opens in-space, Escape/Back cancels, Save persists and closes.
- `pnpm run check` 0 errors, `lint:ci` clean, **807 unit tests pass**.
- e2e updated for the new selectors/semantics; pet-crud, keyboard, theme, autoShare, redesign-mypets all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)