### PR TITLE
fix(community): bind correction identity fields to the first share

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -83,6 +83,31 @@ service cloud.firestore {
         && data.uploaderUid == null;
     }
 
+    // A correction may not rewrite the identity of the pet it corrects —
+    // only attributes/tags/notes (plus version stamps) are correction-
+    // eligible. Compare the six identity fields against the FIRST-share
+    // doc, whose ID is the hash itself; without this bind, anyone could
+    // append a "correction" with arbitrary name/species/… for someone
+    // else's published pet and permanently deface the catalogue entry
+    // (reads resolve latest-wins and update/delete are denied). Rules
+    // have no `let`, so the get() result is bound exactly once by passing
+    // its data through a function argument. The two functions inline to a
+    // single get() plus six equality checks (~20 evaluated expressions) —
+    // comfortably inside the 1000-expression budget that the unrolled
+    // isValidTagList already dominates (see the create rule below).
+    function identityMatchesFirstShare(data) {
+      return identityEquals(data, get(/databases/$(db)/documents/pets/$(data.contentHash)).data);
+    }
+
+    function identityEquals(data, base) {
+      return data.name == base.name
+        && data.character == base.character
+        && data.species == base.species
+        && data.gender == base.gender
+        && data.breed == base.breed
+        && data.breeder == base.breeder;
+    }
+
     // Pet *metadata* only — name, tags, attributes, attribution, schema/
     // version stamps, and the server-side upload timestamp. The genome text
     // itself lives in `/genomes/{contentHash}` (see below) so the catalogue
@@ -99,10 +124,12 @@ service cloud.firestore {
     //
     //  2. Correction — an auto-ID doc carrying a `contentHash` field that
     //     points back at an already-published genome. Lets a user append a
-    //     superseding metadata entry (corrected attributes/tags) without
-    //     mutating the original; reads resolve a hash to its latest entry
-    //     by `uploadedAt`. Requires the genome to already exist, so a
-    //     correction can never precede a first share.
+    //     superseding metadata entry (corrected attributes/tags/notes)
+    //     without mutating the original; reads resolve a hash to its latest
+    //     entry by `uploadedAt`. Requires the genome to already exist, so a
+    //     correction can never precede a first share — and its identity
+    //     fields must equal the first-share doc's (identityMatchesFirstShare
+    //     above), so a correction can never deface someone else's entry.
     //
     // update/delete stay denied — corrections are appends, never edits.
     match /pets/{docId} {
@@ -140,6 +167,11 @@ service cloud.firestore {
                           // already published the genome — it cannot bootstrap
                           // the genome in its own batch.
                           && exists(/databases/$(db)/documents/genomes/$(request.resource.data.contentHash))
+                          // Identity binding: the six identity fields must
+                          // equal the first-share doc's (see the function
+                          // comment above). Ordered after exists() so the
+                          // get() only runs for a plausible correction.
+                          && identityMatchesFirstShare(request.resource.data)
                         )
                     );
 

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -65,6 +65,7 @@ import {
 } from '$lib/services/petService.js';
 import { Gender, type ListPetsOpts, type Pet, type SharedPet, type SharedPetsPage } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
+import { mergeCorrectionIdentity } from '$lib/utils/sharedPet.js';
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
@@ -181,19 +182,34 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
   }
   await assertGenomeIntegrity(pet.content_hash, genomeSnap);
 
-  // Resolve the latest metadata across base + corrections. If it already
+  // Resolve the latest metadata across base + corrections (identity always
+  // from the base entry — see mergeCorrectionIdentity). If it already
   // matches what we're publishing, this is an idempotent no-op.
