### PR TITLE
fix(ui): rework pet-detail header — BreedSelector, control clusters

### DIFF
--- a/src/lib/components/community/CommunityPetVisualization.svelte
+++ b/src/lib/components/community/CommunityPetVisualization.svelte
@@ -14,6 +14,7 @@
  */
 import GeneStatsTable from '$lib/components/gene/GeneStatsTable.svelte';
 import GeneVisualizer from '$lib/components/gene/GeneVisualizer.svelte';
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { getSharedPet, type ImportResult } from '$lib/services/shareService.js';
 import { communityView, importSelected } from '$lib/stores/community.svelte.js';
@@ -120,8 +121,8 @@ function handleAttributeFilter(event: CustomEvent<{ attribute: string; ctrlKey: 
   }
 }
 
-function setBreedFilter(fullName: string): void {
-  breedFilter = breedFilter === fullName ? '' : fullName;
+function handleBreedChange(fullName: string): void {
+  breedFilter = fullName;
   geneVisualizerRef?.setBreedFilter(breedFilter);
 }
 </script>
@@ -154,21 +155,23 @@ function setBreedFilter(fullName: string): void {
     </div>
     <div class="header-controls">
       {#if isHorse}
-        <div class="breed-filter">
-          <span class="breed-label">Breed:</span>
-          <button class="breed-btn" class:active={breedFilter === ''} onclick={() => setBreedFilter('')}>All</button>
-          {#each Object.entries(HORSE_BREEDS) as [name, abbrev] (name)}
-            <button class="breed-btn" class:active={breedFilter === name} onclick={() => setBreedFilter(name)} title={name}>{abbrev}</button>
-          {/each}
-        </div>
+        <BreedSelector value={breedFilter} breeds={HORSE_BREEDS} onChange={handleBreedChange} />
       {/if}
-      <div class="view-controls">
+      <div class="view-controls" role="group" aria-label="Grid view">
         <button class="view-btn" class:active={currentView === 'attribute'} onclick={() => handleViewChange('attribute')}>Attributes</button>
         <button class="view-btn" class:active={currentView === 'appearance'} onclick={() => handleViewChange('appearance')}>Appearance</button>
-        <button class="view-btn stats-btn" class:active={statsOpen} onclick={toggleStats}>Stats</button>
-        <span class="vc-divider" aria-hidden="true"></span>
+      </div>
+      <button
+        class="toggle-btn"
+        class:active={statsOpen}
+        aria-pressed={statsOpen}
+        data-testid="detail-stats-toggle"
+        title="Toggle the stats side panel"
+        onclick={toggleStats}
+      >Stats</button>
+      <div class="header-actions">
         <button
-          class="view-btn import-btn"
+          class="import-btn"
           data-testid="community-import"
           onclick={handleImport}
           disabled={isAnyImportInFlight || !fullPet}
@@ -285,46 +288,14 @@ function setBreedFilter(fullName: string): void {
     font-size: 10px;
   }
 
+  /* Control kinds, each its own cluster: exclusive views (segmented), the
+     Stats panel toggle (bordered, pressed state), and the Import action.
+     Wraps so everything stays reachable at narrow widths. */
   .header-controls {
     display: flex;
     align-items: center;
-    gap: 12px;
-  }
-
-  .breed-filter {
-    display: flex;
-    align-items: center;
-    gap: 3px;
-  }
-
-  .breed-label {
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--text-tertiary);
-    margin-right: 4px;
-  }
-
-  .breed-btn {
-    padding: 3px 8px;
-    border: 1px solid var(--border-primary);
-    border-radius: 4px;
-    background: var(--bg-primary);
-    color: var(--text-tertiary);
-    font-size: 11px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s;
-  }
-
-  .breed-btn:hover {
-    border-color: var(--border-secondary);
-    color: var(--text-secondary);
-  }
-
-  .breed-btn.active {
-    background: var(--accent);
-    border-color: var(--accent);
-    color: var(--bg-primary);
+    flex-wrap: wrap;
+    gap: 6px 12px;
   }
 
   .view-controls {
@@ -336,11 +307,32 @@ function setBreedFilter(fullName: string): void {
     padding: 3px;
   }
 
-  .vc-divider {
-    width: 1px;
-    align-self: stretch;
-    margin: 2px 4px;
-    background: var(--border-secondary);
+  .toggle-btn {
+    padding: 4px 12px;
+    border: 1px solid var(--border-primary);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    color: var(--text-tertiary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+
+  .toggle-btn:hover {
+    border-color: var(--border-secondary);
+    color: var(--text-secondary);
+  }
+
+  .toggle-btn.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg-primary);
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
   }
 
   .view-btn {
@@ -366,8 +358,15 @@ function setBreedFilter(fullName: string): void {
   }
 
   .import-btn {
+    padding: 5px 14px;
+    border: none;
+    border-radius: 6px;
     background: var(--accent);
     color: var(--text-inverse);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
   }
 
   .import-btn:hover:not(:disabled) {

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -100,8 +100,18 @@ function handleViewChange(view: string): void {
 }
 
 function toggleStats(): void {
+  // The stats drawer belongs to the grid content: opening it brings the grid
+  // back if the gallery took over, so pressed state always matches the screen.
+  if (!statsOpen) galleryOpen = false;
   statsOpen = !statsOpen;
   if (statsOpen) refreshStats();
+}
+
+function toggleGallery(): void {
+  galleryOpen = !galleryOpen;
+  // The gallery hides the grid and its stats drawer; close Stats too so its
+  // pressed state never points at a hidden panel.
+  if (galleryOpen) statsOpen = false;
 }
 
 function refreshStats(): void {
@@ -223,7 +233,7 @@ onDestroy(() => {
                     aria-pressed={galleryOpen}
                     data-testid="detail-gallery-toggle"
                     title="Toggle the image gallery"
-                    onclick={() => { galleryOpen = !galleryOpen; }}
+                    onclick={toggleGallery}
                 >
                     Gallery
                 </button>

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -3,6 +3,7 @@ import { onDestroy } from 'svelte';
 import SharePetDialog from '$lib/components/community/SharePetDialog.svelte';
 import GeneStatsTable from '$lib/components/gene/GeneStatsTable.svelte';
 import GeneVisualizer from '$lib/components/gene/GeneVisualizer.svelte';
+import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
 import PetActions from '$lib/components/shared/PetActions.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { settings } from '$lib/stores/settings.js';
@@ -78,8 +79,8 @@ function toggleAutoBreed(): void {
   }
 }
 
-function setBreedFilter(fullName: string): void {
-  breedFilter = breedFilter === fullName ? '' : fullName;
+function handleBreedChange(fullName: string): void {
+  breedFilter = fullName;
   if (geneVisualizerRef) {
     geneVisualizerRef.setBreedFilter(breedFilter);
   }
@@ -89,6 +90,8 @@ function setBreedFilter(fullName: string): void {
 let cleanupResize = $state<(() => void) | null>(null);
 
 function handleViewChange(view: string): void {
+  // Picking a grid view always brings the grid back if the gallery took over.
+  galleryOpen = false;
   currentView = view;
   if (geneVisualizerRef) {
     geneVisualizerRef.handleViewChange(view);
@@ -147,7 +150,7 @@ onDestroy(() => {
 <div class="pet-visualization">
     <div class="detail-header">
         <div class="detail-header-info">
-            <h2 class="detail-title">{pet?.name || 'Pet'}</h2>
+            <!-- The pet name lives in the DetailOverlay title; only the meta line here. -->
             <div class="detail-meta">
                 <span>{pet?.species || 'Unknown'}</span>
                 {#if pet?.breed && pet.breed !== 'Mixed'}
@@ -169,47 +172,63 @@ onDestroy(() => {
         <div class="header-controls">
             {#if isHorse}
                 <div class="breed-filter">
-                    <span class="breed-label">Breed:</span>
                     {#if petHasKnownBreed}
-                        <button class="breed-btn auto-btn" class:active={autoBreed} onclick={toggleAutoBreed} title="Auto-select pet's breed">Auto</button>
-                        <span class="breed-divider"></span>
+                        <button
+                            type="button"
+                            class="auto-btn"
+                            class:active={autoBreed}
+                            aria-pressed={autoBreed}
+                            onclick={toggleAutoBreed}
+                            title="Auto-select pet's breed"
+                        >Auto</button>
                     {/if}
-                    <button class="breed-btn" class:active={!autoBreed && breedFilter === ''} disabled={autoBreed} onclick={() => setBreedFilter('')}>All</button>
-                    {#each Object.entries(HORSE_BREEDS) as [name, abbrev]}
-                        <button class="breed-btn" class:active={!autoBreed && breedFilter === name} disabled={autoBreed} onclick={() => setBreedFilter(name)} title={name}>{abbrev}</button>
-                    {/each}
+                    <BreedSelector
+                        value={breedFilter}
+                        breeds={HORSE_BREEDS}
+                        disabled={autoBreed && !!petHasKnownBreed}
+                        onChange={handleBreedChange}
+                    />
                 </div>
             {/if}
-            <div class="view-controls">
+            <div class="view-controls" role="group" aria-label="Grid view">
                 <button
                     class="view-btn"
-                    class:active={currentView === "attribute"}
+                    class:active={!galleryOpen && currentView === "attribute"}
                     onclick={() => handleViewChange("attribute")}
                 >
                     Attributes
                 </button>
                 <button
                     class="view-btn"
-                    class:active={currentView === "appearance"}
+                    class:active={!galleryOpen && currentView === "appearance"}
                     onclick={() => handleViewChange("appearance")}
                 >
                     Appearance
                 </button>
+            </div>
+            <div class="toggle-controls">
                 <button
-                    class="view-btn stats-btn"
+                    class="toggle-btn"
                     class:active={statsOpen}
+                    aria-pressed={statsOpen}
+                    data-testid="detail-stats-toggle"
+                    title="Toggle the stats side panel"
                     onclick={toggleStats}
                 >
                     Stats
                 </button>
                 <button
-                    class="view-btn"
+                    class="toggle-btn"
                     class:active={galleryOpen}
+                    aria-pressed={galleryOpen}
+                    data-testid="detail-gallery-toggle"
+                    title="Toggle the image gallery"
                     onclick={() => { galleryOpen = !galleryOpen; }}
                 >
                     Gallery
                 </button>
-                <span class="vc-divider" aria-hidden="true"></span>
+            </div>
+            <div class="header-actions">
                 <button
                     class="view-btn share-btn"
                     data-testid="share-pet-btn"
@@ -300,17 +319,9 @@ onDestroy(() => {
         flex-shrink: 0;
     }
 
-    .detail-title {
-        font-size: 15px;
-        font-weight: 700;
-        color: var(--text-primary);
-        margin: 0;
-    }
-
     .detail-meta {
         font-size: 12px;
         color: var(--text-tertiary);
-        margin-top: 2px;
     }
 
     .unknown-badge {
@@ -318,26 +329,24 @@ onDestroy(() => {
         font-weight: 600;
     }
 
+    /* Three control kinds, each its own cluster: exclusive views (segmented),
+       panel/content toggles (bordered, pressed state), actions (Share/Edit/
+       Delete). Wraps so everything stays reachable at narrow widths. */
     .header-controls {
         display: flex;
         align-items: center;
-        gap: 12px;
+        flex-wrap: wrap;
+        gap: 6px 12px;
     }
 
     .breed-filter {
         display: flex;
         align-items: center;
-        gap: 3px;
+        gap: 6px;
     }
 
-    .breed-label {
-        font-size: 11px;
-        font-weight: 600;
-        color: var(--text-tertiary);
-        margin-right: 4px;
-    }
-
-    .breed-btn {
+    /* Auto = follow the pet's breed; it owns the BreedSelector while active. */
+    .auto-btn {
         padding: 3px 8px;
         border: 1px solid var(--border-primary);
         border-radius: 4px;
@@ -349,34 +358,15 @@ onDestroy(() => {
         transition: all 0.15s;
     }
 
-    .breed-btn:hover {
+    .auto-btn:hover {
         border-color: var(--border-secondary);
         color: var(--text-secondary);
-    }
-
-    .breed-btn.active {
-        background: var(--accent);
-        border-color: var(--accent);
-        color: var(--bg-primary);
-    }
-
-    .breed-btn:disabled {
-        opacity: 0.4;
-        cursor: default;
-        pointer-events: none;
     }
 
     .auto-btn.active {
         background: #22c55e;
         border-color: #22c55e;
         color: var(--bg-primary);
-    }
-
-    .breed-divider {
-        width: 1px;
-        height: 16px;
-        background: var(--border-secondary);
-        margin: 0 2px;
     }
 
     .view-controls {
@@ -388,14 +378,42 @@ onDestroy(() => {
         padding: 3px;
     }
 
-    /* Separates the view toggles (Attributes/Appearance/Stats/Gallery) from the
-       actions (Share/Edit/Delete) so the destructive Delete isn't adjacent to a
-       routine view toggle. */
-    .vc-divider {
-        width: 1px;
-        align-self: stretch;
-        margin: 2px 4px;
-        background: var(--border-secondary);
+    .toggle-controls {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .toggle-btn {
+        padding: 4px 12px;
+        border: 1px solid var(--border-primary);
+        border-radius: 6px;
+        background: var(--bg-primary);
+        color: var(--text-tertiary);
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all 0.15s ease;
+    }
+
+    .toggle-btn:hover {
+        border-color: var(--border-secondary);
+        color: var(--text-secondary);
+    }
+
+    .toggle-btn.active {
+        background: var(--accent);
+        border-color: var(--accent);
+        color: var(--bg-primary);
+    }
+
+    .header-actions {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        background: var(--bg-tertiary);
+        border-radius: 6px;
+        padding: 3px;
     }
 
     .view-btn {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -86,20 +86,20 @@ test.describe('Pet Detail View', () => {
 
   test('opening a pet shows its visualization', async ({ page }) => {
     await expect(page.locator('.pet-visualization')).toBeVisible();
-    await expect(page.locator('.detail-title')).toBeVisible();
+    await expect(page.locator('.detail-meta')).toBeVisible();
   });
 
   test('shows view control buttons', async ({ page }) => {
     await expect(page.locator('.view-btn').filter({ hasText: 'Attributes' })).toBeVisible();
     await expect(page.locator('.view-btn').filter({ hasText: 'Appearance' })).toBeVisible();
-    await expect(page.locator('.view-btn').filter({ hasText: 'Stats' })).toBeVisible();
+    await expect(page.getByTestId('detail-stats-toggle')).toBeVisible();
   });
 
   test('stats drawer toggles on button click', async ({ page }) => {
     await expect(page.locator('.stats-drawer')).toHaveCount(0);
-    await page.locator('.view-btn').filter({ hasText: 'Stats' }).click();
+    await page.getByTestId('detail-stats-toggle').click();
     await expect(page.locator('.stats-drawer')).toBeVisible();
-    await page.locator('.view-btn').filter({ hasText: 'Stats' }).click();
+    await page.getByTestId('detail-stats-toggle').click();
     await expect(page.locator('.stats-drawer')).toHaveCount(0);
   });
 

--- a/tests/e2e/gallery.spec.ts
+++ b/tests/e2e/gallery.spec.ts
@@ -9,13 +9,13 @@ test.describe('Pet Image Gallery', () => {
 
   test('Gallery button appears in view controls', async ({ page }) => {
     await page.locator('[data-testid="roster-open"]', { hasText: 'Sample Fae Bee' }).first().click();
-    await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
+    await expect(page.getByTestId('detail-gallery-toggle')).toBeVisible();
   });
 
   test('Clicking Gallery shows the gallery view', async ({ page }) => {
     await page.locator('[data-testid="roster-open"]', { hasText: 'Sample Fae Bee' }).first().click();
-    await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
-    await page.locator('.view-btn', { hasText: 'Gallery' }).click();
+    await expect(page.getByTestId('detail-gallery-toggle')).toBeVisible();
+    await page.getByTestId('detail-gallery-toggle').click();
 
     await expect(page.locator('.gallery')).toBeVisible();
     await expect(page.getByText('No images yet')).toBeVisible();
@@ -26,28 +26,28 @@ test.describe('Pet Image Gallery', () => {
     await page.locator('[data-testid="roster-open"]', { hasText: 'Sample Fae Bee' }).first().click();
     await expect(page.locator('.gene-visualizer')).toBeVisible();
 
-    await page.locator('.view-btn', { hasText: 'Gallery' }).click();
+    await page.getByTestId('detail-gallery-toggle').click();
     await expect(page.locator('.gallery')).toBeVisible();
     await expect(page.locator('.gene-visualizer')).not.toBeVisible();
 
-    await page.locator('.view-btn', { hasText: 'Gallery' }).click();
+    await page.getByTestId('detail-gallery-toggle').click();
     await expect(page.locator('.gene-visualizer')).toBeVisible();
     await expect(page.locator('.gallery')).not.toBeVisible();
   });
 
   test('Gallery shows image count', async ({ page }) => {
     await page.locator('[data-testid="roster-open"]', { hasText: 'Sample Fae Bee' }).first().click();
-    await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
-    await page.locator('.view-btn', { hasText: 'Gallery' }).click();
+    await expect(page.getByTestId('detail-gallery-toggle')).toBeVisible();
+    await page.getByTestId('detail-gallery-toggle').click();
 
     await expect(page.locator('.gallery-count')).toHaveText('0 images');
   });
 
   test('Upload button exists but requires Tauri for actual upload', async ({ page }) => {
     await page.locator('[data-testid="roster-open"]', { hasText: 'Sample Fae Bee' }).first().click();
-    await expect(page.locator('.view-btn', { hasText: 'Gallery' })).toBeVisible();
+    await expect(page.getByTestId('detail-gallery-toggle')).toBeVisible();
 
-    await page.locator('.view-btn', { hasText: 'Gallery' }).click();
+    await page.getByTestId('detail-gallery-toggle').click();
     await expect(page.getByText('Upload Images')).toBeVisible();
     await expect(page.getByText('Upload Images')).toBeEnabled();
   });

--- a/tests/e2e/layout-debug.spec.ts
+++ b/tests/e2e/layout-debug.spec.ts
@@ -171,7 +171,7 @@ test('debug: capture pet visualization layout', async ({ page }) => {
   console.log(JSON.stringify(dims, null, 2));
 
   // Now click Stats button
-  const statsBtn = page.locator('.view-btn').filter({ hasText: 'Stats' });
+  const statsBtn = page.getByTestId('detail-stats-toggle');
   if (await statsBtn.isVisible()) {
     await statsBtn.click();
     await page.waitForTimeout(500);

--- a/tests/unit/communityPetVisualization.test.ts
+++ b/tests/unit/communityPetVisualization.test.ts
@@ -102,3 +102,39 @@ describe('CommunityPetVisualization genome lazy-load', () => {
     );
   });
 });
+
+// Header rework (#394/#395): the community detail adopts the shared
+// BreedSelector popover (no Auto — there is no local pet to follow) and
+// separates the Attributes/Appearance segmented pair from the Stats toggle
+// and the Import action.
+describe('CommunityPetVisualization detail header', () => {
+  it('renders the shared BreedSelector for horses instead of the abbreviation row', () => {
+    getSharedPet.mockReturnValue(new Promise(() => {}));
+    const { container } = render(CommunityPetVisualization, {
+      pet: makeSharedPet({ species: 'Horse', breed: 'Kurbone' }),
+    });
+    expect(container.querySelector('[data-testid="breed-selector-trigger"]')).not.toBeNull();
+    expect(container.querySelectorAll('.breed-btn')).toHaveLength(0);
+    // No Auto button in the community view.
+    expect(container.querySelector('.auto-btn')).toBeNull();
+  });
+
+  it('omits the breed control for non-horse species', () => {
+    getSharedPet.mockReturnValue(new Promise(() => {}));
+    const { container } = render(CommunityPetVisualization, { pet: makeSharedPet() });
+    expect(container.querySelector('[data-testid="breed-selector"]')).toBeNull();
+  });
+
+  it('keeps Attributes/Appearance segmented and Stats as a separate pressed toggle', () => {
+    getSharedPet.mockReturnValue(new Promise(() => {}));
+    const { container, getByTestId } = render(CommunityPetVisualization, { pet: makeSharedPet() });
+    const segment = container.querySelector('.view-controls') as HTMLElement;
+    expect([...segment.querySelectorAll('button')].map((b) => b.textContent?.trim())).toEqual([
+      'Attributes',
+      'Appearance',
+    ]);
+    const stats = getByTestId('detail-stats-toggle');
+    expect(stats.getAttribute('aria-pressed')).toBe('false');
+    expect(container.querySelector('.header-actions [data-testid="community-import"]')).not.toBeNull();
+  });
+});

--- a/tests/unit/petVisualization.test.ts
+++ b/tests/unit/petVisualization.test.ts
@@ -1,0 +1,162 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { writable } from 'svelte/store';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Pet } from '$lib/types/index.js';
+
+// Covers the detail header rework (#394/#395): the shared BreedSelector
+// popover replaces the 11-wide abbreviation row (with the Auto follow-the-pet
+// behaviour preserved), the control strip separates exclusive views from the
+// Stats/Gallery toggles and the Share/Edit/Delete actions, opening the Gallery
+// clears the sibling view highlight (the stale-highlight bug), and the pet
+// name is no longer duplicated under the DetailOverlay title.
+
+vi.mock('$lib/stores/settings.js', () => ({
+  settings: writable<Record<string, unknown>>({}),
+}));
+
+vi.mock('$lib/stores/pets.js', () => ({
+  appState: { deletePet: vi.fn(async () => {}) },
+}));
+
+// Stub the heavy/irrelevant children; the header behaviour is what's under test.
+vi.mock('$lib/components/gene/GeneVisualizer.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+vi.mock('$lib/components/gene/GeneStatsTable.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+vi.mock('$lib/components/pet/PetImageGallery.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+vi.mock('$lib/components/community/SharePetDialog.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+
+import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
+
+function makePet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    id: 3,
+    name: 'Dobbin',
+    species: 'Horse',
+    gender: 'Male',
+    breed: 'Kurbone',
+    ...overrides,
+  } as Pet;
+}
+
+const q = (c: HTMLElement, sel: string) => c.querySelector(sel) as HTMLElement | null;
+const btn = (c: HTMLElement, text: string) =>
+  [...c.querySelectorAll<HTMLButtonElement>('.view-btn')].find(
+    (b) => b.textContent?.trim() === text,
+  ) as HTMLButtonElement;
+
+afterEach(cleanup);
+
+describe('PetVisualization detail header', () => {
+  it('does not repeat the pet name (DetailOverlay owns the title); only the meta line renders', () => {
+    const { container } = render(PetVisualization, { pet: makePet() });
+    expect(q(container, '.detail-title')).toBeNull();
+    expect(q(container, '.detail-meta')?.textContent).toContain('Horse');
+  });
+
+  describe('breed control (#394)', () => {
+    it('renders the shared BreedSelector popover instead of the abbreviation button row', () => {
+      const { container } = render(PetVisualization, { pet: makePet() });
+      expect(q(container, '[data-testid="breed-selector-trigger"]')).not.toBeNull();
+      expect(container.querySelectorAll('.breed-btn')).toHaveLength(0);
+    });
+
+    it('omits the breed control for non-horse pets', () => {
+      const { container } = render(PetVisualization, { pet: makePet({ species: 'Cat', breed: '' }) });
+      expect(q(container, '[data-testid="breed-selector"]')).toBeNull();
+      expect(q(container, '.auto-btn')).toBeNull();
+    });
+
+    it('picking a breed from the popover updates the trigger', async () => {
+      const { container } = render(PetVisualization, { pet: makePet() });
+      await fireEvent.click(q(container, '[data-testid="breed-selector-trigger"]') as HTMLElement);
+      await fireEvent.click(q(container, '.bs-opt[data-breed="Ilmarian"]') as HTMLElement);
+      expect(q(container, '[data-testid="breed-selector-trigger"] .bs-value')?.textContent).toBe('Ilmarian');
+    });
+
+    it("Auto follows the pet's breed and locks the selector; toggling off releases it", async () => {
+      const { container } = render(PetVisualization, { pet: makePet({ breed: 'Kurbone' }) });
+      const auto = q(container, '.auto-btn') as HTMLButtonElement;
+      expect(auto).not.toBeNull();
+      expect(auto.getAttribute('aria-pressed')).toBe('false');
+
+      await fireEvent.click(auto);
+      const trigger = q(container, '[data-testid="breed-selector-trigger"]') as HTMLButtonElement;
+      expect(auto.getAttribute('aria-pressed')).toBe('true');
+      expect(trigger.disabled).toBe(true);
+      expect(trigger.querySelector('.bs-value')?.textContent).toBe('Kurbone');
+
+      await fireEvent.click(auto);
+      expect(trigger.disabled).toBe(false);
+      expect(trigger.querySelector('.bs-value')?.textContent).toBe('All');
+    });
+
+    it('hides the Auto button when the breed is unknown', () => {
+      const { container } = render(PetVisualization, { pet: makePet({ breed: 'Mixed' }) });
+      expect(q(container, '.auto-btn')).toBeNull();
+      expect(q(container, '[data-testid="breed-selector-trigger"]')).not.toBeNull();
+    });
+  });
+
+  describe('control strip separation (#395)', () => {
+    it('keeps Attributes/Appearance as the exclusive segmented pair, with Stats/Gallery and actions in their own clusters', () => {
+      const { container } = render(PetVisualization, { pet: makePet() });
+      const segment = q(container, '.view-controls') as HTMLElement;
+      expect([...segment.querySelectorAll('button')].map((b) => b.textContent?.trim())).toEqual([
+        'Attributes',
+        'Appearance',
+      ]);
+      expect(q(container, '.toggle-controls [data-testid="detail-stats-toggle"]')).not.toBeNull();
+      expect(q(container, '.toggle-controls [data-testid="detail-gallery-toggle"]')).not.toBeNull();
+      expect(q(container, '.header-actions [data-testid="share-pet-btn"]')).not.toBeNull();
+      expect(q(container, '.header-actions [data-testid="pet-edit-btn"]')).not.toBeNull();
+      expect(q(container, '.header-actions [data-testid="pet-delete-btn"]')).not.toBeNull();
+    });
+
+    it('Stats is a pressed toggle, not a sibling view highlight', async () => {
+      const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
+      const stats = getByTestId('detail-stats-toggle');
+      expect(stats.getAttribute('aria-pressed')).toBe('false');
+      await fireEvent.click(stats);
+      expect(stats.getAttribute('aria-pressed')).toBe('true');
+      // Attributes stays highlighted — the grid is still the content.
+      expect(btn(container, 'Attributes').classList.contains('active')).toBe(true);
+      expect(q(container, '.stats-drawer')).not.toBeNull();
+    });
+
+    it('opening the Gallery clears the view highlights (stale-highlight fix)', async () => {
+      const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
+      expect(btn(container, 'Attributes').classList.contains('active')).toBe(true);
+
+      const gallery = getByTestId('detail-gallery-toggle');
+      await fireEvent.click(gallery);
+      expect(gallery.getAttribute('aria-pressed')).toBe('true');
+      expect(btn(container, 'Attributes').classList.contains('active')).toBe(false);
+      expect(btn(container, 'Appearance').classList.contains('active')).toBe(false);
+
+      // Closing the gallery restores the previous view highlight.
+      await fireEvent.click(gallery);
+      expect(gallery.getAttribute('aria-pressed')).toBe('false');
+      expect(btn(container, 'Attributes').classList.contains('active')).toBe(true);
+    });
+
+    it('picking a view while the Gallery is open closes it and re-highlights the view', async () => {
+      const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
+      const gallery = getByTestId('detail-gallery-toggle');
+      await fireEvent.click(gallery);
+      expect(gallery.getAttribute('aria-pressed')).toBe('true');
+
+      await fireEvent.click(btn(container, 'Appearance'));
+      expect(gallery.getAttribute('aria-pressed')).toBe('false');
+      expect(btn(container, 'Appearance').classList.contains('active')).toBe(true);
+      expect(btn(container, 'Attributes').classList.contains('active')).toBe(false);
+    });
+  });
+});

--- a/tests/unit/petVisualization.test.ts
+++ b/tests/unit/petVisualization.test.ts
@@ -147,6 +147,26 @@ describe('PetVisualization detail header', () => {
       expect(btn(container, 'Attributes').classList.contains('active')).toBe(true);
     });
 
+    it('opening the Gallery closes the Stats drawer so its pressed state never points at a hidden panel', async () => {
+      const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
+      const stats = getByTestId('detail-stats-toggle');
+      const gallery = getByTestId('detail-gallery-toggle');
+
+      await fireEvent.click(stats);
+      expect(stats.getAttribute('aria-pressed')).toBe('true');
+
+      await fireEvent.click(gallery);
+      expect(gallery.getAttribute('aria-pressed')).toBe('true');
+      expect(stats.getAttribute('aria-pressed')).toBe('false');
+      expect(q(container, '.stats-drawer')).toBeNull();
+
+      // Pressing Stats while the gallery is open swaps back to the grid + drawer.
+      await fireEvent.click(stats);
+      expect(gallery.getAttribute('aria-pressed')).toBe('false');
+      expect(stats.getAttribute('aria-pressed')).toBe('true');
+      expect(q(container, '.stats-drawer')).not.toBeNull();
+    });
+
     it('picking a view while the Gallery is open closes it and re-highlights the view', async () => {
       const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
       const gallery = getByTestId('detail-gallery-toggle');


### PR DESCRIPTION
Reworks the detail header band in `PetVisualization` and `CommunityPetVisualization`.

**#394 — clipped header.** Replaces the 11-wide breed abbreviation rows with the shared `BreedSelector` popover (per design doc §4 decision 1). The local view keeps the Auto (follow-the-pet's-breed) toggle, reusing the Compare pattern: Auto owns the selector, which is disabled but still shows the pet's breed. `.header-controls` now wraps, so view tabs, Stats, Gallery, Share, Edit and Delete all stay reachable at 700px.

**#395 — mixed control kinds / stale highlight.** The strip is now three clusters: Attributes/Appearance as the exclusive segmented pair; Stats and Gallery as bordered pressed toggles (`aria-pressed`); Share/Edit/Delete (Import in Community) as a separate actions cluster. Opening the Gallery clears the view highlights; picking a view closes the Gallery. The pet name duplicated under the DetailOverlay title is removed — only the meta line remains, matching Community.

**Tests.** New `tests/unit/petVisualization.test.ts` (BreedSelector adoption, Auto behaviour, cluster separation, stale-highlight fix, name de-dup); community header cases added to `communityPetVisualization.test.ts`; e2e selectors updated to the new `detail-stats-toggle` / `detail-gallery-toggle` testids. `pnpm vitest run` (828 passed) and `pnpm run lint:ci` pass locally.

Closes #394
Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)