### PR TITLE
fix(ui): overlay layering — Escape, nav gating, stale preview, dirty guard

### DIFF
--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -2,16 +2,24 @@
 import { ArrowLeft } from '@lucide/svelte';
 import logoImg from '$lib/assets/logo.png';
 import { activeTab, appState, canGoBack, type Tab } from '$lib/stores/pets.js';
-import { uiActions } from '$lib/stores/ui.js';
+import { overlayOpen, uiActions } from '$lib/stores/ui.js';
 import DataMenu from './DataMenu.svelte';
 
+// Destination navigation is gated (disabled) while a root overlay (Settings /
+// pet editor) is open: switching the tab underneath would move the content and
+// the nav highlight while the overlay stays on top, leaving the two in
+// disagreement — and a nav click could silently discard editor changes (#396).
+// Close the overlay (Back / Escape) first, then navigate.
+
 function switchTab(tab: Tab) {
+  if ($overlayOpen) return; // defence in depth — the buttons are also disabled
   appState.switchTab(tab);
 }
 
 function handleWindowKeydown(e: KeyboardEvent) {
   // Alt+Left → previous tab. Don't hijack it while the user is typing.
   if (!(e.altKey && e.key === 'ArrowLeft')) return;
+  if ($overlayOpen) return; // nav is gated while a root overlay is open
   const t = e.target as HTMLElement | null;
   if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return;
   e.preventDefault();
@@ -21,7 +29,7 @@ function handleWindowKeydown(e: KeyboardEvent) {
 function handleMouseUp(e: MouseEvent) {
   // Mouse "back" button (button 3) → previous tab. goBack is a no-op
   // when there's no history, so an unconditional call is safe.
-  if (e.button === 3) {
+  if (e.button === 3 && !$overlayOpen) {
     e.preventDefault();
     appState.goBack();
   }
@@ -39,7 +47,7 @@ function handleMouseUp(e: MouseEvent) {
     <button
         class="back-btn"
         onclick={() => appState.goBack()}
-        disabled={!$canGoBack}
+        disabled={!$canGoBack || $overlayOpen}
         title="Back to previous tab (Alt+←)"
         aria-label="Back to previous tab"
     >
@@ -50,6 +58,7 @@ function handleMouseUp(e: MouseEvent) {
             class="tab-btn"
             class:active={$activeTab === "library"}
             data-testid="tab-library"
+            disabled={$overlayOpen}
             onclick={() => switchTab("library")}
         >
             ✨ My Pets
@@ -58,6 +67,7 @@ function handleMouseUp(e: MouseEvent) {
             class="tab-btn"
             class:active={$activeTab === "breed"}
             data-testid="tab-breed"
+            disabled={$overlayOpen}
             onclick={() => switchTab("breed")}
         >
             💞 Breed
@@ -66,6 +76,7 @@ function handleMouseUp(e: MouseEvent) {
             class="tab-btn"
             class:active={$activeTab === "community"}
             data-testid="tab-community"
+            disabled={$overlayOpen}
             onclick={() => switchTab("community")}
         >
             🌐 Community
@@ -74,13 +85,14 @@ function handleMouseUp(e: MouseEvent) {
             class="tab-btn"
             class:active={$activeTab === "reference"}
             data-testid="tab-reference"
+            disabled={$overlayOpen}
             onclick={() => switchTab("reference")}
         >
             📚 Reference
         </button>
     </nav>
     <DataMenu />
-    <button type="button" class="settings-toggle" onclick={() => uiActions.openSettings()} title="Settings" aria-label="Settings">
+    <button type="button" class="settings-toggle" disabled={$overlayOpen} onclick={() => uiActions.openSettings()} title="Settings" aria-label="Settings">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
             <circle cx="12" cy="12" r="3"/>
@@ -170,9 +182,16 @@ function handleMouseUp(e: MouseEvent) {
         transition: all 0.15s ease;
     }
 
-    .tab-btn:hover {
+    .tab-btn:hover:not(:disabled) {
         color: var(--text-secondary);
         background: var(--border-primary);
+    }
+
+    /* Gated while a root overlay (Settings / editor) is open. The active
+       highlight stays visible so the current destination remains legible. */
+    .tab-btn:disabled {
+        opacity: 0.55;
+        cursor: default;
     }
 
     .tab-btn.active {
@@ -195,8 +214,13 @@ function handleMouseUp(e: MouseEvent) {
         transition: all 0.15s ease;
     }
 
-    .settings-toggle:hover {
+    .settings-toggle:hover:not(:disabled) {
         background: var(--bg-tertiary);
         color: var(--text-secondary);
+    }
+
+    .settings-toggle:disabled {
+        opacity: 0.4;
+        cursor: default;
     }
 </style>

--- a/src/lib/components/layout/TopBar.svelte
+++ b/src/lib/components/layout/TopBar.svelte
@@ -19,19 +19,23 @@ function switchTab(tab: Tab) {
 function handleWindowKeydown(e: KeyboardEvent) {
   // Alt+Left → previous tab. Don't hijack it while the user is typing.
   if (!(e.altKey && e.key === 'ArrowLeft')) return;
-  if ($overlayOpen) return; // nav is gated while a root overlay is open
   const t = e.target as HTMLElement | null;
   if (t?.tagName === 'INPUT' || t?.tagName === 'TEXTAREA' || t?.isContentEditable) return;
+  // Always suppress the webview's own back gesture — even while the nav is
+  // gated, Alt+Left must not navigate the app shell away.
   e.preventDefault();
+  if ($overlayOpen) return; // nav is gated while a root overlay is open
   appState.goBack();
 }
 
 function handleMouseUp(e: MouseEvent) {
-  // Mouse "back" button (button 3) → previous tab. goBack is a no-op
-  // when there's no history, so an unconditional call is safe.
-  if (e.button === 3 && !$overlayOpen) {
+  // Mouse back/forward buttons (3/4): suppress the webview's history
+  // navigation unconditionally so the app shell can't be navigated away,
+  // then treat "back" as previous-tab — unless the nav is gated by an open
+  // root overlay. goBack is a no-op without history, so the call is safe.
+  if (e.button === 3 || e.button === 4) {
     e.preventDefault();
-    appState.goBack();
+    if (e.button === 3 && !$overlayOpen) appState.goBack();
   }
 }
 </script>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -240,7 +240,7 @@ function updateAttribute(attrKey: string, value: string): void {
           class="modal-backdrop"
           data-testid="pet-editor-discard-confirm"
           onclick={(e) => { if (e.target === e.currentTarget) keepEditing(); }}
-          onkeydown={(e) => { if (e.key === 'Escape') keepEditing(); }}
+          onkeydown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); keepEditing(); } }}
         >
           <div class="confirm-dialog" role="alertdialog" aria-label="Discard unsaved changes" aria-modal="true" use:focusTrap>
             <p class="confirm-message">Discard unsaved changes?</p>

--- a/src/lib/components/pet/PetEditor.svelte
+++ b/src/lib/components/pet/PetEditor.svelte
@@ -6,6 +6,7 @@ import { getAllAttributeDisplayInfo, getAllAttributeNames } from '$lib/services/
 import { allTags as allTagsStore, appState } from '$lib/stores/pets.js';
 import type { AttributeInfo, Gender, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
+import { focusTrap } from '$lib/utils/focusTrap.js';
 import { computePetChanges } from '$lib/utils/petChanges.js';
 import TagInput from './TagInput.svelte';
 
@@ -53,6 +54,7 @@ let editStarred: boolean = $state(untrack(() => !!pet.starred));
 let editStabled: boolean = $state(untrack(() => !!pet.stabled));
 let editIsPetQuality: boolean = $state(untrack(() => !!pet.is_pet_quality));
 let saveError: string = $state('');
+let confirmingDiscard: boolean = $state(false);
 
 const allTags: string[] = $derived($allTagsStore);
 
@@ -61,18 +63,23 @@ const filteredAttributeList: AttributeInfo[] = $derived(
   ALL_ATTRIBUTES.filter((attr) => availableAttributes.includes(attr.key.toLowerCase())),
 );
 
+/** The current form values, in the shape `computePetChanges` diffs against the pet. */
+function currentEdits() {
+  return {
+    name: editName,
+    gender: editGender,
+    breed: editBreed,
+    attributes: editAttributes,
+    tags: editTags,
+    starred: editStarred,
+    stabled: editStabled,
+    isPetQuality: editIsPetQuality,
+  };
+}
+
 async function handleSave(): Promise<void> {
   try {
-    const updateData = computePetChanges(pet, {
-      name: editName,
-      gender: editGender,
-      breed: editBreed,
-      attributes: editAttributes,
-      tags: editTags,
-      starred: editStarred,
-      stabled: editStabled,
-      isPetQuality: editIsPetQuality,
-    });
+    const updateData = computePetChanges(pet, currentEdits());
 
     if (Object.keys(updateData).length > 0) {
       await appState.updatePet(pet.id, updateData);
@@ -86,6 +93,23 @@ async function handleSave(): Promise<void> {
 
 function handleCancel(): void {
   saveError = '';
+  // Dirty guard: backing out (Cancel / back button / Escape) with pending
+  // changes asks for confirmation instead of silently discarding them.
+  // `computePetChanges` diffs the form against the saved pet, so reverting an
+  // edit by hand counts as clean again.
+  if (Object.keys(computePetChanges(pet, currentEdits())).length > 0) {
+    confirmingDiscard = true;
+    return;
+  }
+  onClose?.();
+}
+
+function keepEditing(): void {
+  confirmingDiscard = false;
+}
+
+function discardChanges(): void {
+  confirmingDiscard = false;
   onClose?.();
 }
 
@@ -205,6 +229,29 @@ function updateAttribute(attrKey: string, value: string): void {
         <button class="btn btn-secondary" onclick={handleCancel}>Cancel</button>
         <button class="btn btn-primary" onclick={handleSave}>Save Changes</button>
       </div>
+
+      {#if confirmingDiscard}
+        <!-- Same true-modal pattern as PetActions' delete confirm: a focus-
+             trapped alertdialog on .modal-backdrop. DetailOverlay's document-
+             level Escape defers to any open .modal-backdrop, so Escape here
+             closes only this dialog (keep editing), not the editor. -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+          class="modal-backdrop"
+          data-testid="pet-editor-discard-confirm"
+          onclick={(e) => { if (e.target === e.currentTarget) keepEditing(); }}
+          onkeydown={(e) => { if (e.key === 'Escape') keepEditing(); }}
+        >
+          <div class="confirm-dialog" role="alertdialog" aria-label="Discard unsaved changes" aria-modal="true" use:focusTrap>
+            <p class="confirm-message">Discard unsaved changes?</p>
+            <p class="confirm-subtext">Your edits to <strong>{pet.name}</strong> have not been saved.</p>
+            <div class="confirm-actions">
+              <button class="btn btn-secondary" data-testid="discard-keep-editing" onclick={keepEditing}>Keep editing</button>
+              <button class="btn btn-danger" data-testid="discard-confirm" onclick={discardChanges}>Discard</button>
+            </div>
+          </div>
+        </div>
+      {/if}
     </div>
   {/snippet}
 </DetailOverlay>
@@ -406,5 +453,34 @@ function updateAttribute(attrKey: string, value: string): void {
     font-size: 13px;
     padding: 10px 14px;
     margin-bottom: 16px;
+  }
+
+  /* Discard-confirm dialog (mirrors PetActions' delete confirm). */
+  .confirm-dialog {
+    background: var(--bg-primary);
+    border-radius: 12px;
+    box-shadow: var(--shadow-xl);
+    padding: 24px;
+    width: 340px;
+    max-width: 90vw;
+    text-align: center;
+  }
+
+  .confirm-message {
+    font-size: 15px;
+    color: var(--text-primary);
+    margin: 0 0 4px 0;
+  }
+
+  .confirm-subtext {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 0 0 20px 0;
+  }
+
+  .confirm-actions {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
   }
 </style>

--- a/src/lib/components/shared/DetailOverlay.svelte
+++ b/src/lib/components/shared/DetailOverlay.svelte
@@ -1,3 +1,14 @@
+<script lang="ts" module>
+/**
+ * Stack of currently-mounted overlays, bottom → top. Escape is handled by a
+ * document-level listener (so it works no matter where focus sits — e.g. on
+ * document.body after a click on non-focusable content), but only the topmost
+ * overlay backs out, so stacked lenses (Settings opened over a pet detail)
+ * unwind one per press.
+ */
+const overlayStack: symbol[] = [];
+</script>
+
 <script lang="ts">
 /**
  * The unified full-view shell for the Workspace's detail lenses — single pet,
@@ -52,8 +63,11 @@ const {
 let sectionEl = $state<HTMLElement | null>(null);
 let backBtn = $state<HTMLButtonElement | null>(null);
 
+const stackId = Symbol('detail-overlay');
+
 onMount(() => {
   const previouslyFocused = document.activeElement as HTMLElement | null;
+  overlayStack.push(stackId);
 
   // Make the covered UI inert: the overlay sits over its siblings (the
   // table/list), so keyboard focus and assistive tech must not reach controls
@@ -73,29 +87,36 @@ onMount(() => {
   backBtn?.focus();
 
   return () => {
+    const idx = overlayStack.indexOf(stackId);
+    if (idx !== -1) overlayStack.splice(idx, 1);
     for (const sib of covered) sib.removeAttribute('inert');
     previouslyFocused?.focus();
   };
 });
 
-function handleKeydown(e: KeyboardEvent) {
+// Document-level so Escape backs out regardless of where focus is (a section
+// -scoped handler misses it when focus rests on document.body). Scoped to the
+// topmost mounted overlay via the module-level stack.
+function handleDocumentKeydown(e: KeyboardEvent) {
   if (e.key !== 'Escape') return;
-  // Defer to a nested true-modal (the delete-confirm dialog): it owns its own
-  // Escape, so don't also tear down the lens underneath it.
-  if ((e.target as HTMLElement | null)?.closest?.('.modal-backdrop')) return;
+  if (overlayStack[overlayStack.length - 1] !== stackId) return;
+  // Defer to an open true-modal (delete/discard confirms, import dialogs —
+  // anything on a .modal-backdrop): it owns its own Escape, so don't also
+  // tear down the lens underneath it.
+  if (document.querySelector('.modal-backdrop')) return;
   onBack();
 }
 </script>
 
+<svelte:document onkeydown={handleDocumentKeydown} />
+
 <!-- A <section> with an accessible name is already a `region` landmark. -->
-<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <section
   bind:this={sectionEl}
   class="detail-overlay"
   data-testid={testid}
   aria-label={ariaLabel}
   tabindex="-1"
-  onkeydown={handleKeydown}
 >
   <header class="do-head">
     <button bind:this={backBtn} type="button" class="back-btn" data-testid={backTestid} onclick={onBack}>

--- a/src/lib/components/shared/DetailOverlay.svelte
+++ b/src/lib/components/shared/DetailOverlay.svelte
@@ -104,6 +104,12 @@ function handleDocumentKeydown(e: KeyboardEvent) {
   // anything on a .modal-backdrop): it owns its own Escape, so don't also
   // tear down the lens underneath it.
   if (document.querySelector('.modal-backdrop')) return;
+  // The modal's own Escape handler may already have torn it down earlier in
+  // this same event's bubble path (Svelte flushes the removal synchronously),
+  // so the live-DOM check above misses it. The event target still sits in the
+  // detached subtree, and `closest` walks detached trees — if this Escape was
+  // aimed at a modal, it's consumed, not a back-out of the lens beneath.
+  if ((e.target as HTMLElement | null)?.closest?.('.modal-backdrop')) return;
   onBack();
 }
 </script>

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -86,7 +86,7 @@ async function doDelete(): Promise<void> {
   <div
     class="modal-backdrop"
     onclick={(e) => { if (e.target === e.currentTarget) cancelDelete(); }}
-    onkeydown={(e) => { if (e.key === 'Escape') cancelDelete(); }}
+    onkeydown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); cancelDelete(); } }}
   >
     <div class="confirm-dialog" role="alertdialog" aria-label="Confirm delete" aria-modal="true" use:focusTrap>
       <p class="confirm-message">Delete <strong>{pet.name}</strong>?</p>

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -16,7 +16,7 @@
 
 import { isPlaceholderConfig } from '$lib/firebase.js';
 import { type ImportResult, importCommunityPet, listPets } from '$lib/services/shareService.js';
-import { appState } from '$lib/stores/pets.js';
+import { activeTab, appState } from '$lib/stores/pets.js';
 import type { SharedPet } from '$lib/types/index.js';
 import { errorMessage } from '$lib/utils/error.js';
 
@@ -106,14 +106,22 @@ export function selectedSharedPet(): SharedPet | null {
   return communityView.pets.find((p) => p.contentHash === communityView.selectedHash) ?? null;
 }
 
+// Close the open preview whenever the user leaves the Community destination.
+// The page cache above deliberately survives tab switches (read quota), but
+// the *preview* must not: My Pets holds its detail in component-local state
+// that dies on unmount, so a destination switch always lands back on the
+// table — mirror that instead of restoring a stale detail on return (#396).
+activeTab.subscribe((tab) => {
+  if (tab !== 'community') communityView.selectedHash = null;
+});
+
 /**
  * Load the first page. By default short-circuits when the cached page is
  * fresh (see `STALE_AFTER_MS`) — pass `{ force: true }` to bypass the
  * cache (used by the "Try again" button in the error state).
  *
- * Selection is intentionally preserved across reloads — if the user
- * navigates away from the tab and returns, the pet they were
- * inspecting stays selected (provided it's still in the loaded page).
+ * Selection is preserved across reloads *within* the tab, but cleared on
+ * destination switch (see the `activeTab` subscription above).
  */
 export async function loadInitial(opts: { force?: boolean } = {}): Promise<void> {
   if (isPlaceholderConfig) {

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -50,6 +50,9 @@ const TAB_STATE_RESETS: Record<Tab, () => void> = {
   // Breed ranks across the whole stable by species; it doesn't use the library
   // single-pet/gene state, so clear it on entry.
   breed: clearSelectionAndGeneView,
+  // The Community preview (communityView.selectedHash) resets itself on any
+  // destination switch via the community store's own activeTab subscription —
+  // importing it here would pull firebase into every pets.js consumer.
   community: clearSelectionAndGeneView,
   // Reference (gene-template editing) clears any single-pet selection so it
   // can't carry over from the library when switching destinations.

--- a/src/lib/stores/ui.ts
+++ b/src/lib/stores/ui.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 import type { Pet } from '$lib/types/index.js';
 
 /**
@@ -9,6 +9,18 @@ import type { Pet } from '$lib/types/index.js';
  */
 export const settingsOpen = writable(false);
 export const editingPet = writable<Pet | null>(null);
+
+/**
+ * True while a root overlay (Settings or the pet editor) covers the workspace.
+ * The TopBar gates destination navigation (tab buttons, history back, the
+ * settings toggle) on this: switching the underlying destination while an
+ * overlay covers it would desync the nav highlight from what's visible, and
+ * a nav-dismiss would bypass the editor's unsaved-changes guard (#396).
+ */
+export const overlayOpen = derived(
+  [settingsOpen, editingPet],
+  ([$settingsOpen, $editingPet]) => $settingsOpen || $editingPet !== null,
+);
 
 export const uiActions = {
   openSettings: () => settingsOpen.set(true),

--- a/tests/e2e/keyboard.spec.ts
+++ b/tests/e2e/keyboard.spec.ts
@@ -91,6 +91,41 @@ test.describe('Keyboard Navigation', () => {
       await expect(page.locator('[data-testid="settings-view"]')).not.toBeVisible();
     });
 
+    test('Escape closes settings even when focus is outside the overlay', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await page.locator('.settings-toggle').click();
+      await expect(page.locator('[data-testid="settings-view"]')).toBeVisible();
+
+      // Click non-focusable overlay content so focus falls back to the body —
+      // the document-level Escape handler must still catch it (#396).
+      await page.locator('.settings-inner').click({ position: { x: 5, y: 5 } });
+      await page.keyboard.press('Escape');
+      await expect(page.locator('[data-testid="settings-view"]')).not.toBeVisible();
+    });
+
+    test('top nav is gated while settings is open', async ({ page }) => {
+      await page.goto('/');
+      await waitForAppReady(page);
+
+      await page.locator('.settings-toggle').click();
+      await expect(page.locator('[data-testid="settings-view"]')).toBeVisible();
+
+      // Destination buttons, history back, and the settings toggle are
+      // disabled while a root overlay covers the workspace (#396).
+      for (const id of ['tab-library', 'tab-breed', 'tab-community', 'tab-reference']) {
+        await expect(page.locator(`[data-testid="${id}"]`)).toBeDisabled();
+      }
+      await expect(page.locator('.top-bar .back-btn')).toBeDisabled();
+      await expect(page.locator('.settings-toggle')).toBeDisabled();
+
+      // Backing out re-enables the nav.
+      await page.keyboard.press('Escape');
+      await expect(page.locator('[data-testid="tab-breed"]')).toBeEnabled();
+      await expect(page.locator('.settings-toggle')).toBeEnabled();
+    });
+
     test('settings is a labelled in-space region', async ({ page }) => {
       await page.goto('/');
       await waitForAppReady(page);

--- a/tests/e2e/pet-crud.spec.ts
+++ b/tests/e2e/pet-crud.spec.ts
@@ -200,25 +200,60 @@ test.describe('Pet Editor – Cancel', () => {
     await waitForPets(page);
   });
 
-  test('cancel discards name change', async ({ page }) => {
+  // Backing out with pending changes (Cancel / Escape / back button) opens a
+  // discard-confirm dialog instead of silently dropping the edits (#396).
+
+  test('cancel with no changes closes immediately without a confirm', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('.editor-footer .btn-secondary').click();
+
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
+  });
+
+  test('cancel with a name change asks before discarding', async ({ page }) => {
     const originalName = (await page.locator('[data-testid="roster-open"]').first().textContent()) ?? '';
 
     await openEditor(page);
     await page.locator('#petName').fill('ShouldNotPersist');
-    await page.locator('.btn-secondary').click();
+    await page.locator('.editor-footer .btn-secondary').click();
 
+    // The editor stays until the discard is confirmed.
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toBeVisible();
+    await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
+
+    await page.locator('[data-testid="discard-confirm"]').click();
     await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);
   });
 
-  test('cancel discards attribute change', async ({ page }) => {
+  test('"Keep editing" returns to the editor with the edits intact', async ({ page }) => {
+    await openEditor(page);
+    await page.locator('#petName').fill('StillEditing');
+    await page.locator('[data-testid="pet-editor-back"]').click();
+
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toBeVisible();
+    await page.locator('[data-testid="discard-keep-editing"]').click();
+
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
+    await expect(page.locator('#petName')).toHaveValue('StillEditing');
+
+    // Clean up: discard for real.
+    await page.locator('[data-testid="pet-editor-back"]').click();
+    await page.locator('[data-testid="discard-confirm"]').click();
+    await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
+  });
+
+  test('cancel discards attribute change after confirming', async ({ page }) => {
     await openEditor(page);
 
     const attrInput = page.locator('.attr-field input[type="number"]').first();
     const originalValue = await attrInput.inputValue();
 
     await attrInput.fill('0');
-    await page.locator('.btn-secondary').click();
+    await page.locator('.editor-footer .btn-secondary').click();
+    await page.locator('[data-testid="discard-confirm"]').click();
 
     await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
 
@@ -228,23 +263,34 @@ test.describe('Pet Editor – Cancel', () => {
     await page.locator('[data-testid="pet-editor-back"]').click();
   });
 
-  test('escape key closes editor without saving', async ({ page }) => {
+  test('escape key with unsaved changes asks, then discards', async ({ page }) => {
     const originalName = (await page.locator('[data-testid="roster-open"]').first().textContent()) ?? '';
 
     await openEditor(page);
     await page.locator('#petName').fill('EscapeShouldDiscard');
     await page.keyboard.press('Escape');
 
+    // Escape surfaces the guard rather than closing outright; a second Escape
+    // dismisses only the dialog (keep editing).
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-testid="pet-editor-discard-confirm"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="pet-editor"]')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await page.locator('[data-testid="discard-confirm"]').click();
+
     await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);
   });
 
-  test('back button closes editor without saving', async ({ page }) => {
+  test('back button with unsaved changes asks, then discards', async ({ page }) => {
     const originalName = (await page.locator('[data-testid="roster-open"]').first().textContent()) ?? '';
 
     await openEditor(page);
     await page.locator('#petName').fill('BackShouldDiscard');
     await page.locator('[data-testid="pet-editor-back"]').click();
+    await page.locator('[data-testid="discard-confirm"]').click();
 
     await expect(page.locator('[data-testid="pet-editor"]')).not.toBeVisible();
     await expect(page.locator('[data-testid="roster-open"]').first()).toHaveText(originalName);

--- a/tests/fixtures/DetailOverlayHarness.svelte
+++ b/tests/fixtures/DetailOverlayHarness.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+/**
+ * Test harness for DetailOverlay's document-level Escape handling: a base
+ * overlay (A), an optional stacked overlay (B, mounted after A so it is the
+ * topmost), and an optional fake true-modal (.modal-backdrop) that Escape
+ * must defer to.
+ */
+import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
+
+interface Props {
+  onBackA: () => void;
+  onBackB?: () => void;
+  showB?: boolean;
+  showModal?: boolean;
+}
+
+const { onBackA, onBackB = () => {}, showB = false, showModal = false }: Props = $props();
+</script>
+
+<div class="host">
+  <DetailOverlay onBack={onBackA} testid="overlay-a" backTestid="overlay-a-back">
+    {#snippet title()}A{/snippet}
+    <p>overlay A body</p>
+  </DetailOverlay>
+
+  {#if showB}
+    <DetailOverlay onBack={onBackB} testid="overlay-b" backTestid="overlay-b-back">
+      {#snippet title()}B{/snippet}
+      <p>overlay B body</p>
+    </DetailOverlay>
+  {/if}
+
+  {#if showModal}
+    <div class="modal-backdrop" data-testid="fake-modal"><button type="button">ok</button></div>
+  {/if}
+</div>

--- a/tests/unit/communityStore.test.ts
+++ b/tests/unit/communityStore.test.ts
@@ -17,12 +17,18 @@ vi.mock('$lib/services/shareService.js', () => ({
   verifySharedPet: vi.fn(),
 }));
 
-vi.mock('$lib/stores/pets.js', () => ({
-  appState: {
-    loadPets: vi.fn().mockResolvedValue(undefined),
-    appendPet: vi.fn().mockResolvedValue(undefined),
-  },
-}));
+vi.mock('$lib/stores/pets.js', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    // The store subscribes to `activeTab` at module scope to clear the open
+    // preview on destination switch (#396) — provide a real writable.
+    activeTab: writable('community'),
+    appState: {
+      loadPets: vi.fn().mockResolvedValue(undefined),
+      appendPet: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
 
 import {
   type ImportResult,
@@ -39,7 +45,7 @@ import {
   selectedSharedPet,
   selectPet,
 } from '$lib/stores/community.svelte.js';
-import { appState as appStateReal } from '$lib/stores/pets.js';
+import { activeTab, appState as appStateReal } from '$lib/stores/pets.js';
 import { Gender, type SharedPet } from '$lib/types/index.js';
 
 // These modules are `vi.mock`ed above, so the imported bindings are
@@ -78,6 +84,7 @@ afterEach(() => {
   // or in-flight generation counters.
   vi.resetAllMocks();
   _resetCommunityStoreState();
+  activeTab.set('community');
   communityView.pets = [];
   communityView.loading = false;
   communityView.loadingMore = false;
@@ -436,5 +443,30 @@ describe('community.svelte.ts — add-only latest-per-hash dedup', () => {
     const dups = communityView.pets.filter((p) => p.contentHash === 'dup');
     expect(dups).toHaveLength(1);
     expect(dups[0].name).toBe('Corrected');
+  });
+});
+
+describe('community.svelte.ts — preview reset on destination switch (#396)', () => {
+  it('clears selectedHash when the user leaves the Community destination', () => {
+    selectPet('h1');
+    expect(communityView.selectedHash).toBe('h1');
+
+    activeTab.set('library');
+    expect(communityView.selectedHash).toBeNull();
+  });
+
+  it('keeps the selection while staying on Community', () => {
+    selectPet('h1');
+    activeTab.set('community');
+    expect(communityView.selectedHash).toBe('h1');
+  });
+
+  it('the preview reset does not evict the cached page', () => {
+    communityView.pets = [makeSharedPet('h1')];
+    selectPet('h1');
+
+    activeTab.set('breed');
+    expect(communityView.selectedHash).toBeNull();
+    expect(communityView.pets).toHaveLength(1);
   });
 });

--- a/tests/unit/detailOverlay.test.ts
+++ b/tests/unit/detailOverlay.test.ts
@@ -1,0 +1,71 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import DetailOverlayHarness from '../fixtures/DetailOverlayHarness.svelte';
+
+// DetailOverlay's Escape handling is a document-level listener scoped to the
+// topmost mounted overlay (#396): it must fire even when focus rests on
+// document.body (a section-scoped handler misses that), stacked overlays must
+// unwind one per press, and an open true-modal (.modal-backdrop) owns Escape.
+
+afterEach(cleanup);
+
+const pressEscape = () => fireEvent.keyDown(document.body, { key: 'Escape' });
+
+describe('DetailOverlay Escape handling', () => {
+  it('backs out when Escape is pressed with focus on document.body', async () => {
+    const onBackA = vi.fn();
+    render(DetailOverlayHarness, { onBackA } as never);
+
+    // Simulate focus having drifted to the body (e.g. after a click on
+    // non-focusable overlay content).
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    await pressEscape();
+    expect(onBackA).toHaveBeenCalledTimes(1);
+  });
+
+  it('only the topmost of stacked overlays backs out per press', async () => {
+    const onBackA = vi.fn();
+    const onBackB = vi.fn();
+    const { rerender } = render(DetailOverlayHarness, { onBackA, onBackB, showB: true } as never);
+
+    await pressEscape();
+    expect(onBackB).toHaveBeenCalledTimes(1);
+    expect(onBackA).not.toHaveBeenCalled();
+
+    // Once the top overlay unmounts, the one beneath becomes topmost.
+    await rerender({ onBackA, onBackB, showB: false });
+    await pressEscape();
+    expect(onBackA).toHaveBeenCalledTimes(1);
+    expect(onBackB).toHaveBeenCalledTimes(1);
+  });
+
+  it('defers to an open .modal-backdrop true-modal', async () => {
+    const onBackA = vi.fn();
+    const { rerender } = render(DetailOverlayHarness, { onBackA, showModal: true } as never);
+
+    await pressEscape();
+    expect(onBackA).not.toHaveBeenCalled();
+
+    // With the modal gone, Escape reaches the overlay again.
+    await rerender({ onBackA, showModal: false });
+    await pressEscape();
+    expect(onBackA).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores non-Escape keys', async () => {
+    const onBackA = vi.fn();
+    render(DetailOverlayHarness, { onBackA } as never);
+
+    await fireEvent.keyDown(document.body, { key: 'Enter' });
+    expect(onBackA).not.toHaveBeenCalled();
+  });
+
+  it('removes its document listener on unmount', async () => {
+    const onBackA = vi.fn();
+    const { unmount } = render(DetailOverlayHarness, { onBackA } as never);
+
+    unmount();
+    await pressEscape();
+    expect(onBackA).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/petEditorDiscardGuard.test.ts
+++ b/tests/unit/petEditorDiscardGuard.test.ts
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Backing out of the Pet Editor (Cancel / back button / Escape) with pending
+// changes must ask for confirmation instead of silently discarding them (#396).
+
+vi.mock('$lib/services/petService.js', () => ({
+  updatePet: vi.fn(),
+  getAllPets: vi.fn(),
+  deletePet: vi.fn(),
+  reorderPets: vi.fn(),
+  uploadPet: vi.fn(),
+}));
+
+import PetEditor from '$lib/components/pet/PetEditor.svelte';
+import { getAllAttributeDisplayInfo } from '$lib/services/configService.js';
+import type { Pet } from '$lib/types/index.js';
+
+// Give the pet a value for every editable attribute so the untouched form
+// diffs clean against it (initEditState defaults missing attributes to 50).
+const attributeFields = Object.fromEntries(getAllAttributeDisplayInfo().map((a) => [a.key.toLowerCase(), 50]));
+
+function makePet(overrides: Partial<Pet> = {}): Pet {
+  return {
+    id: 7,
+    name: 'Dobbin',
+    // BeeWasp with breed 'Bee': the breed is a valid editor option, so the
+    // untouched form diffs clean (a breed outside the options list would be
+    // coerced to the first option and read as a pending change).
+    species: 'BeeWasp',
+    breed: 'Bee',
+    gender: 'Male',
+    tags: [],
+    starred: false,
+    stabled: false,
+    is_pet_quality: false,
+    ...attributeFields,
+    ...overrides,
+  } as unknown as Pet;
+}
+
+function mount(onClose = vi.fn()) {
+  const pet = makePet();
+  const utils = render(PetEditor, { pet, onClose } as never);
+  return { ...utils, onClose };
+}
+
+const q = (c: HTMLElement, sel: string) => c.querySelector(sel) as HTMLElement | null;
+const backBtn = (c: HTMLElement) => q(c, '[data-testid="pet-editor-back"]') as HTMLElement;
+const confirmDialog = (c: HTMLElement) => q(c, '[data-testid="pet-editor-discard-confirm"]');
+
+afterEach(cleanup);
+
+describe('PetEditor discard guard', () => {
+  it('closes immediately when nothing changed', async () => {
+    const { container, onClose } = mount();
+    await fireEvent.click(backBtn(container));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(confirmDialog(container)).toBeNull();
+  });
+
+  it('shows the discard confirm instead of closing when the form is dirty', async () => {
+    const { container, onClose } = mount();
+    await fireEvent.input(q(container, '#petName') as HTMLElement, { target: { value: 'Renamed' } });
+
+    await fireEvent.click(backBtn(container));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(confirmDialog(container)).not.toBeNull();
+  });
+
+  it('guards Escape too (via DetailOverlay onBack)', async () => {
+    const { container, onClose } = mount();
+    await fireEvent.input(q(container, '#petName') as HTMLElement, { target: { value: 'Renamed' } });
+
+    await fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(confirmDialog(container)).not.toBeNull();
+
+    // With the confirm dialog (a .modal-backdrop true-modal) open, another
+    // Escape closes only the dialog — the editor stays.
+    await fireEvent.keyDown(confirmDialog(container) as HTMLElement, { key: 'Escape' });
+    expect(confirmDialog(container)).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('"Keep editing" dismisses the dialog and preserves the form', async () => {
+    const { container, onClose } = mount();
+    await fireEvent.input(q(container, '#petName') as HTMLElement, { target: { value: 'Renamed' } });
+    await fireEvent.click(backBtn(container));
+
+    await fireEvent.click(q(container, '[data-testid="discard-keep-editing"]') as HTMLElement);
+    expect(confirmDialog(container)).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+    expect((q(container, '#petName') as HTMLInputElement).value).toBe('Renamed');
+  });
+
+  it('"Discard" closes the editor without saving', async () => {
+    const { container, onClose } = mount();
+    await fireEvent.input(q(container, '#petName') as HTMLElement, { target: { value: 'Renamed' } });
+    await fireEvent.click(backBtn(container));
+
+    await fireEvent.click(q(container, '[data-testid="discard-confirm"]') as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('reverting an edit by hand counts as clean again', async () => {
+    const { container, onClose } = mount();
+    const name = q(container, '#petName') as HTMLElement;
+    await fireEvent.input(name, { target: { value: 'Renamed' } });
+    await fireEvent.input(name, { target: { value: 'Dobbin' } });
+
+    await fireEvent.click(backBtn(container));
+    expect(confirmDialog(container)).toBeNull();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/settingsViewEscape.test.ts
+++ b/tests/unit/settingsViewEscape.test.ts
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Settings is an in-space DetailOverlay lens, so it must close on Escape like
+// the pet detail and the Pet Editor — including when focus sits on
+// document.body rather than inside the overlay (#396).
+
+vi.mock('$lib/services/settingsService.js', () => ({
+  getAllSettings: vi.fn().mockResolvedValue({}),
+  getDefaultSettings: () => ({}),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+import SettingsView from '$lib/components/layout/SettingsView.svelte';
+
+afterEach(cleanup);
+
+describe('SettingsView Escape handling', () => {
+  it('renders as a labelled settings region', () => {
+    const { container } = render(SettingsView, { onClose: () => {} } as never);
+    const view = container.querySelector('[data-testid="settings-view"]');
+    expect(view).not.toBeNull();
+    expect(view?.getAttribute('aria-label')).toBe('Settings');
+  });
+
+  it('closes on Escape even with focus on document.body', async () => {
+    const onClose = vi.fn();
+    render(SettingsView, { onClose } as never);
+
+    (document.activeElement as HTMLElement | null)?.blur?.();
+    await fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes via the back button', async () => {
+    const onClose = vi.fn();
+    const { container } = render(SettingsView, { onClose } as never);
+
+    const back = container.querySelector('[data-testid="settings-back"]') as HTMLElement;
+    await fireEvent.click(back);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/topBarGating.test.ts
+++ b/tests/unit/topBarGating.test.ts
@@ -1,0 +1,111 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// While a root overlay (Settings / Pet Editor) is open, the TopBar gates
+// destination navigation: switching the tab underneath the overlay would
+// desync the nav highlight from what's visible and could bypass the editor's
+// unsaved-changes guard (#396).
+
+vi.mock('$lib/services/petService.js', () => ({
+  updatePet: vi.fn(),
+  getAllPets: vi.fn(),
+  deletePet: vi.fn(),
+  reorderPets: vi.fn(),
+  uploadPet: vi.fn(),
+}));
+
+// Stub DataMenu — it drags in backup/file services and is irrelevant here.
+vi.mock('$lib/components/layout/DataMenu.svelte', async () => ({
+  default: (await import('./fixtures/ChildStub.svelte')).default,
+}));
+
+import TopBar from '$lib/components/layout/TopBar.svelte';
+import { activeTab, appState, canGoBack } from '$lib/stores/pets.js';
+import { editingPet, settingsOpen } from '$lib/stores/ui.js';
+import type { Pet } from '$lib/types/index.js';
+
+beforeEach(() => {
+  let guard = 0;
+  while (get(canGoBack) && guard++ < 200) appState.goBack();
+  activeTab.set('library');
+  settingsOpen.set(false);
+  editingPet.set(null);
+});
+
+afterEach(cleanup);
+
+const tabButton = (c: HTMLElement, id: string) => c.querySelector(`[data-testid="tab-${id}"]`) as HTMLButtonElement;
+
+describe('TopBar nav gating while a root overlay is open', () => {
+  it('destination buttons are enabled with no overlay open', () => {
+    const { container } = render(TopBar);
+    for (const id of ['library', 'breed', 'community', 'reference']) {
+      expect(tabButton(container, id).disabled).toBe(false);
+    }
+  });
+
+  it('disables destination buttons and the settings toggle while Settings is open', () => {
+    settingsOpen.set(true);
+    const { container } = render(TopBar);
+    for (const id of ['library', 'breed', 'community', 'reference']) {
+      expect(tabButton(container, id).disabled).toBe(true);
+    }
+    expect((container.querySelector('.settings-toggle') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('disables destination buttons while the pet editor is open', () => {
+    editingPet.set({ id: 1, name: 'Dobbin' } as Pet);
+    const { container } = render(TopBar);
+    for (const id of ['library', 'breed', 'community', 'reference']) {
+      expect(tabButton(container, id).disabled).toBe(true);
+    }
+  });
+
+  it('re-enables the nav when the overlay closes', async () => {
+    settingsOpen.set(true);
+    const { container } = render(TopBar);
+    expect(tabButton(container, 'breed').disabled).toBe(true);
+
+    settingsOpen.set(false);
+    await Promise.resolve();
+    expect(tabButton(container, 'breed').disabled).toBe(false);
+  });
+
+  it('a gated destination click does not switch the tab', async () => {
+    settingsOpen.set(true);
+    const { container } = render(TopBar);
+
+    await fireEvent.click(tabButton(container, 'community'));
+    expect(get(activeTab)).toBe('library');
+  });
+
+  it('disables the history back button while an overlay is open', () => {
+    appState.switchTab('community'); // gives goBack a target
+    settingsOpen.set(true);
+    const { container } = render(TopBar);
+    expect((container.querySelector('.back-btn') as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('gates the Alt+Left keyboard back-navigation', async () => {
+    appState.switchTab('community');
+    settingsOpen.set(true);
+    render(TopBar);
+
+    await fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
+    expect(get(activeTab)).toBe('community');
+
+    settingsOpen.set(false);
+    await fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
+    expect(get(activeTab)).toBe('library');
+  });
+
+  it('gates the mouse back-button navigation', async () => {
+    appState.switchTab('community');
+    settingsOpen.set(true);
+    render(TopBar);
+
+    await fireEvent.mouseUp(window, { button: 3 });
+    expect(get(activeTab)).toBe('community');
+  });
+});

--- a/tests/unit/topBarGating.test.ts
+++ b/tests/unit/topBarGating.test.ts
@@ -87,25 +87,33 @@ describe('TopBar nav gating while a root overlay is open', () => {
     expect((container.querySelector('.back-btn') as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it('gates the Alt+Left keyboard back-navigation', async () => {
+  it('gates the Alt+Left keyboard back-navigation but still suppresses the browser gesture', async () => {
     appState.switchTab('community');
     settingsOpen.set(true);
     render(TopBar);
 
-    await fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
+    // Gated: no tab switch, but the default (webview history back) is still
+    // prevented so the app shell can't be navigated away.
+    const notPrevented = await fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
     expect(get(activeTab)).toBe('community');
+    expect(notPrevented).toBe(false);
 
     settingsOpen.set(false);
     await fireEvent.keyDown(window, { key: 'ArrowLeft', altKey: true });
     expect(get(activeTab)).toBe('library');
   });
 
-  it('gates the mouse back-button navigation', async () => {
+  it('gates the mouse back-button navigation but still suppresses the browser gesture', async () => {
     appState.switchTab('community');
     settingsOpen.set(true);
     render(TopBar);
 
-    await fireEvent.mouseUp(window, { button: 3 });
+    const notPrevented = await fireEvent.mouseUp(window, { button: 3 });
     expect(get(activeTab)).toBe('community');
+    expect(notPrevented).toBe(false);
+
+    // The forward button is suppressed too (it has no in-app meaning).
+    const fwdNotPrevented = await fireEvent.mouseUp(window, { button: 4 });
+    expect(fwdNotPrevented).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #396.

- **Settings closes on Escape.** DetailOverlay's Escape handler moves from the section element to a document-level listener scoped to the topmost mounted overlay (module-level stack), so it fires even when focus rests on document.body. It still defers to open `.modal-backdrop` true-modals, and stacked lenses unwind one per press.
- **Nav is gated while a root overlay is open** (chosen over dismiss-on-nav-click). Destination buttons, the history back button, Alt+Left / mouse-back, and the settings toggle are disabled while Settings or the Pet Editor covers the workspace. Rationale: gating keeps Back/Escape returning to exactly the context you left, and it composes with the editor's new dirty guard — a nav-dismiss path would either bypass the guard or need its own confirm flow. It also prevents stacking Settings over the editor.
- **Community resets its open preview on destination switch**, matching My Pets (whose detail state is component-local and dies on unmount). Implemented as an `activeTab` subscription in the community store — adding it to `TAB_STATE_RESETS` would pull firebase into every `pets.js` consumer. The page cache still survives tab toggles (read quota).
- **Pet Editor dirty guard.** Cancel / back / Escape with pending changes opens a discard-confirm dialog (same `.modal-backdrop` + focus-trap pattern as the delete confirm); reverting edits by hand counts as clean again.

Tests: new unit suites for DetailOverlay Escape scoping, SettingsView Escape, TopBar gating, and the editor discard guard; community store test covers the preview reset. E2E specs asserting the old silent-discard behaviour updated; not run locally (CI validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)