-  const latest = pickLatestSnapshot([baseSnap, ...corrSnap.docs]);
-  if (metadataMatches(toMetadataSharedPet(latest), pet)) {
+  const base = toMetadataSharedPet(baseSnap);
+  const latest = mergeCorrectionIdentity(toMetadataSharedPet(pickLatestSnapshot([baseSnap, ...corrSnap.docs])), base);
+  if (metadataMatches(latest, pet)) {
     return { status: 'already-shared', contentHash: pet.content_hash };
   }
 
-  // Attributes/tags (or name/breed/…) differ from the latest entry: append
-  // a correction. The genome blob is unchanged, so this is a single metadata
-  // write under an auto-ID with a `contentHash` back-reference. Add-only —
-  // the prior entries stay, and reads resolve to this newest one.
+  // Attributes/tags/notes differ from the latest entry: append a correction.
+  // The genome blob is unchanged, so this is a single metadata write under
+  // an auto-ID with a `contentHash` back-reference. Add-only — the prior
+  // entries stay, and reads resolve to this newest one. Identity fields are
+  // pinned to the first-share doc's values: firestore.rules rejects a
+  // correction whose identity differs from the base entry
+  // (identityMatchesFirstShare), so a locally-renamed pet re-shares its
+  // corrected attributes/tags without tripping permission-denied.
   const correctionRef = doc(collection(db, META_COLLECTION));
-  await setDoc(correctionRef, { ...payload, contentHash: pet.content_hash });
+  await setDoc(correctionRef, {
+    ...payload,
+    name: base.name,
+    character: base.character,
+    species: base.species,
+    gender: base.gender,
+    breed: base.breed,
+    breeder: base.breeder,
+    contentHash: pet.content_hash,
+  });
   return { status: 'created', contentHash: pet.content_hash };
 }
 
