### PR TITLE
fix(breed): species default/persistence, stale trio guard, table sizing

### DIFF
--- a/src/lib/components/breeding/BreedView.svelte
+++ b/src/lib/components/breeding/BreedView.svelte
@@ -17,7 +17,8 @@ import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { rankBreedingPairs } from '$lib/services/breedingService.js';
 import { getAllAttributeNames, getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { breedingView } from '$lib/stores/breeding.svelte.js';
-import { pets } from '$lib/stores/pets.js';
+// `loading` aliased: this component has its own ranking `loading` flag.
+import { pets, loading as petsLoading } from '$lib/stores/pets.js';
 import { type BreedingPairResult, HORSE_BREEDS } from '$lib/types/index.js';
 import { getSpeciesEmoji } from '$lib/utils/species.js';
 import { capitalize } from '$lib/utils/string.js';
@@ -29,7 +30,45 @@ const speciesOptions = getSupportedSpecies().map((s) => ({
   label: capitalize(normalizeSpecies(s)),
 }));
 
-let species = $state(speciesOptions[0]?.key ?? '');
+// Until the player picks a species, default to the most-populated *stabled*
+// one (a user with 25 stabled horses and 7 beewasps should land on horses,
+// not the alphabetical first). Derived, not assigned at mount: the pet list
+// lands well after mount (AuthWrapper's loadPets), so a mount-time pick would
+// race it and lock in the fallback. Ties go to supported-species order.
+const defaultSpecies = $derived.by(() => {
+  const counts = new Map<string, number>();
+  for (const p of $pets) {
+    if (!p.stabled) continue;
+    const key = normalizeSpecies(p.species);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  let best = '';
+  let bestCount = 0;
+  for (const opt of speciesOptions) {
+    const count = counts.get(opt.key) ?? 0;
+    if (count > bestCount) {
+      best = opt.key;
+      bestCount = count;
+    }
+  }
+  return best || (speciesOptions[0]?.key ?? '');
+});
+
+// An explicit pick persists in breedingView.species across destination
+// switches (this component unmounts); '' falls through to the default.
+const species = $derived(breedingView.species || defaultSpecies);
+
+function selectSpecies(key: string) {
+  const changed = key !== species;
+  // Pin the choice even when it matches the current default, so a later
+  // change in stable composition can't silently move the player elsewhere.
+  breedingView.species = key;
+  if (changed) {
+    breedingView.offspringBreed = '';
+    breedingView.scrollTop = 0;
+    breedingView.scrollLeft = 0;
+  }
+}
 
 // Offspring breed only shapes the ranking for species that have breeds (horses:
 // breed-locked loci are dropped, and it feeds the pool-gap pairing weight).
@@ -95,6 +134,22 @@ $effect(() => {
     });
 });
 
+// An open Trio holds Pet objects frozen at click time; nothing above ties its
+// lifetime to the candidate set, so a parent that is deleted or unstabled
+// would keep rendering stale data indefinitely. Drop back to the pair table
+// when either parent leaves the candidates — but only on a *settled* load
+// (!$petsLoading): during an in-flight reload the list can briefly lack the
+// pet, and that window always closes with `loading` true, so it can't be
+// mistaken for a deletion (same guard as MyPets' detail overlay).
+$effect(() => {
+  const pair = breedingView.selectedPair;
+  if (!pair || $petsLoading) return;
+  const inCandidates = (id: number) => candidates.some((p) => p.id === id);
+  if (!inCandidates(pair.male.id) || !inCandidates(pair.female.id)) {
+    breedingView.selectedPair = null;
+  }
+});
+
 onDestroy(() => {
   breedingView.selectedPair = null;
 });
@@ -115,7 +170,7 @@ onDestroy(() => {
         class:active={species === opt.key}
         aria-pressed={species === opt.key}
         data-species={opt.key}
-        onclick={() => { species = opt.key; breedingView.offspringBreed = ''; }}
+        onclick={() => selectSpecies(opt.key)}
       >
         {getSpeciesEmoji(opt.raw)} {opt.label}
       </button>

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -75,9 +75,30 @@ function openTrio(pair: BreedingPairResult) {
 function fmt(n: number) {
   return n.toFixed(1);
 }
+
+// --- Scroll persistence -----------------------------------------------------
+// The wrapper is the ranking's scroll container; the component unmounts on a
+// destination switch (e.g. a parent-name excursion to My Pets), so the offsets
+// live in breedingView. Restore once the ranked rows are in the DOM — before
+// that, scrollHeight is too small for the saved offset to apply.
+let wrapperEl = $state<HTMLDivElement>();
+let restored = false;
+
+$effect(() => {
+  if (restored || !wrapperEl || sortedResults.length === 0) return;
+  restored = true;
+  wrapperEl.scrollTop = breedingView.scrollTop;
+  wrapperEl.scrollLeft = breedingView.scrollLeft;
+});
+
+function persistScroll() {
+  if (!wrapperEl) return;
+  breedingView.scrollTop = wrapperEl.scrollTop;
+  breedingView.scrollLeft = wrapperEl.scrollLeft;
+}
 </script>
 
-<div class="table-wrapper" data-testid="breeding-pair-table">
+<div class="table-wrapper" data-testid="breeding-pair-table" bind:this={wrapperEl} onscroll={persistScroll}>
     <table>
         <thead>
             <tr>
@@ -129,8 +150,12 @@ function fmt(n: number) {
 </div>
 
 <style>
+    /* Hug the rows: `flex: 0 1 auto` sizes the bordered box to the table's
+       natural height (a sparse ranking doesn't sit in a full-height frame of
+       empty space), while flex-shrink + min-height: 0 still cap it at the
+       parent's constrained height so a long ranking scrolls inside as before. */
     .table-wrapper {
-        flex: 1;
+        flex: 0 1 auto;
         min-height: 0;
         overflow: auto;
         border: 1px solid var(--border-primary);

--- a/src/lib/components/breeding/BreedingPairTable.svelte
+++ b/src/lib/components/breeding/BreedingPairTable.svelte
@@ -79,16 +79,23 @@ function fmt(n: number) {
 // --- Scroll persistence -----------------------------------------------------
 // The wrapper is the ranking's scroll container; the component unmounts on a
 // destination switch (e.g. a parent-name excursion to My Pets), so the offsets
-// live in breedingView. Restore once the ranked rows are in the DOM — before
-// that, scrollHeight is too small for the saved offset to apply.
+// live in breedingView. Sync the DOM to the store whenever the offsets
+// change: this restores them on mount (only once the ranked rows are in the
+// DOM — before that, scrollHeight is too small for the offset to apply) AND
+// applies external resets (a species change zeroes the offsets while this
+// component stays mounted; a one-shot restore would leave the table visually
+// scrolled with the store saying 0, and the next user scroll would re-persist
+// the stale offsets). Comparing before assigning breaks the feedback loop
+// with the onscroll handler — a store write that merely echoes the element's
+// own scroll position is a no-op here.
 let wrapperEl = $state<HTMLDivElement>();
-let restored = false;
 
 $effect(() => {
-  if (restored || !wrapperEl || sortedResults.length === 0) return;
-  restored = true;
-  wrapperEl.scrollTop = breedingView.scrollTop;
-  wrapperEl.scrollLeft = breedingView.scrollLeft;
+  const top = breedingView.scrollTop;
+  const left = breedingView.scrollLeft;
+  if (!wrapperEl || sortedResults.length === 0) return;
+  if (wrapperEl.scrollTop !== top) wrapperEl.scrollTop = top;
+  if (wrapperEl.scrollLeft !== left) wrapperEl.scrollLeft = left;
 });
 
 function persistScroll() {

--- a/src/lib/stores/breeding.svelte.ts
+++ b/src/lib/stores/breeding.svelte.ts
@@ -6,7 +6,6 @@
  * user navigates away, but this state persists for the session.
  */
 
-import { getSupportedSpecies } from '$lib/services/configService.js';
 import type { Pet } from '$lib/types/index.js';
 
 /** The (father, mother) pair currently open in the trio detail view. */
@@ -26,8 +25,14 @@ export interface SelectedBreedingPair {
 export type BreedingSortColumn = 'evMixed' | 'evPositiveTotal' | 'evUnknown' | (string & {});
 
 export const breedingView = $state({
-  /** Canonical species the player is breeding within (defaults to first supported). */
-  species: getSupportedSpecies()[0],
+  /**
+   * Normalized species key the player is breeding within. '' means "not
+   * chosen yet" — BreedView then derives a default (the most-populated
+   * stabled species) instead of the alphabetical first. Set on an explicit
+   * species click so the choice survives destination switches (e.g. a
+   * parent-name excursion to My Pets and back).
+   */
+  species: '' as string,
   /** Player-selected offspring breed (horse-only; '' = no filter / mixed). */
   offspringBreed: '' as string,
   /** Active sort column for the pair table. */
@@ -36,4 +41,12 @@ export const breedingView = $state({
   sortDir: 'desc' as 'asc' | 'desc',
   /** Pair open in the trio detail view; null when the view is closed. */
   selectedPair: null as SelectedBreedingPair | null,
+  /**
+   * Pair-table scroll offsets, saved by BreedingPairTable so the ranking
+   * position survives destination switches (the component unmounts).
+   * Reset on a species change — an offset from one species' table is
+   * meaningless in another's.
+   */
+  scrollTop: 0,
+  scrollLeft: 0,
 });

--- a/tests/e2e/redesign-breed-destination.spec.ts
+++ b/tests/e2e/redesign-breed-destination.spec.ts
@@ -66,6 +66,32 @@ test.describe('Redesign — Breed destination', () => {
     await expect(page.locator('[data-testid="tab-library"]')).toHaveClass(/active/);
     await expect(page.locator('[data-testid="pet-detail"]')).toBeVisible();
     await expect(page.locator('.pet-visualization')).toBeVisible();
+
+    // Returning to Breed keeps the chosen species — the excursion must not
+    // reset the destination to its default (#399).
+    await page.locator('[data-testid="tab-breed"]').click();
+    await expect(page.locator('[data-testid="breed-view"]')).toBeVisible();
+    await expect(page.locator('[data-testid="breed-species"] [data-species="horse"]')).toHaveClass(/active/);
+    await expect(page.locator('[data-testid="breeding-pair-table"]')).toBeVisible();
+  });
+
+  test('a sparse pair table hugs its rows instead of framing empty space', async ({ page }) => {
+    // The demo stable ranks a single horse pair; the bordered wrapper must
+    // size to the table rather than stretching to the full body height (#401).
+    await openBreed(page);
+    await page.locator('[data-testid="breed-species"] [data-species="horse"]').click();
+    const wrapper = page.locator('[data-testid="breeding-pair-table"]');
+    await expect(wrapper).toBeVisible();
+    await expect(wrapper.locator('tbody tr').first()).toBeVisible();
+
+    const wrapperBox = await wrapper.boundingBox();
+    const tableBox = await wrapper.locator('table').boundingBox();
+    expect(wrapperBox).not.toBeNull();
+    expect(tableBox).not.toBeNull();
+    if (!wrapperBox || !tableBox) return;
+    // Allowance: 2px of border + a horizontal scrollbar gutter (the table is
+    // wide) on platforms with classic scrollbars.
+    expect(wrapperBox.height).toBeLessThanOrEqual(tableBox.height + 20);
   });
 
   test('offspring breed can be chosen and re-ranks the pairs (horses)', async ({ page }) => {

--- a/tests/unit/breedView.test.ts
+++ b/tests/unit/breedView.test.ts
@@ -1,0 +1,165 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import { loading, pets } from '$lib/stores/pets.js';
+import type { Pet } from '$lib/types/index.js';
+
+// The ranking service is exercised by its own suite; stub it so these tests
+// stay a focused check of BreedView's species defaulting and trio lifecycle.
+vi.mock('$lib/services/breedingService.js', () => ({
+  rankBreedingPairs: vi.fn(async () => []),
+}));
+
+// The real TrioView mounts the heavy offspring grid (~2304 cells); the guard
+// under test only cares whether the pair is still selected.
+vi.mock('$lib/components/breeding/TrioView.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+
+import BreedView from '$lib/components/breeding/BreedView.svelte';
+
+const pet = (over: Partial<Pet>): Pet =>
+  ({
+    id: 0,
+    name: 'Pet',
+    species: 'Horse',
+    breed: 'Standardbred',
+    gender: 'Female',
+    tags: [],
+    stabled: true,
+    positive_genes: 0,
+    ...over,
+  }) as unknown as Pet;
+
+const stallion = pet({ id: 1, name: 'Dusty', gender: 'Male' });
+const mare = pet({ id: 2, name: 'Roach' });
+
+function resetView() {
+  breedingView.species = '';
+  breedingView.offspringBreed = '';
+  breedingView.sortCol = 'evPositiveTotal';
+  breedingView.sortDir = 'desc';
+  breedingView.selectedPair = null;
+  breedingView.scrollTop = 0;
+  breedingView.scrollLeft = 0;
+}
+
+beforeEach(() => {
+  resetView();
+  loading.set(false);
+  pets.set([]);
+});
+
+afterEach(() => {
+  cleanup();
+  loading.set(false);
+  pets.set([]);
+  resetView();
+});
+
+const activeSpecies = (c: HTMLElement) =>
+  c.querySelector('[data-testid="breed-species"] .species-btn.active')?.getAttribute('data-species');
+
+describe('BreedView — default species', () => {
+  it('defaults to the most-populated stabled species, not the alphabetical first', async () => {
+    // Beewasps outnumber horses overall, but most are unstabled — only the
+    // stabled population should drive the default.
+    pets.set([
+      stallion,
+      mare,
+      pet({ id: 3, species: 'Beewasp', breed: 'Bee' }),
+      pet({ id: 4, species: 'Beewasp', breed: 'Bee', stabled: false }),
+      pet({ id: 5, species: 'Beewasp', breed: 'Bee', stabled: false }),
+      pet({ id: 6, species: 'Beewasp', breed: 'Bee', stabled: false }),
+    ]);
+    const { container, rerender } = render(BreedView);
+    await rerender({});
+    expect(activeSpecies(container)).toBe('horse');
+    // The default is derived, not committed — only an explicit click pins it.
+    expect(breedingView.species).toBe('');
+  });
+
+  it('re-derives the default when the pet list lands after mount (no mount-time lock-in)', async () => {
+    const { container, rerender } = render(BreedView);
+    await rerender({});
+    // Nothing loaded yet → the first supported species is the fallback.
+    expect(activeSpecies(container)).toBe('beewasp');
+
+    pets.set([stallion, mare, pet({ id: 3, species: 'Beewasp', breed: 'Bee' })]);
+    await rerender({});
+    expect(activeSpecies(container)).toBe('horse');
+  });
+
+  it('a persisted explicit choice wins over the population default', async () => {
+    breedingView.species = 'beewasp';
+    pets.set([stallion, mare, pet({ id: 3, species: 'Beewasp', breed: 'Bee' })]);
+    const { container, rerender } = render(BreedView);
+    await rerender({});
+    expect(activeSpecies(container)).toBe('beewasp');
+  });
+
+  it('clicking a species pins it in the store and resets breed + scroll state', async () => {
+    pets.set([stallion, mare]);
+    breedingView.scrollTop = 120;
+    breedingView.scrollLeft = 40;
+    const { container, rerender } = render(BreedView);
+    await rerender({});
+
+    const beewaspBtn = container.querySelector('[data-testid="breed-species"] [data-species="beewasp"]');
+    expect(beewaspBtn).not.toBeNull();
+    await fireEvent.click(beewaspBtn as Element);
+    await rerender({});
+
+    expect(breedingView.species).toBe('beewasp');
+    expect(activeSpecies(container)).toBe('beewasp');
+    expect(breedingView.scrollTop).toBe(0);
+    expect(breedingView.scrollLeft).toBe(0);
+  });
+});
+
+describe('BreedView — trio invalidation when a parent leaves the candidate set', () => {
+  beforeEach(() => {
+    breedingView.species = 'horse';
+    pets.set([stallion, mare]);
+    breedingView.selectedPair = { male: stallion, female: mare };
+  });
+
+  it('keeps the trio open across an in-flight reload that briefly lacks a parent', async () => {
+    const { rerender } = render(BreedView);
+    await rerender({});
+    expect(breedingView.selectedPair).not.toBeNull();
+
+    // Mid-reload: loading true and the list momentarily empty must not be
+    // mistaken for a deletion.
+    loading.set(true);
+    pets.set([]);
+    await rerender({});
+    expect(breedingView.selectedPair).not.toBeNull();
+
+    // The reload settles with both parents present (fresh object refs).
+    pets.set([pet({ id: 1, name: 'Dusty', gender: 'Male' }), pet({ id: 2, name: 'Roach' })]);
+    loading.set(false);
+    await rerender({});
+    expect(breedingView.selectedPair).not.toBeNull();
+  });
+
+  it('drops back to the pair table when a parent is deleted (settled load)', async () => {
+    const { rerender } = render(BreedView);
+    await rerender({});
+    expect(breedingView.selectedPair).not.toBeNull();
+
+    pets.set([mare]);
+    await rerender({});
+    expect(breedingView.selectedPair).toBeNull();
+  });
+
+  it('drops back to the pair table when a parent is unstabled (settled load)', async () => {
+    const { rerender } = render(BreedView);
+    await rerender({});
+    expect(breedingView.selectedPair).not.toBeNull();
+
+    pets.set([stallion, pet({ id: 2, name: 'Roach', stabled: false })]);
+    await rerender({});
+    expect(breedingView.selectedPair).toBeNull();
+  });
+});

--- a/tests/unit/breedingPairTable.test.ts
+++ b/tests/unit/breedingPairTable.test.ts
@@ -1,0 +1,106 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import BreedingPairTable from '$lib/components/breeding/BreedingPairTable.svelte';
+import { breedingView } from '$lib/stores/breeding.svelte.js';
+import type { BreedingPairResult, Pet } from '$lib/types/index.js';
+
+const pet = (over: Partial<Pet>): Pet =>
+  ({
+    id: 0,
+    name: 'Pet',
+    species: 'Horse',
+    breed: 'Standardbred',
+    gender: 'Female',
+    tags: [],
+    stabled: true,
+    positive_genes: 0,
+    ...over,
+  }) as unknown as Pet;
+
+const result = (male: Pet, female: Pet): BreedingPairResult => ({
+  male,
+  female,
+  evMixed: 1,
+  evPositiveByAttribute: {},
+  evPositiveTotal: 2,
+  evPositiveWeighted: 2,
+  evUnknown: 0,
+  totalLoci: 10,
+});
+
+const RESULTS = [result(pet({ id: 1, name: 'Dusty', gender: 'Male' }), pet({ id: 2, name: 'Roach' }))];
+
+function resetView() {
+  breedingView.species = '';
+  breedingView.offspringBreed = '';
+  breedingView.sortCol = 'evPositiveTotal';
+  breedingView.sortDir = 'desc';
+  breedingView.selectedPair = null;
+  breedingView.scrollTop = 0;
+  breedingView.scrollLeft = 0;
+}
+
+beforeEach(resetView);
+
+afterEach(() => {
+  cleanup();
+  resetView();
+});
+
+const wrapper = (c: HTMLElement) => c.querySelector('[data-testid="breeding-pair-table"]') as HTMLDivElement;
+
+describe('BreedingPairTable — scroll persistence', () => {
+  it('restores the persisted offsets once rows are rendered', async () => {
+    breedingView.scrollTop = 120;
+    breedingView.scrollLeft = 40;
+    const { container, rerender } = render(BreedingPairTable, { results: RESULTS, attrNames: [] });
+    await rerender({});
+    expect(wrapper(container).scrollTop).toBe(120);
+    expect(wrapper(container).scrollLeft).toBe(40);
+  });
+
+  it('persists the wrapper offsets into the store on scroll', async () => {
+    const { container, rerender } = render(BreedingPairTable, { results: RESULTS, attrNames: [] });
+    await rerender({});
+    const el = wrapper(container);
+    el.scrollTop = 80;
+    el.scrollLeft = 15;
+    await fireEvent.scroll(el);
+    expect(breedingView.scrollTop).toBe(80);
+    expect(breedingView.scrollLeft).toBe(15);
+  });
+
+  it('re-syncs the DOM when the store offsets are reset externally (species change)', async () => {
+    const { container, rerender } = render(BreedingPairTable, { results: RESULTS, attrNames: [] });
+    await rerender({});
+    const el = wrapper(container);
+
+    // User scrolls; the store follows.
+    el.scrollTop = 200;
+    el.scrollLeft = 30;
+    await fireEvent.scroll(el);
+    expect(breedingView.scrollTop).toBe(200);
+
+    // A species change resets the store while the table stays mounted — the
+    // DOM must follow, or the next scroll event would re-persist the stale
+    // offsets over the reset.
+    breedingView.scrollTop = 0;
+    breedingView.scrollLeft = 0;
+    await rerender({});
+    expect(el.scrollTop).toBe(0);
+    expect(el.scrollLeft).toBe(0);
+  });
+
+  it('a store write echoing the element position does not loop or move the DOM', async () => {
+    const { container, rerender } = render(BreedingPairTable, { results: RESULTS, attrNames: [] });
+    await rerender({});
+    const el = wrapper(container);
+
+    el.scrollTop = 60;
+    await fireEvent.scroll(el);
+    await rerender({});
+    // The sync effect saw store === element and left the DOM alone.
+    expect(el.scrollTop).toBe(60);
+    expect(breedingView.scrollTop).toBe(60);
+  });
+});


### PR DESCRIPTION
Three Breed-destination fixes:

- Default species is now the most-populated stabled species, derived reactively so the late-landing pet list can't lock in the alphabetical fallback. Species and pair-table scroll persist in `breedingView` across destination switches; scroll resets on a species change. Closes #399
- An open Trio is invalidated when either parent is deleted or unstabled — same settled-load (`!$loading`) guard as MyPets' detail overlay, so an in-flight reload can't false-trigger. Closes #400
- The pair table's bordered wrapper sizes to its rows (`flex: 0 1 auto` + `min-height: 0`) instead of framing empty space when sparse; long rankings still scroll inside the constrained parent. Closes #401

Tests: new `tests/unit/breedView.test.ts` (default pick, explicit-choice persistence, trio guard across in-flight vs settled loads); e2e extended with a return-from-excursion persistence check and a sparse-table sizing check. `pnpm vitest run` (822), `pnpm run lint:ci`, `pnpm run check` all clean; Playwright left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)