@@ -277,16 +293,16 @@ function pickLatestSnapshot(snaps: DocumentSnapshot<DocumentData>[]): DocumentSn
 /**
  * True when the already-published latest metadata equals what `pet` would
  * publish now — the signal to skip an add-only correction. Compares only
- * user-editable fields; `uploadedAt`/`appVersion`/`schemaVersion` are
- * expected to drift and don't count as a change. A legacy entry with no
+ * the correction-eligible fields (notes/tags/attributes);
+ * `uploadedAt`/`appVersion`/`schemaVersion` are expected to drift and don't
+ * count as a change, and the identity fields (name/character/species/
+ * gender/breed/breeder) are bound to the first share by firestore.rules —
+ * a local rename can't be published, so counting it as a difference would
+ * append a no-op correction on every re-share. A legacy entry with no
  * attributes never matches a pet that now carries them, so re-sharing an
  * old pet backfills its attributes via one correction.
  */
 function metadataMatches(existing: SharedPet, pet: Pet): boolean {
-  if (existing.name !== pet.name) return false;
-  if (existing.gender !== pet.gender) return false;
-  if (existing.breed !== pet.breed) return false;
-  if ((existing.breeder ?? '') !== (pet.breeder ?? '')) return false;
   if ((existing.notes ?? '') !== (pet.notes ?? '')) return false;
   if (!sameStringSet(existing.tags, sanitizeTags(pet.tags))) return false;
   return sameAttributes(existing.attributes, buildAttributes(pet));
@@ -491,8 +507,16 @@ export async function getSharedPet(contentHash: string, db: Firestore = defaultF
   const metaSnaps = [...(baseSnap.exists() ? [baseSnap] : []), ...corrSnap.docs];
   if (metaSnaps.length === 0) return null;
 
-  // Latest-wins: resolve the hash to its most recent metadata entry.
-  const pet = toMetadataSharedPet(pickLatestSnapshot(metaSnaps));
+  // Latest-wins for the correction-eligible fields (attributes/tags/notes),
+  // but identity fields always come from the first-share doc — a hostile
+  // pre-rule "correction" must not be able to rename/re-species the entry
+  // (issue #393). When no correction exists the merge is a no-op; when the
+  // base doc is somehow missing (half-published legacy state) the latest
+  // entry is returned unmerged, as before.
+  let pet = toMetadataSharedPet(pickLatestSnapshot(metaSnaps));
+  if (baseSnap.exists()) {
+    pet = mergeCorrectionIdentity(pet, toMetadataSharedPet(baseSnap));
+  }
   pet.contentHash = contentHash;
   const genomeData = genomeSnap.exists() ? (genomeSnap.data().genomeData as unknown) : undefined;
   pet.genomeData = typeof genomeData === 'string' ? genomeData : undefined;
@@ -800,8 +824,11 @@ function toMetadataSharedPet(snap: DocumentSnapshot<DocumentData>): SharedPet {
 
   return {
     // Correction docs carry the hash as a field (their doc ID is an
-    // auto-ID); the first-share doc's ID *is* the hash.
+    // auto-ID); the first-share doc's ID *is* the hash. `isCorrection`
+    // preserves the distinction so read-side merges can resolve identity
+    // fields from the first-share entry (see mergeCorrectionIdentity).
     contentHash: typeof data.contentHash === 'string' ? data.contentHash : snap.id,
+    isCorrection: typeof data.contentHash === 'string',
     name: str(data.name),
     character: str(data.character),
     species: str(data.species),

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -19,6 +19,7 @@ import { type ImportResult, importCommunityPet, listPets } from '$lib/services/s
 import { appState } from '$lib/stores/pets.js';
 import type { SharedPet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
+import { mergeCorrectionIdentity } from '$lib/utils/sharedPet.js';
 
 const PAGE_SIZE = 50;
 
@@ -30,14 +31,28 @@ const PAGE_SIZE = 50;
  * latest and preserves the newest-first display order. Deduping the whole
  * accumulated list (not just each page) also catches the case where a base
  * entry and its correction straddle a page boundary.
+ *
+ * Identity binding (issue #393): only attributes/tags/notes are
+ * correction-eligible — the identity fields (name/character/species/
+ * gender/breed/breeder) belong to the first-share entry. firestore.rules
+ * enforces that for new writes; this merge covers already-poisoned
+ * pre-rule corrections. When the kept row is a correction and its base
+ * (first-share) entry is encountered later in the accumulated list, the
+ * base's identity fields overwrite the correction's. A correction whose
+ * base hasn't been paged in yet is shown as-is (best effort — the detail
+ * view's `getSharedPet` always fetches the base doc and re-merges).
  */
 function dedupeLatest(pets: SharedPet[]): SharedPet[] {
-  const seen = new Set<string>();
+  const indexByHash = new Map<string, number>();
   const out: SharedPet[] = [];
   for (const pet of pets) {
-    if (seen.has(pet.contentHash)) continue;
-    seen.add(pet.contentHash);
-    out.push(pet);
+    const keptIndex = indexByHash.get(pet.contentHash);
+    if (keptIndex === undefined) {
+      indexByHash.set(pet.contentHash, out.length);
+      out.push(pet);
+    } else if (!pet.isCorrection && out[keptIndex].isCorrection) {
+      out[keptIndex] = mergeCorrectionIdentity(out[keptIndex], pet);
+    }
   }
   return out;
 }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -491,6 +491,15 @@ export interface SharedPet {
   genomeData?: string;
   uploadedAt: Date;
   uploaderUid: string | null;
+  /**
+   * True when this entry was read from a correction doc (auto-ID, carries
+   * a `contentHash` field) rather than the first-share doc (whose ID *is*
+   * the hash). The read path uses it to resolve identity fields
+   * (name/character/species/gender/breed/breeder) from the first-share
+   * entry — corrections may only alter attributes/tags/notes, and this
+   * flag lets the client enforce that even for pre-rule poisoned docs.
+   */
+  isCorrection?: boolean;
 }
 
 /**

--- a/src/lib/utils/sharedPet.ts
+++ b/src/lib/utils/sharedPet.ts
@@ -29,6 +29,31 @@ const ATTRIBUTE_KEYS = [
   'temperament',
 ] as const;
 
+/**
+ * Resolve a catalogue entry's identity from its FIRST-share doc. The
+ * catalogue is add-only and reads collapse a hash to its latest entry —
+ * but only attributes/tags/notes are correction-eligible; the identity
+ * fields (name/character/species/gender/breed/breeder) belong to the
+ * first share. `firestore.rules` enforces that binding for new writes
+ * (identityMatchesFirstShare); this client-side merge is defence in
+ * depth for corrections that predate the rule (issue #393 — a hostile
+ * "correction" could rename/re-species someone else's published pet).
+ *
+ * Returns `latest` with the six identity fields overwritten from `base`.
+ * When `latest` IS the base entry the merge is a no-op.
+ */
+export function mergeCorrectionIdentity(latest: SharedPet, base: SharedPet): SharedPet {
+  return {
+    ...latest,
+    name: base.name,
+    character: base.character,
+    species: base.species,
+    gender: base.gender,
+    breed: base.breed,
+    breeder: base.breeder,
+  };
+}
+
 export function sharedPetToPet(shared: SharedPet): Pet {
   const attrs = shared.attributes ?? {};
   const attributeFields = Object.fromEntries(

--- a/tests/integration/shareService.emulator.test.ts
+++ b/tests/integration/shareService.emulator.test.ts
@@ -200,6 +200,29 @@ describe('shareService end-to-end via emulator', () => {
     expect((await uploadPet(pet, db)).status).toBe('already-shared');
     expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(1);
   });
+
+  it('a rename-only local change is already-shared (identity is not correction-eligible)', async () => {
+    const pet = await freshPet('C3');
+    await uploadPet(pet, db);
+    expect((await uploadPet({ ...pet, name: 'RenamedLocally' }, db)).status).toBe('already-shared');
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(1);
+  });
+
+  it('a correction after a local rename passes the rules (identity pinned to first share)', async () => {
+    // The correction payload must carry the FIRST-share identity — sending
+    // the renamed local values would trip identityMatchesFirstShare and
+    // fail the whole re-share with permission-denied.
+    const pet = await freshPet('C4');
+    await uploadPet(pet, db);
+
+    const corrected = { ...pet, name: 'RenamedLocally', intelligence: 99 };
+    expect((await uploadPet(corrected, db)).status).toBe('created');
+
+    const fetched = await getSharedPet(pet.content_hash, db);
+    expect(fetched?.name).toBe(pet.name); // identity from the first share
+    expect(fetched?.attributes?.intelligence).toBe(99); // eligible field corrected
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(2);
+  });
 });
 
 // Any 64-char lowercase hex value passes the rule regex; the rules
@@ -389,6 +412,38 @@ describe('firestore.rules — add-only corrections', () => {
   it('rejects a correction carrying an unknown extra field', async () => {
     await batchWrite(VALID_DOC_ID);
     await expectRejected(setDoc(doc(collection(db, META_COLLECTION)), correctionMeta(VALID_DOC_ID, { nope: 1 })));
+  });
+
+  it('accepts a correction that changes only the correction-eligible fields (attributes/tags/notes)', async () => {
+    await batchWrite(VALID_DOC_ID);
+    await setDoc(
+      doc(collection(db, META_COLLECTION)),
+      correctionMeta(VALID_DOC_ID, {
+        attributes: { ...validAttributes(), intelligence: 99 },
+        tags: ['fast', 'corrected'],
+        notes: 'corrected notes',
+      }),
+    );
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(2);
+  });
+
+  // Identity binding (issue #393): a correction whose identity fields differ
+  // from the first-share doc would let anyone permanently deface someone
+  // else's published pet (reads resolve latest-wins; update/delete denied).
+  // Every override below is individually valid per isValidPetMeta — the
+  // rejection must come from identityMatchesFirstShare alone.
+  it.each([
+    ['name', { name: 'Defaced' }],
+    ['character', { character: 'Mallory' }],
+    ['species', { species: 'Horse' }],
+    ['gender', { gender: Gender.MALE }],
+    ['breed', { breed: 'FakeBreed' }],
+    ['breeder', { breeder: 'Mallory' }],
+  ])('rejects a correction that changes the identity field %s', async (_field, override) => {
+    await batchWrite(VALID_DOC_ID);
+    await expectRejected(setDoc(doc(collection(db, META_COLLECTION)), correctionMeta(VALID_DOC_ID, override)));
+    // The defacement never landed — the base entry stays the only doc.
+    expect((await getDocs(query(collection(db, META_COLLECTION)))).size).toBe(1);
   });
 });
 

--- a/tests/unit/communityStore.test.ts
+++ b/tests/unit/communityStore.test.ts
@@ -411,8 +411,15 @@ describe('community.svelte.ts — selection helpers', () => {
 describe('community.svelte.ts — add-only latest-per-hash dedup', () => {
   it('keeps only the newest entry per content hash within a page (newest-first)', async () => {
     // listPets pages newest-first, so a correction (newer) precedes the base
-    // it supersedes. Keep-first-seen therefore keeps the correction.
-    const correction = makeSharedPet('dup', { name: 'Corrected', uploadedAt: new Date('2026-06-01T00:00:00Z') });
+    // it supersedes. Keep-first-seen therefore keeps the correction's
+    // correction-eligible fields — but its identity fields resolve from
+    // the base entry (issue #393), so the displayed name is the original.
+    const correction = makeSharedPet('dup', {
+      name: 'Corrected',
+      notes: 'corrected notes',
+      isCorrection: true,
+      uploadedAt: new Date('2026-06-01T00:00:00Z'),
+    });
     const base = makeSharedPet('dup', { name: 'Original', uploadedAt: new Date('2026-05-01T00:00:00Z') });
     listPets.mockResolvedValueOnce({ pets: [makeSharedPet('other'), correction, base], cursor: null });
 
@@ -420,21 +427,92 @@ describe('community.svelte.ts — add-only latest-per-hash dedup', () => {
 
     expect(communityView.pets).toHaveLength(2);
     const dup = communityView.pets.find((p) => p.contentHash === 'dup');
-    expect(dup?.name).toBe('Corrected');
+    expect(dup?.name).toBe('Original');
+    expect(dup?.notes).toBe('corrected notes');
+    expect(dup?.uploadedAt).toEqual(new Date('2026-06-01T00:00:00Z'));
   });
 
   it('collapses a base/correction pair that straddles a page boundary', async () => {
     // Correction lands on page 1 (newer), its base on page 2 (older). The
-    // accumulated list must not show both.
-    const correction = makeSharedPet('dup', { name: 'Corrected', uploadedAt: new Date('2026-06-01T00:00:00Z') });
+    // accumulated list must not show both, and once the base is paged in
+    // its identity fields win over the correction's. Page 1 must be FULL
+    // (PAGE_SIZE = 50 rows) or `hasMore` flips false and loadMore never
+    // runs — an earlier revision of this test passed vacuously that way.
+    const correction = makeSharedPet('dup', {
+      name: 'Corrected',
+      tags: ['updated'],
+      isCorrection: true,
+      uploadedAt: new Date('2026-06-01T00:00:00Z'),
+    });
     const base = makeSharedPet('dup', { name: 'Original', uploadedAt: new Date('2026-05-01T00:00:00Z') });
-    listPets.mockResolvedValueOnce({ pets: [correction], cursor: { __snap: 'c1' } });
+    const filler = Array.from({ length: 49 }, (_, i) => makeSharedPet(`filler-${i}`));
+    listPets.mockResolvedValueOnce({ pets: [correction, ...filler], cursor: { __snap: 'c1' } });
     await loadInitial();
     listPets.mockResolvedValueOnce({ pets: [base], cursor: null });
     await loadMore();
 
     const dups = communityView.pets.filter((p) => p.contentHash === 'dup');
     expect(dups).toHaveLength(1);
-    expect(dups[0].name).toBe('Corrected');
+    expect(dups[0].name).toBe('Original');
+    expect(dups[0].tags).toEqual(['updated']);
+  });
+
+  it('resolves identity from the base entry when a hostile correction rewrites name/species (issue #393)', async () => {
+    // Pre-rule poisoned data: a "correction" carrying a different
+    // name/species/breeder for someone else's pet. The merged row must
+    // pin every identity field to the first-share entry and honour only
+    // the correction-eligible attributes/tags/notes.
+    const hostile = makeSharedPet('dup', {
+      name: 'HACKED',
+      character: 'Mallory',
+      species: 'Horse',
+      gender: Gender.MALE,
+      breed: 'FakeBreed',
+      breeder: 'Mallory',
+      notes: 'rude notes',
+      tags: ['defaced'],
+      attributes: { intelligence: 1 },
+      isCorrection: true,
+      uploadedAt: new Date('2026-06-01T00:00:00Z'),
+    });
+    const base = makeSharedPet('dup', { name: 'Original', uploadedAt: new Date('2026-05-01T00:00:00Z') });
+    listPets.mockResolvedValueOnce({ pets: [hostile, base], cursor: null });
+
+    await loadInitial();
+
+    expect(communityView.pets).toHaveLength(1);
+    const merged = communityView.pets[0];
+    expect(merged.name).toBe('Original');
+    expect(merged.character).toBe('Player');
+    expect(merged.species).toBe('BeeWasp');
+    expect(merged.gender).toBe(Gender.FEMALE);
+    expect(merged.breed).toBe('');
+    expect(merged.breeder).toBe('Player');
+    // Correction-eligible fields still come from the latest entry.
+    expect(merged.notes).toBe('rude notes');
+    expect(merged.tags).toEqual(['defaced']);
+    expect(merged.attributes).toEqual({ intelligence: 1 });
+  });
+
+  it('does not merge identity across two corrections (base not yet paged in)', async () => {
+    // Without the base entry there is nothing authoritative to pin to —
+    // the newest correction is shown as-is (the detail view's
+    // getSharedPet always fetches the base doc and re-merges).
+    const newer = makeSharedPet('dup', {
+      name: 'Newer',
+      isCorrection: true,
+      uploadedAt: new Date('2026-06-02T00:00:00Z'),
+    });
+    const older = makeSharedPet('dup', {
+      name: 'Older',
+      isCorrection: true,
+      uploadedAt: new Date('2026-06-01T00:00:00Z'),
+    });
+    listPets.mockResolvedValueOnce({ pets: [newer, older], cursor: null });
+
+    await loadInitial();
+
+    expect(communityView.pets).toHaveLength(1);
+    expect(communityView.pets[0].name).toBe('Newer');
   });
 });

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -330,6 +330,54 @@ describe('shareService.uploadPet — add-only corrections', () => {
     expect(setDoc).toHaveBeenCalledTimes(1);
   });
 
+  it('pins the correction identity fields to the first-share doc, not the local pet (issue #393)', async () => {
+    // The catalogue entry's identity belongs to the first share — rules
+    // reject a correction whose identity differs. The local pet was
+    // renamed and re-bred; the appended correction must carry the BASE
+    // doc's identity so the write passes the rules, while still
+    // publishing the corrected attributes.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(
+          matchingMeta({
+            name: 'CatalogueName',
+            breed: 'CatalogueBreed',
+            attributes: { ...FIXTURE_ATTRS, intelligence: 99 },
+          }),
+          { id: RAW_TEXT_HASH },
+        ),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ name: 'LocalRename', breed: 'LocalBreed' }));
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.name).toBe('CatalogueName');
+    expect(payload.breed).toBe('CatalogueBreed');
+    expect(payload.character).toBe('PlayerOne');
+    expect(payload.species).toBe('BeeWasp');
+    expect(payload.gender).toBe(Gender.FEMALE);
+    expect(payload.breeder).toBe('PlayerOne');
+    // The correction-eligible payload still comes from the local pet.
+    expect(payload.attributes).toEqual(FIXTURE_ATTRS);
+    expect(payload.contentHash).toBe(RAW_TEXT_HASH);
+  });
+
+  it('treats a rename-only local change as already-shared (identity is not correction-eligible)', async () => {
+    // Identity fields can't be published via a correction, so a local
+    // rename with identical notes/tags/attributes must be an idempotent
+    // no-op — NOT an appended no-op correction on every re-share.
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta(), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ name: 'RenamedLocally' }));
+    expect(result.status).toBe('already-shared');
+    expect(setDoc).not.toHaveBeenCalled();
+    expect(writeBatch).not.toHaveBeenCalled();
+  });
+
   it('resolves the latest entry across base + corrections before deciding', async () => {
     // Base (older) differs, but a correction (newer) already matches → no-op.
     getDocMock
@@ -405,6 +453,21 @@ describe('shareService.listPets', () => {
     expect(pets[0].name).toBe('Buzz');
     // Cursor is the underlying snapshot — opaque to callers.
     expect(cursor).toBe(lastSnap);
+  });
+
+  it('flags correction docs with isCorrection so read-side merges can find the base entry', async () => {
+    getDocsMock.mockResolvedValueOnce({
+      docs: [
+        readSnap(matchingMeta({ contentHash: RAW_TEXT_HASH }), { id: 'auto-1' }),
+        readSnap(matchingMeta(), { id: RAW_TEXT_HASH }),
+      ],
+    } as never);
+
+    const { pets } = await listPets();
+    expect(pets[0].isCorrection).toBe(true);
+    expect(pets[0].contentHash).toBe(RAW_TEXT_HASH);
+    expect(pets[1].isCorrection).toBe(false);
+    expect(pets[1].contentHash).toBe(RAW_TEXT_HASH);
   });
 
   it('returns a null cursor when the page is empty', async () => {
@@ -494,9 +557,11 @@ describe('shareService.getSharedPet', () => {
     expect(pet?.genomeData).toBeUndefined();
   });
 
-  it('resolves the latest correction over the base entry (latest-wins)', async () => {
+  it('resolves the latest correction over the base entry (latest-wins), identity from the base', async () => {
     // Base entry (older) + a correction doc (newer, carries the hash as a
-    // field). getSharedPet must return the newest.
+    // field). getSharedPet must return the newest correction-eligible
+    // fields (attributes/tags/notes) — but the identity fields stay the
+    // base entry's (issue #393).
     getDocMock
       .mockResolvedValueOnce(
         readSnap(matchingMeta({ name: 'OldName', uploadedAt: Timestamp.fromDate(new Date('2026-05-01T00:00:00Z')) }), {
@@ -508,8 +573,8 @@ describe('shareService.getSharedPet', () => {
       docs: [
         readSnap(
           matchingMeta({
-            name: 'NewName',
             contentHash: RAW_TEXT_HASH,
+            notes: 'corrected notes',
             attributes: { ...FIXTURE_ATTRS, intelligence: 90 },
             uploadedAt: Timestamp.fromDate(new Date('2026-06-01T00:00:00Z')),
           }),
@@ -519,10 +584,58 @@ describe('shareService.getSharedPet', () => {
     } as never);
 
     const pet = await getSharedPet(RAW_TEXT_HASH);
-    expect(pet?.name).toBe('NewName');
+    expect(pet?.name).toBe('OldName');
     expect(pet?.contentHash).toBe(RAW_TEXT_HASH);
+    expect(pet?.notes).toBe('corrected notes');
     expect(pet?.attributes).toEqual({ ...FIXTURE_ATTRS, intelligence: 90 });
     expect(pet?.genomeData).toBe('GENOME-BODY');
+  });
+
+  it('ignores identity fields on a hostile correction (defacement attempt, issue #393)', async () => {
+    // A pre-rule "correction" that tries to rewrite someone else's entry:
+    // new name/character/species/gender/breed/breeder. The read must pin
+    // every identity field to the first-share doc and honour only the
+    // correction-eligible attributes/tags/notes.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ uploadedAt: Timestamp.fromDate(new Date('2026-05-01T00:00:00Z')) }), {
+          id: RAW_TEXT_HASH,
+        }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: 'GENOME-BODY' }));
+    getDocsMock.mockResolvedValueOnce({
+      docs: [
+        readSnap(
+          matchingMeta({
+            contentHash: RAW_TEXT_HASH,
+            name: 'HACKED',
+            character: 'Mallory',
+            species: 'Horse',
+            gender: Gender.MALE,
+            breed: 'FakeBreed',
+            breeder: 'Mallory',
+            notes: 'rude notes',
+            tags: ['defaced'],
+            attributes: { ...FIXTURE_ATTRS, ferocity: 100 },
+            uploadedAt: Timestamp.fromDate(new Date('2026-06-01T00:00:00Z')),
+          }),
+          { id: 'auto-evil' },
+        ),
+      ],
+    } as never);
+
+    const pet = await getSharedPet(RAW_TEXT_HASH);
+    // Identity: first-share values, not the hostile correction's.
+    expect(pet?.name).toBe('Buzz');
+    expect(pet?.character).toBe('PlayerOne');
+    expect(pet?.species).toBe('BeeWasp');
+    expect(pet?.gender).toBe(Gender.FEMALE);
+    expect(pet?.breed).toBe('');
+    expect(pet?.breeder).toBe('PlayerOne');
+    // Correction-eligible fields still resolve latest-wins.
+    expect(pet?.notes).toBe('rude notes');
+    expect(pet?.tags).toEqual(['defaced']);
+    expect(pet?.attributes).toEqual({ ...FIXTURE_ATTRS, ferocity: 100 });
   });
 
   it('reads a complete attribute map into SharedPet.attributes, undefined when incomplete', async () => {


### PR DESCRIPTION
The correction write shape only required a well-formed doc plus an existing /genomes/{hash}, so any client could append a "correction" with arbitrary name/species/breed/notes for someone else's published pet; latest-wins reads and denied update/delete made it the permanent displayed entry.

Closes #393

Two layers:

**Rules.** The correction branch now `get()`s the first-share doc (its ID is the hash) and requires the six identity fields (name, character, species, gender, breed, breeder) to equal it. The get() result is bound once by passing its `.data` through a helper-function argument (rules have no `let`), inlining to one get() plus six equality checks — well inside the 1000-expression cap that the unrolled tag validator dominates. Verified against the emulator: all 51 integration tests pass, including six new per-field rejection cases and acceptance of attributes/tags/notes-only corrections.

**Client read merge (defence in depth, covers already-poisoned data).** `toMetadataSharedPet` marks correction docs (`isCorrection`); `getSharedPet` and the community store's `dedupeLatest` resolve identity fields from the first-share entry and honour only attributes/tags/notes from later corrections (`mergeCorrectionIdentity` in `utils/sharedPet.ts`). The correction write path pins identity to the base doc's values, so a locally renamed pet still re-shares its corrected attributes without tripping permission-denied; `metadataMatches` now compares only correction-eligible fields, so a rename-only re-share is `already-shared` rather than a no-op correction appended per re-share.

Tests: unit suite 821 passed (new coverage for hostile corrections in shareService + community store, identity pinning on the write path); emulator integration suite 51 passed locally. Note: the pre-existing "straddles a page boundary" store test was passing vacuously (1-row page 1 set `hasMore=false`, so `loadMore` never ran) — fixed to use a full first page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)