### PR TITLE
Trio/compare grids: gene-DB attribute focus + two-row chrome

### DIFF
--- a/src/lib/components/breeding/TrioView.svelte
+++ b/src/lib/components/breeding/TrioView.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
 import GenomeGridTrio from '$lib/components/comparison/GenomeGridTrio.svelte';
-import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
-import { normalizeSpecies } from '$lib/services/configService.js';
 import type { SelectedBreedingPair } from '$lib/stores/breeding.svelte.js';
-import { getSpeciesEmoji } from '$lib/utils/species.js';
 
 interface Props {
   pair: SelectedBreedingPair;
@@ -13,55 +10,9 @@ interface Props {
 
 const { pair, offspringBreed = '', onClose }: Props = $props();
 
-const father = $derived(pair.male);
-const mother = $derived(pair.female);
-const speciesLabel = $derived(father ? normalizeSpecies(father.species) : '');
+// Thin adapter: GenomeGridTrio owns the DetailOverlay shell (back button, the
+// parent-name title, and the stat pills in the header), so this just maps the
+// breeding pair to its parents.
 </script>
 
-<DetailOverlay
-  testid="trio-view"
-  backTestid="trio-view-back"
-  backLabel="← Pairs"
-  ariaLabel="Offspring trio"
-  onBack={onClose}
->
-  {#snippet title()}
-    <span class="parent-name father">♂ {father?.name}</span>
-    <span class="cross">×</span>
-    <span class="parent-name mother">♀ {mother?.name}</span>
-    {#if speciesLabel}
-      <span class="species-badge">{getSpeciesEmoji(father?.species)} {speciesLabel}</span>
-    {/if}
-  {/snippet}
-
-  <div class="trio-body">
-    <GenomeGridTrio {father} {mother} {offspringBreed} />
-  </div>
-</DetailOverlay>
-
-<style>
-  .parent-name { font-weight: 700; }
-  .parent-name.father { color: var(--accent); }
-  .parent-name.mother { color: var(--pet-b); }
-  .cross { color: var(--text-muted); font-weight: 500; }
-
-  .species-badge {
-    font-size: 12px;
-    font-weight: 500;
-    padding: 2px 8px;
-    background: var(--bg-tertiary);
-    border-radius: 10px;
-    color: var(--text-secondary);
-    white-space: nowrap;
-  }
-
-  /* Fill the overlay body; the grid itself owns the single scroll region so the
-     filters / summary stay pinned above it (no nested double scrollbar). */
-  .trio-body {
-    flex: 1;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-    padding: 8px 14px;
-  }
-</style>
+<GenomeGridTrio father={pair.male} mother={pair.female} {offspringBreed} {onClose} />

--- a/src/lib/components/comparison/GenomeDiffControls.svelte
+++ b/src/lib/components/comparison/GenomeDiffControls.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
 import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
 import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
-import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary } from '$lib/types/index.js';
+import type { AppearanceInfo, AttributeInfo } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
 
+/**
+ * The compare view's filter row: breed picker + attribute/appearance tri-state
+ * pills. The summary stats and the view / diffs-only toggles now ride in the
+ * DetailOverlay header (rendered by GenomeGridDiff), so the lens reads as two
+ * rows of chrome — header + this row — matching the trio view.
+ */
 interface Props {
-  summary: GenomeDiffSummary;
   isHorse: boolean;
   breedFilter: string;
   autoBreed?: boolean;
   petsHaveKnownBreed?: boolean;
   petsShareBreed?: boolean;
-  showDiffsOnly: boolean;
   selectedAttributes: string[];
   hiddenAttributes: string[];
   attributeDisplayInfo: AttributeInfo[];
@@ -23,20 +27,16 @@ interface Props {
   onAutoBreedToggle: () => void;
   onAttributeToggle: (key: string, ctrlKey: boolean, altKey: boolean) => void;
   onAppearanceToggle: (key: string, ctrlKey: boolean, altKey: boolean) => void;
-  onDiffsOnlyChange: (val: boolean) => void;
   onResetAttributes: () => void;
   onResetAppearances: () => void;
-  onViewChange: (view: 'attribute' | 'appearance') => void;
 }
 
 const {
-  summary,
   isHorse,
   breedFilter,
   autoBreed = false,
   petsHaveKnownBreed = false,
   petsShareBreed = false,
-  showDiffsOnly,
   selectedAttributes,
   hiddenAttributes,
   attributeDisplayInfo,
@@ -48,10 +48,8 @@ const {
   onAutoBreedToggle,
   onAttributeToggle,
   onAppearanceToggle,
-  onDiffsOnlyChange,
   onResetAttributes,
   onResetAppearances,
-  onViewChange,
 }: Props = $props();
 
 const attributeItems = $derived<FilterPillItem[]>(
@@ -67,20 +65,7 @@ const appearanceItems = $derived<FilterPillItem[]>(
 );
 </script>
 
-<div class="diff-controls">
-    <div class="diff-summary">
-        <span class="similarity-badge">{summary.similarityPercent}% identical</span>
-        <span class="summary-detail">{summary.identicalGenes}/{summary.totalGenes} genes match · {summary.differentGenes} diff</span>
-        <div class="view-toggle">
-            <button class="view-btn" class:active={currentView === 'attribute'} onclick={() => onViewChange('attribute')}>Attributes</button>
-            <button class="view-btn" class:active={currentView === 'appearance'} onclick={() => onViewChange('appearance')}>Appearance</button>
-        </div>
-        <label class="diff-toggle">
-            <input type="checkbox" checked={showDiffsOnly} onchange={(e) => onDiffsOnlyChange((e.target as HTMLInputElement).checked)} />
-            Differences only
-        </label>
-    </div>
-    <div class="diff-filters">
+<div class="diff-filters">
     {#if isHorse}
         <div class="breed-filter">
             {#if petsHaveKnownBreed}
@@ -121,26 +106,13 @@ const appearanceItems = $derived<FilterPillItem[]>(
             onReset={onResetAppearances}
         />
     {/if}
-    </div>
 </div>
 
 <div class="grid-instructions">Click chromosome labels · Ctrl+click multi · Alt+click hide</div>
 
 <style>
-    .diff-controls { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
-    .diff-summary { display: flex; align-items: center; gap: 10px; padding: 6px 12px; background: var(--bg-secondary); border-radius: 8px; flex-wrap: wrap; }
     /* Breed selector + attribute/appearance pills share one wrapping band. */
     .diff-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 4px 14px; }
-    .similarity-badge { font-size: 14px; font-weight: 700; color: var(--text-primary); padding: 4px 10px; background: var(--bg-tertiary); border-radius: 10px; }
-    .summary-detail { font-size: 12px; color: var(--text-secondary); }
-    .diff-toggle { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
-    .diff-toggle input { cursor: pointer; }
-
-    .view-toggle { margin-left: auto; display: inline-flex; border: 1px solid var(--border-primary); border-radius: 4px; overflow: hidden; }
-    .view-btn { padding: 3px 10px; border: none; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
-    .view-btn + .view-btn { border-left: 1px solid var(--border-primary); }
-    .view-btn:hover { color: var(--text-secondary); }
-    .view-btn.active { background: var(--accent); color: white; }
 
     .breed-filter { display: flex; align-items: center; gap: 6px; padding: 0 4px; }
     /* Auto = Compare-only mode toggle that owns the breed; the breed picker
@@ -149,7 +121,5 @@ const appearanceItems = $derived<FilterPillItem[]>(
     .auto-btn:hover { border-color: var(--border-secondary); color: var(--text-secondary); }
     .auto-btn.active { background: var(--auto-active); border-color: var(--auto-active); color: var(--bg-primary); }
 
-    /* Attribute / appearance tri-state pills now live in GeneFilterPills. */
-
-    .grid-instructions { font-size: 10px; color: var(--text-muted); margin-bottom: 4px; font-style: italic; padding: 0 4px; }
+    .grid-instructions { font-size: 10px; color: var(--text-muted); margin: 4px 0; font-style: italic; padding: 0 4px; }
 </style>

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -3,6 +3,7 @@ import { onDestroy, onMount } from 'svelte';
 import '$lib/components/gene/geneCell.css';
 import GenomeDiffControls from '$lib/components/comparison/GenomeDiffControls.svelte';
 import GeneTooltip from '$lib/components/gene/GeneTooltip.svelte';
+import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAppearanceConfig, getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
@@ -10,7 +11,7 @@ import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { settings } from '$lib/stores/settings.js';
 import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
-import { buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { ATTR_DELIM, buildFilterCSS } from '$lib/utils/filterCSS.js';
 import { triStateToggle } from '$lib/utils/filterToggle.js';
 import { breedFor, effectFor, type GeneEffectData, isNoEffect } from '$lib/utils/geneAnalysis.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
@@ -21,6 +22,12 @@ interface ChromosomeRow {
   cellsA: Record<string, (GeneCell | null)[]>;
   cellsB: Record<string, (GeneCell | null)[]>;
   diffs: Record<string, boolean[]>;
+  /**
+   * Delimited (`·Attr·Attr·`) potential-attribute set per locus, derived once
+   * from the gene effect DB (both alleles) and shared by both pet rows — the
+   * attribute filter keys off this, not each pet's resolved allele.
+   */
+  attrs: Record<string, string[]>;
   hasDiffs: boolean;
 }
 
@@ -32,9 +39,11 @@ interface ChrBreedEntry {
 interface Props {
   petA: Pet;
   petB: Pet;
+  /** Back out of the compare lens (→ Pets). */
+  onBack: () => void;
 }
 
-const { petA, petB }: Props = $props();
+const { petA, petB, onBack }: Props = $props();
 
 let loading = $state(false);
 let error = $state<string | null>(null);
@@ -248,6 +257,7 @@ async function loadData() {
       const cellsA: Record<string, (GeneCell | null)[]> = {};
       const cellsB: Record<string, (GeneCell | null)[]> = {};
       const diffs: Record<string, boolean[]> = {};
+      const attrs: Record<string, string[]> = {};
       let chrDiffs = 0;
 
       for (const block of sortedBlocks) {
@@ -257,6 +267,7 @@ async function loadData() {
         cellsA[block] = new Array(maxLen);
         cellsB[block] = new Array(maxLen);
         diffs[block] = new Array(maxLen);
+        attrs[block] = new Array(maxLen);
 
         for (let i = 0; i < maxLen; i++) {
           const gA = genesA[i] || null;
@@ -264,6 +275,11 @@ async function loadData() {
           // Pre-compute everything: static CSS class, attribute, breed
           cellsA[block][i] = gA ? cellBuilder.makeCell(gA) : null;
           cellsB[block][i] = gB ? cellBuilder.makeCell(gB) : null;
+          // Both pets share the locus gene, so resolve its potential attributes
+          // once (from the effect DB) and use the same value for both rows.
+          const geneId = (gA ?? gB)?.id;
+          const list = geneId ? cellBuilder.attributesForGene(geneId) : [];
+          attrs[block][i] = list.length ? ATTR_DELIM + list.join(ATTR_DELIM) + ATTR_DELIM : '';
           const isDiff = (gA?.type || null) !== (gB?.type || null);
           diffs[block][i] = isDiff;
           if (isDiff) chrDiffs++;
@@ -271,7 +287,7 @@ async function loadData() {
       }
 
       differentGenes += chrDiffs;
-      return { chr, cellsA, cellsB, diffs, hasDiffs: chrDiffs > 0 };
+      return { chr, cellsA, cellsB, diffs, attrs, hasDiffs: chrDiffs > 0 };
     });
 
     const identicalGenes = totalGenes - differentGenes;
@@ -367,20 +383,46 @@ function handleCellLeave() {
 }
 </script>
 
-<div class="genome-grid-diff">
+<DetailOverlay
+    testid="pet-compare"
+    backTestid="pet-compare-back"
+    backLabel="← Pets"
+    ariaLabel="Pet comparison"
+    {onBack}
+>
+    {#snippet title()}⚖️ {petA.name || 'Pet A'} vs {petB.name || 'Pet B'}{/snippet}
+
+    <!-- Summary + view / diffs-only ride in the header bar next to the names;
+         the filter row sits below — two rows of chrome, matching the trio. -->
+    {#snippet headerActions()}
+        {#if summary}
+            <div class="diff-summary">
+                <span class="similarity-badge">{summary.similarityPercent}% identical</span>
+                <span class="summary-detail">{summary.identicalGenes}/{summary.totalGenes} genes match · {summary.differentGenes} diff</span>
+                <div class="view-toggle">
+                    <button type="button" class="view-btn" class:active={currentView === 'attribute'} onclick={() => { currentView = 'attribute'; }}>Attributes</button>
+                    <button type="button" class="view-btn" class:active={currentView === 'appearance'} onclick={() => { currentView = 'appearance'; }}>Appearance</button>
+                </div>
+                <label class="diff-toggle">
+                    <input type="checkbox" checked={showDiffsOnly} onchange={(e) => { showDiffsOnly = (e.target as HTMLInputElement).checked; }} />
+                    Differences only
+                </label>
+            </div>
+        {/if}
+    {/snippet}
+
+    <div class="genome-grid-diff">
     {#if loading}
         <StatusPane variant="loading" body="Loading genomes..." />
     {:else if error}
         <StatusPane variant="error" icon="⚠️" body={error} />
     {:else if summary}
         <GenomeDiffControls
-            {summary}
             {isHorse}
             {breedFilter}
             {autoBreed}
             {petsHaveKnownBreed}
             {petsShareBreed}
-            {showDiffsOnly}
             {selectedAttributes}
             {hiddenAttributes}
             {attributeDisplayInfo}
@@ -388,7 +430,6 @@ function handleCellLeave() {
             {hiddenAppearances}
             {appearanceDisplayInfo}
             {currentView}
-            onViewChange={(v) => { currentView = v; }}
             onBreedChange={(name) => { breedFilter = name; }}
             onAutoBreedToggle={() => {
                 manualBreedOverride = true;
@@ -401,7 +442,6 @@ function handleCellLeave() {
             }}
             onAttributeToggle={toggleAttributeFilter}
             onAppearanceToggle={toggleAppearanceFilter}
-            onDiffsOnlyChange={(val) => { showDiffsOnly = val; }}
             onResetAttributes={() => { selectedAttributes = []; hiddenAttributes = []; }}
             onResetAppearances={() => { selectedAppearances = []; hiddenAppearances = []; }}
         />
@@ -435,7 +475,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attrs={row.attrs[block][i]} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}
@@ -453,7 +493,7 @@ function handleCellLeave() {
                                         data-isdiff={isDiff} data-hascell={!!cell}>
                                         {#if cell}
                                             <!-- svelte-ignore a11y_no_static_element_interactions -->
-                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attr={cell.attribute} data-appearance={cell.appearance} data-breed={cell.breed}
+                                            <div class={currentView === 'appearance' ? cell.appearanceCls : cell.attributeCls} data-attrs={row.attrs[block][i]} data-appearance={cell.appearance} data-breed={cell.breed}
                                                 onmouseenter={(e) => handleCellEnter(e, cell)} onmouseleave={handleCellLeave}
                                             >{#if cell.type === '?'}<span class="gene-unknown-symbol">?</span>{/if}</div>
                                         {/if}
@@ -470,18 +510,35 @@ function handleCellLeave() {
     {:else}
         <p class="empty-text">No genome data available for comparison.</p>
     {/if}
-</div>
+    </div>
+</DetailOverlay>
 
 <style>
-    .genome-grid-diff { width: 100%; }
+    /* Fills the overlay body. */
+    .genome-grid-diff { width: 100%; height: 100%; display: flex; flex-direction: column; min-height: 0; padding: 8px 14px; box-sizing: border-box; }
 
-    .grid-container { overflow: auto; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-secondary); }
+    /* Summary band content now lives in the DetailOverlay header (headerActions). */
+    .diff-summary { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .similarity-badge { font-size: 14px; font-weight: 700; color: var(--text-primary); padding: 4px 10px; background: var(--bg-tertiary); border-radius: 10px; }
+    .summary-detail { font-size: 12px; color: var(--text-secondary); }
+    .diff-toggle { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
+    .diff-toggle input { cursor: pointer; }
+    .view-toggle { display: inline-flex; border: 1px solid var(--border-primary); border-radius: 4px; overflow: hidden; }
+    .view-btn { padding: 3px 10px; border: none; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
+    .view-btn + .view-btn { border-left: 1px solid var(--border-primary); }
+    .view-btn:hover { color: var(--text-secondary); }
+    .view-btn.active { background: var(--accent); color: white; }
+
+    /* --cell-size 18px → 16px gene cells (calc subtracts the 2px border), the
+       same density as the trio view. flex:1 makes the grid the single scroll
+       region so the filter row stays pinned above it. */
+    .grid-container { --cell-size: 18px; flex: 1; min-height: 0; overflow: auto; border: 1px solid var(--border-primary); border-radius: 6px; background: var(--bg-secondary); }
     .gene-grid-table { width: auto; border-collapse: collapse; table-layout: fixed; }
     .gene-headers { position: sticky; top: 0; z-index: 10; background: var(--bg-secondary); }
     .gene-headers th { background: var(--bg-secondary); border-bottom: 1px solid var(--border-primary); padding: 2px 4px; font-size: 9px; font-weight: normal; color: var(--text-secondary); text-align: center; white-space: nowrap; }
     .chromosome-header { position: sticky; left: 0; z-index: 11; background: var(--bg-secondary); font-weight: bold; width: 28px; min-width: 28px; max-width: 28px; }
     .pet-label-header { position: sticky; left: 28px; z-index: 11; background: var(--bg-secondary); font-weight: bold; width: 60px; min-width: 60px; max-width: 60px; }
-    .position-header { width: 16px; min-width: 16px; max-width: 16px; }
+    .position-header { width: 18px; min-width: 18px; max-width: 18px; }
     .position-header.block-label { font-weight: bold; }
     .position-header.block-start { padding-left: 10px; }
 
@@ -500,7 +557,10 @@ function handleCellLeave() {
     .gene-cell-container { padding: 1px; text-align: center; vertical-align: middle; }
     .gene-cell-container.empty { opacity: 0.3; }
     .gene-cell-container.block-start { padding-left: 8px; }
-    .gene-cell-container.diff-cell { background: rgba(234, 179, 8, 0.15); }
+    /* Confine the diff tint to the gene square (content box) so it doesn't
+       paint the cell padding — otherwise it bleeds across the 8px inter-block
+       gap on block-start cells and merges adjacent diffs into one band. */
+    .gene-cell-container.diff-cell { background-color: rgba(234, 179, 8, 0.15); background-clip: content-box; }
     .gene-cell-container.identical-dimmed { opacity: 0.2; }
 
     /* Breed override — applied via direct DOM manipulation */

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -11,7 +11,7 @@ import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { settings } from '$lib/stores/settings.js';
 import type { AppearanceInfo, AttributeInfo, GenomeDiffSummary, Pet } from '$lib/types/index.js';
 import { HORSE_BREEDS } from '$lib/types/index.js';
-import { ATTR_DELIM, buildFilterCSS } from '$lib/utils/filterCSS.js';
+import { buildFilterCSS, joinAttrs } from '$lib/utils/filterCSS.js';
 import { triStateToggle } from '$lib/utils/filterToggle.js';
 import { breedFor, effectFor, type GeneEffectData, isNoEffect } from '$lib/utils/geneAnalysis.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
@@ -279,7 +279,7 @@ async function loadData() {
           // once (from the effect DB) and use the same value for both rows.
           const geneId = (gA ?? gB)?.id;
           const list = geneId ? cellBuilder.attributesForGene(geneId) : [];
-          attrs[block][i] = list.length ? ATTR_DELIM + list.join(ATTR_DELIM) + ATTR_DELIM : '';
+          attrs[block][i] = joinAttrs(list);
           const isDiff = (gA?.type || null) !== (gB?.type || null);
           diffs[block][i] = isDiff;
           if (isDiff) chrDiffs++;

--- a/src/lib/components/comparison/GenomeGridTrio.svelte
+++ b/src/lib/components/comparison/GenomeGridTrio.svelte
@@ -2,15 +2,17 @@
 import { onDestroy, onMount, untrack } from 'svelte';
 import '$lib/components/gene/geneCell.css';
 import BreedSelector from '$lib/components/shared/BreedSelector.svelte';
+import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import GeneFilterPills, { type FilterPillItem } from '$lib/components/shared/GeneFilterPills.svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAttributeConfig, normalizeSpecies } from '$lib/services/configService.js';
 import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { computeOffspringTrio } from '$lib/services/offspringTrioService.js';
 import { type AttributeInfo, GeneType, HORSE_BREEDS, type OffspringTrioResult, type Pet } from '$lib/types/index.js';
-import { attributeFilterCSS } from '$lib/utils/filterCSS.js';
+import { attributePotentialFilterCSS } from '$lib/utils/filterCSS.js';
 import { triStateToggle } from '$lib/utils/filterToggle.js';
 import { buildAppearanceLookup, createGeneCellBuilder, type GeneCell } from '$lib/utils/geneGridCells.js';
+import { getSpeciesEmoji } from '$lib/utils/species.js';
 import { capitalize } from '$lib/utils/string.js';
 import { buildTrioGrid, distBarBackground, type TrioGrid, type TrioLocusCell } from '$lib/utils/trioGrid.js';
 
@@ -18,11 +20,14 @@ interface Props {
   father: Pet;
   mother: Pet;
   offspringBreed?: string;
+  /** Back out of the trio lens (→ Pairs). */
+  onClose: () => void;
 }
 
-const { father, mother, offspringBreed = '' }: Props = $props();
+const { father, mother, offspringBreed = '', onClose }: Props = $props();
 
 const isHorse = $derived(normalizeSpecies(father.species) === 'horse');
+const speciesLabel = $derived(normalizeSpecies(father.species));
 
 let loading = $state(false);
 let error = $state<string | null>(null);
@@ -96,8 +101,16 @@ onDestroy(() => {
 $effect(() => {
   if (!filterStyleEl) return;
   // `*` cell selector: the trio's three rows use different cell classes
-  // (`.gene-cell` parents, `.dist-bar` offspring); all carry `data-attr`.
-  filterStyleEl.textContent = attributeFilterCSS('.trio-grid-container', '*', selectedAttributes, hiddenAttributes);
+  // (`.gene-cell` parents, `.dist-bar` offspring); all carry `data-attrs`.
+  // Potential-attribute match keeps both parents + the offspring lit at every
+  // locus whose gene could affect the attribute, even where a parent's current
+  // allele is neutral.
+  filterStyleEl.textContent = attributePotentialFilterCSS(
+    '.trio-grid-container',
+    '*',
+    selectedAttributes,
+    hiddenAttributes,
+  );
 });
 
 function toggleAttributeFilter(attrKey: string, ctrlKey: boolean, altKey: boolean) {
@@ -172,7 +185,50 @@ function parentTitle(cell: GeneCell | null, label: string) {
 }
 </script>
 
-<div class="genome-grid-trio">
+<DetailOverlay
+    testid="trio-view"
+    backTestid="trio-view-back"
+    backLabel="← Pairs"
+    ariaLabel="Offspring trio"
+    onBack={onClose}
+>
+    {#snippet title()}
+        <span class="parent-name father">♂ {father?.name}</span>
+        <span class="cross">×</span>
+        <span class="parent-name mother">♀ {mother?.name}</span>
+        {#if speciesLabel}
+            <span class="species-badge">{getSpeciesEmoji(father?.species)} {speciesLabel}</span>
+        {/if}
+    {/snippet}
+
+    <!-- Stat pills ride in the header bar alongside the parent names; the filter
+         row + legend sit below — two rows of chrome instead of three. -->
+    {#snippet headerActions()}
+        {#if grid && summary && grid.rows.length > 0}
+            <div class="trio-stats">
+                <span class="chip chip-gain" title="Gains the offspring could newly acquire (locked-in positives both parents already share are counted under “locked”, not here). {summary.gains} gain loci total.">{newGainCount} gains</span>
+                <span class="chip chip-risk">{summary.risks} risks</span>
+                {#if lockedCount > 0}
+                    <button
+                        type="button"
+                        class="chip chip-lock toggle"
+                        class:active={hideLocked}
+                        aria-pressed={hideLocked}
+                        data-testid="trio-hide-locked"
+                        title="Locked: both parents share the same allele (both dominant or both recessive), so the offspring can't differ here. Toggle to hide these and show new gains only."
+                        onclick={() => { hideLocked = !hideLocked; }}
+                    >
+                        {lockedCount} locked{hideLocked ? ' · hidden' : ''}
+                    </button>
+                {/if}
+                {#if summary.unknownLoci > 0}
+                    <span class="chip chip-unknown">{summary.unknownLoci} unknown</span>
+                {/if}
+            </div>
+        {/if}
+    {/snippet}
+
+    <div class="trio-body">
     {#if !error}
         <div class="trio-filters">
             {#if isHorse}
@@ -193,37 +249,19 @@ function parentTitle(cell: GeneCell | null, label: string) {
                     hidden={hiddenAttributes}
                     onToggle={toggleAttributeFilter}
                     onReset={() => { selectedAttributes = []; hiddenAttributes = []; }}
-                    hint="Click focus · Ctrl multi · Alt hide"
                     testid="trio-attribute-filter"
                 />
             {/if}
             {#if grid && summary && grid.rows.length > 0}
-                <div class="trio-summary">
-                    <span class="chip chip-gain" title="Gains the offspring could newly acquire (locked-in positives both parents already share are counted under “locked”, not here). {summary.gains} gain loci total.">{newGainCount} gains</span>
-                    <span class="chip chip-risk">{summary.risks} risks</span>
-                    {#if lockedCount > 0}
-                        <button
-                            type="button"
-                            class="chip chip-lock toggle"
-                            class:active={hideLocked}
-                            aria-pressed={hideLocked}
-                            data-testid="trio-hide-locked"
-                            title="Locked: both parents share the same allele (both dominant or both recessive), so the offspring can't differ here. Toggle to hide these and show new gains only."
-                            onclick={() => { hideLocked = !hideLocked; }}
-                        >
-                            {lockedCount} locked{hideLocked ? ' · hidden' : ''}
-                        </button>
-                    {/if}
-                    {#if summary.unknownLoci > 0}
-                        <span class="chip chip-unknown">{summary.unknownLoci} unknown</span>
-                    {/if}
-                    <span class="legend">
-                        <span class="legend-item"><span class="swatch swatch-gain"></span>gain</span>
-                        <span class="legend-item"><span class="swatch swatch-risk"></span>risk</span>
-                    </span>
-                </div>
+                <span class="legend">
+                    <span class="legend-item"><span class="swatch swatch-gain"></span>gain</span>
+                    <span class="legend-item"><span class="swatch swatch-risk"></span>risk</span>
+                </span>
             {/if}
         </div>
+        {#if attributeItems.length > 0}
+            <div class="grid-instructions">Click attribute to focus · Ctrl+click multi · Alt+click hide</div>
+        {/if}
     {/if}
 
     {#if loading}
@@ -254,7 +292,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                     {@const cell = row.cells[`${block}${pos}`]}
                                     <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
                                         {#if cell?.fatherCell}
-                                            <div class={cell.fatherCell.attributeCls} class:fixed={isLocked(cell)} data-attr={cell.fatherCell.attribute} title={parentTitle(cell.fatherCell, 'Father')}>
+                                            <div class={cell.fatherCell.attributeCls} class:fixed={isLocked(cell)} data-attrs={cell.attrs} title={parentTitle(cell.fatherCell, 'Father')}>
                                                 {#if cell.fatherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
                                             </div>
                                         {/if}
@@ -273,7 +311,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                                 class="dist-bar verdict-{cell.verdict}"
                                                 class:locked={cell.lockedIn}
                                                 class:fixed={isLocked(cell)}
-                                                data-attr={cell.attribute ?? ''}
+                                                data-attrs={cell.attrs}
                                                 role="img"
                                                 title={offspringTitle(cell)}
                                                 aria-label={offspringAria(cell)}
@@ -291,7 +329,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
                                     {@const cell = row.cells[`${block}${pos}`]}
                                     <td class="grid-cell {pos === 1 ? 'block-start' : ''}">
                                         {#if cell?.motherCell}
-                                            <div class={cell.motherCell.attributeCls} class:fixed={isLocked(cell)} data-attr={cell.motherCell.attribute} title={parentTitle(cell.motherCell, 'Mother')}>
+                                            <div class={cell.motherCell.attributeCls} class:fixed={isLocked(cell)} data-attrs={cell.attrs} title={parentTitle(cell.motherCell, 'Mother')}>
                                                 {#if cell.motherCell.type === '?'}<span class="unknown-symbol">?</span>{/if}
                                             </div>
                                         {/if}
@@ -308,15 +346,40 @@ function parentTitle(cell: GeneCell | null, label: string) {
     {:else}
         <p class="empty-text">No genome data available for this pair.</p>
     {/if}
-</div>
+    </div>
+</DetailOverlay>
 
 <style>
-    /* Flex column so the grid-container can be the single scroll region while
-       the filters + summary stay pinned above it. */
-    .genome-grid-trio { width: 100%; height: 100%; display: flex; flex-direction: column; min-height: 0; }
+    /* Title (header bar) — parent names + species badge, moved here now that
+       this component owns its DetailOverlay. */
+    .parent-name { font-weight: 700; }
+    .parent-name.father { color: var(--accent); }
+    .parent-name.mother { color: var(--pet-b); }
+    .cross { color: var(--text-muted); font-weight: 500; }
+    .species-badge {
+        font-size: 12px;
+        font-weight: 500;
+        padding: 2px 8px;
+        background: var(--bg-tertiary);
+        border-radius: 10px;
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
 
-    /* One compact controls band: breed selector, attribute pills, and the
-       summary chips share a single wrapping row instead of stacking. */
+    /* Stat pills that ride in the header bar (DetailOverlay's headerActions). No
+       band background — the header itself is the bar. */
+    .trio-stats { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+
+    /* Body fills the overlay; a flex column so the grid is the single scroll
+       region and the filter row stays pinned above it. */
+    .trio-body {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        padding: 8px 14px;
+    }
+    /* Filter row: breed + attribute pills on the left, legend pushed right. */
     .trio-filters {
         display: flex;
         flex-wrap: wrap;
@@ -328,15 +391,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
     /* Attribute pills → GeneFilterPills; breed picker → shared BreedSelector. */
     .breed-filter { display: flex; padding: 0 4px; }
 
-    .trio-summary {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        margin-bottom: 0;
-        margin-left: auto;
-        flex-wrap: wrap;
-        flex-shrink: 0;
-    }
+    /* Shared instruction line (identical to GenomeGridDiff's .grid-instructions). */
+    .grid-instructions { font-size: 10px; color: var(--text-muted); margin-bottom: 4px; font-style: italic; padding: 0 4px; }
     .chip {
         font-size: 12px;
         font-weight: 600;
@@ -381,7 +437,7 @@ function parentTitle(cell: GeneCell | null, label: string) {
     }
     .chr-header { position: sticky; left: 0; z-index: 11; width: 28px; min-width: 28px; font-weight: bold; }
     .role-header { position: sticky; left: 28px; z-index: 11; width: 72px; min-width: 72px; }
-    .pos-header { width: 22px; min-width: 22px; max-width: 22px; }
+    .pos-header { width: 18px; min-width: 18px; max-width: 18px; }
     .pos-header.block-start { font-weight: bold; padding-left: 8px; }
 
     .chr-label {
@@ -417,10 +473,10 @@ function parentTitle(cell: GeneCell | null, label: string) {
     .grid-cell.block-start { padding-left: 8px; }
 
     /* Offspring row is taller and its cells host the distribution bar. */
-    .offspring-cell { height: 26px; }
+    .offspring-cell { height: 22px; }
     .dist-bar {
-        width: 20px;
-        height: 20px;
+        width: 16px;
+        height: 16px;
         margin: 0 auto;
         border-radius: 3px;
         overflow: hidden;
@@ -435,8 +491,8 @@ function parentTitle(cell: GeneCell | null, label: string) {
     .dist-bar.locked { box-shadow: inset 0 0 0 1px var(--bg-secondary); }
 
     /* Parent cells share the offspring bar's box size so the three rows line up
-       column-for-column (the shared .gene-cell is 14px elsewhere). */
-    .trio-table :global(.gene-cell) { width: 20px; height: 20px; }
+       column-for-column, at the same 16px density as the compare view. */
+    .trio-table :global(.gene-cell) { width: 16px; height: 16px; }
 
     /* "New gains only": fade locked loci out of ALL three rows (both parents and
        the offspring) so the remaining gain-coloured bars are only new gains. */

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -15,7 +15,7 @@ import { getGeneEffectsCached } from '$lib/services/geneService.js';
 import { loadPetGridFromDb } from '$lib/services/petService.js';
 import { EFFECT_COLORS } from '$lib/theme/gene-colors.js';
 import type { AppearanceInfo, Pet } from '$lib/types/index.js';
-import { ATTR_DELIM, buildVisualizerFilterCSS, type ChrBreedRelevance } from '$lib/utils/filterCSS.js';
+import { buildVisualizerFilterCSS, type ChrBreedRelevance, joinAttrs } from '$lib/utils/filterCSS.js';
 import { resolveFilterClick } from '$lib/utils/filterToggle.js';
 import {
   breedFor,
@@ -537,7 +537,7 @@ function buildGrid() {
     const attrSet = new Set<string>();
     if (!isNoEffect(dEff)) for (const a of matcher.findAll(dEff)) attrSet.add(a);
     if (!isNoEffect(rEff)) for (const a of matcher.findAll(rEff)) attrSet.add(a);
-    const attrs = attrSet.size ? ATTR_DELIM + [...attrSet].join(ATTR_DELIM) + ATTR_DELIM : '';
+    const attrs = joinAttrs(attrSet);
 
     const ctxPosSet = new Set<string>();
     const ctxNegSet = new Set<string>();
@@ -559,8 +559,8 @@ function buildGrid() {
         }
       }
     }
-    const ctxpos = ctxPosSet.size ? ATTR_DELIM + [...ctxPosSet].join(ATTR_DELIM) + ATTR_DELIM : '';
-    const ctxneg = ctxNegSet.size ? ATTR_DELIM + [...ctxNegSet].join(ATTR_DELIM) + ATTR_DELIM : '';
+    const ctxpos = joinAttrs(ctxPosSet);
+    const ctxneg = joinAttrs(ctxNegSet);
 
     const zygCls = `gene-${zygosity}`;
     let attributeCls: string;

--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -313,10 +313,9 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
       <PetVisualization pet={detailPet} />
     </DetailOverlay>
   {:else if comparing && canCompare}
-    <DetailOverlay testid="pet-compare" backTestid="pet-compare-back" backLabel="← Pets" ariaLabel="Pet comparison" onBack={closeCompare}>
-      {#snippet title()}⚖️ {selectedPets[0].name || 'Pet A'} vs {selectedPets[1].name || 'Pet B'}{/snippet}
-      <GenomeGridDiff petA={selectedPets[0]} petB={selectedPets[1]} />
-    </DetailOverlay>
+    <!-- GenomeGridDiff owns its DetailOverlay shell (back button, title, and the
+         summary pills in the header). -->
+    <GenomeGridDiff petA={selectedPets[0]} petB={selectedPets[1]} onBack={closeCompare} />
   {/if}
 </div>
 

--- a/src/lib/components/shared/DetailOverlay.svelte
+++ b/src/lib/components/shared/DetailOverlay.svelte
@@ -51,6 +51,11 @@ interface Props {
   backTestid?: string;
   /** Header title content (plain text, or rich markup like the trio cross). */
   title: Snippet;
+  /**
+   * Optional right-aligned header content — the summary/stat pills the trio and
+   * compare lenses hoist up next to the title so their controls fit in two rows.
+   */
+  headerActions?: Snippet;
   /** The lens body (PetVisualization / GenomeGridDiff / GenomeGridTrio …). */
   children: Snippet;
 }
@@ -62,6 +67,7 @@ const {
   testid,
   backTestid,
   title,
+  headerActions,
   children,
 }: Props = $props();
 
@@ -134,6 +140,7 @@ function handleDocumentKeydown(e: KeyboardEvent) {
       {backLabel}
     </button>
     <span class="do-title">{@render title()}</span>
+    {#if headerActions}<div class="do-actions">{@render headerActions()}</div>{/if}
   </header>
   <div class="do-body">{@render children()}</div>
 </section>
@@ -182,5 +189,8 @@ function handleDocumentKeydown(e: KeyboardEvent) {
     flex-shrink: 0;
   }
   .back-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+  /* Right-aligned header content (summary/stat pills). Wraps under the title on
+     narrow widths rather than overflowing the bar. */
+  .do-actions { margin-left: auto; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
   .do-body { flex: 1; min-height: 0; overflow: hidden; display: flex; }
 </style>

--- a/src/lib/utils/filterCSS.ts
+++ b/src/lib/utils/filterCSS.ts
@@ -8,6 +8,33 @@ const FILTERED = '{ opacity: 0.15 !important; filter: grayscale(1) !important; p
 const HIDDEN = '{ display: none !important; }';
 const INACTIVE = '{ background-color: #e8e8ec !important; border-color: #d0d0d6 !important; opacity: 0.5 !important; }';
 const DIMMED = '{ opacity: 0.2 !important; }';
+/** Drop the diff-cell amber tint on a filtered-out cell (the dimmed glyph would
+ *  otherwise let the tint bleed through, distracting from the focus). */
+const DIFF_BG_CLEARED = '{ background-color: transparent !important; }';
+
+/**
+ * Inner cell selectors (one per active clause) matching the cells to dim:
+ * the single `:not()`-chained selector for a `selected` set, plus one per
+ * `hidden` value. `exact` matches `[attr="v"]`; otherwise a delimited
+ * substring `[attr*="·v·"]` (the both-allele `data-attrs` list).
+ */
+function matchSelectors(
+  baseSelector: string,
+  attr: string,
+  selected: string[],
+  hidden: string[],
+  exact: boolean,
+): string[] {
+  const term = (v: string) => (exact ? `[${attr}="${v}"]` : `[${attr}*="${delim(v)}"]`);
+  const sels: string[] = [];
+  if (selected.length > 0) {
+    let not = '';
+    for (const v of selected) not += `:not(${term(v)})`;
+    sels.push(`${baseSelector}[${attr}]${not}`);
+  }
+  for (const v of hidden) sels.push(`${baseSelector}${term(v)}`);
+  return sels;
+}
 
 function pushInclusionRules(
   rules: string[],
@@ -18,13 +45,30 @@ function pushInclusionRules(
   declaration: string,
   gridSelector: string = G,
 ): void {
-  if (selected.length > 0) {
-    let not = '';
-    for (const v of selected) not += `:not([${attr}="${v}"])`;
-    rules.push(`${gridSelector} ${baseSelector}[${attr}]${not} ${declaration}`);
+  for (const s of matchSelectors(baseSelector, attr, selected, hidden, true)) {
+    rules.push(`${gridSelector} ${s} ${declaration}`);
   }
-  for (const v of hidden) {
-    rules.push(`${gridSelector} ${baseSelector}[${attr}="${v}"] ${declaration}`);
+}
+
+/**
+ * Like `pushInclusionRules`, but matches the *potential* attributes of a locus
+ * carried in a delimited `data-attrs` list (`·Attr·Attr·`) rather than a single
+ * exact `data-attr`. This is the gene-effect-database view of the filter: the
+ * attribute set is a property of the gene (union of both alleles' effects), so
+ * a cell stays lit whenever its gene could affect the attribute — independent
+ * of which allele the pet actually carries. `data-attrs` must be present (even
+ * empty) on every filterable cell so attribute-less loci dim under a selection.
+ */
+function pushPotentialInclusionRules(
+  rules: string[],
+  baseSelector: string,
+  selected: string[],
+  hidden: string[],
+  declaration: string,
+  gridSelector: string = G,
+): void {
+  for (const s of matchSelectors(baseSelector, 'data-attrs', selected, hidden, false)) {
+    rules.push(`${gridSelector} ${s} ${declaration}`);
   }
 }
 
@@ -45,6 +89,27 @@ export function attributeFilterCSS(
 ): string {
   const rules: string[] = [];
   pushInclusionRules(rules, cellSelector, 'data-attr', selectedAttributes, hiddenAttributes, FILTERED, gridSelector);
+  return rules.join('\n');
+}
+
+/**
+ * Like `attributeFilterCSS`, but matches the *potential* attributes of a locus:
+ * the union of both alleles' effects, carried as a delimited `data-attrs` list
+ * (`·Attr·Attr·`). A locus stays lit whenever its gene could affect the
+ * attribute via either allele — even if the pet's current allele is neutral —
+ * so the trio grid's focus highlights both parents and the offspring at every
+ * responsible locus rather than dimming a parent whose allele happens to be
+ * neutral. `data-attrs` must be present (even empty) on every filterable cell,
+ * so attribute-less loci dim under an active selection. See `ATTR_DELIM`.
+ */
+export function attributePotentialFilterCSS(
+  gridSelector: string,
+  cellSelector: string,
+  selectedAttributes: string[],
+  hiddenAttributes: string[],
+): string {
+  const rules: string[] = [];
+  pushPotentialInclusionRules(rules, cellSelector, selectedAttributes, hiddenAttributes, FILTERED, gridSelector);
   return rules.join('\n');
 }
 
@@ -85,10 +150,23 @@ export function buildFilterCSS(filters: FilterCSSInput): string {
 
   const rules: string[] = [];
 
-  if (currentView === 'attribute') {
-    pushInclusionRules(rules, '.gene-cell', 'data-attr', sa, ha, FILTERED);
-  } else if (currentView === 'appearance') {
-    pushInclusionRules(rules, '.gene-cell', 'data-appearance', sap, hap, FILTERED);
+  // Attribute filter keys off the gene effect DB (both alleles), carried as the
+  // delimited `data-attrs` list — not the pet's resolved per-allele `data-attr`.
+  // Both pet rows at a locus share the same gene, so the same selector decides
+  // both; a pet whose current allele is neutral stays lit when its gene could
+  // affect the attribute via the other allele. Appearance is a single per-gene
+  // category (`data-appearance`), matched exactly.
+  const focusSelectors =
+    currentView === 'attribute'
+      ? matchSelectors('.gene-cell', 'data-attrs', sa, ha, false)
+      : currentView === 'appearance'
+        ? matchSelectors('.gene-cell', 'data-appearance', sap, hap, true)
+        : [];
+  for (const s of focusSelectors) {
+    rules.push(`${G} ${s} ${FILTERED}`);
+    // Clear the amber diff tint on the containing cell too, so a dimmed glyph
+    // doesn't let it bleed through and fight the focus.
+    rules.push(`${G} .gene-cell-container.diff-cell:has(> ${s}) ${DIFF_BG_CLEARED}`);
   }
 
   // Breed filter

--- a/src/lib/utils/filterCSS.ts
+++ b/src/lib/utils/filterCSS.ts
@@ -36,28 +36,14 @@ function matchSelectors(
   return sels;
 }
 
-function pushInclusionRules(
-  rules: string[],
-  baseSelector: string,
-  attr: string,
-  selected: string[],
-  hidden: string[],
-  declaration: string,
-  gridSelector: string = G,
-): void {
-  for (const s of matchSelectors(baseSelector, attr, selected, hidden, true)) {
-    rules.push(`${gridSelector} ${s} ${declaration}`);
-  }
-}
-
 /**
- * Like `pushInclusionRules`, but matches the *potential* attributes of a locus
- * carried in a delimited `data-attrs` list (`·Attr·Attr·`) rather than a single
- * exact `data-attr`. This is the gene-effect-database view of the filter: the
- * attribute set is a property of the gene (union of both alleles' effects), so
- * a cell stays lit whenever its gene could affect the attribute — independent
- * of which allele the pet actually carries. `data-attrs` must be present (even
- * empty) on every filterable cell so attribute-less loci dim under a selection.
+ * Push select/hide rules that match the *potential* attributes of a locus
+ * carried in a delimited `data-attrs` list (`·Attr·Attr·`). This is the
+ * gene-effect-database view of the filter: the attribute set is a property of
+ * the gene (union of both alleles' effects), so a cell stays lit whenever its
+ * gene could affect the attribute — independent of which allele the pet
+ * actually carries. `data-attrs` must be present (even empty) on every
+ * filterable cell so attribute-less loci dim under a selection.
  */
 function pushPotentialInclusionRules(
   rules: string[],
@@ -73,34 +59,16 @@ function pushPotentialInclusionRules(
 }
 
 /**
- * Attribute select/hide rules for any genome grid, parameterised by the grid
- * and cell selectors. Selected attributes dim everything else; hidden
- * attributes dim themselves. Shares the exact dimming declaration the 2-pet
- * diff grid uses so the trio grid filters identically. `cellSelector` is the
- * element selector that *carries* `data-attr` — `[data-attr]` is appended
- * internally, so pass the element only (the diff grid uses `.gene-cell`; the
- * trio grid uses `*` because its rows mix `.gene-cell` and `.dist-bar` cells).
- */
-export function attributeFilterCSS(
-  gridSelector: string,
-  cellSelector: string,
-  selectedAttributes: string[],
-  hiddenAttributes: string[],
-): string {
-  const rules: string[] = [];
-  pushInclusionRules(rules, cellSelector, 'data-attr', selectedAttributes, hiddenAttributes, FILTERED, gridSelector);
-  return rules.join('\n');
-}
-
-/**
- * Like `attributeFilterCSS`, but matches the *potential* attributes of a locus:
- * the union of both alleles' effects, carried as a delimited `data-attrs` list
+ * Attribute focus rules matching the *potential* attributes of a locus: the
+ * union of both alleles' effects, carried as a delimited `data-attrs` list
  * (`·Attr·Attr·`). A locus stays lit whenever its gene could affect the
  * attribute via either allele — even if the pet's current allele is neutral —
- * so the trio grid's focus highlights both parents and the offspring at every
- * responsible locus rather than dimming a parent whose allele happens to be
- * neutral. `data-attrs` must be present (even empty) on every filterable cell,
- * so attribute-less loci dim under an active selection. See `ATTR_DELIM`.
+ * so the grids highlight every responsible locus rather than dimming a cell
+ * whose allele happens to be neutral. `data-attrs` must be present (even empty)
+ * on every filterable cell, so attribute-less loci dim under an active
+ * selection. `cellSelector` carries `data-attrs` (the diff grid uses
+ * `.gene-cell`; the trio grid uses `*` because its rows mix `.gene-cell` and
+ * `.dist-bar` cells). See `ATTR_DELIM` / `joinAttrs`.
  */
 export function attributePotentialFilterCSS(
   gridSelector: string,
@@ -224,6 +192,17 @@ export const ATTR_DELIM = '·';
 /** Wrap a single value for a delimited-substring `*=` match. */
 function delim(value: string): string {
   return `${ATTR_DELIM}${value}${ATTR_DELIM}`;
+}
+
+/**
+ * Encode a set of values as a delimited token list for a `data-attrs`-style
+ * attribute (`·a·b·`, empty string when none). The multi-value counterpart of
+ * `delim()` — the single encoder for every producer of these lists, so the
+ * wrapping stays in lockstep with the `[attr*="·v·"]` selectors emitted here.
+ */
+export function joinAttrs(values: Iterable<string>): string {
+  const arr = [...values];
+  return arr.length ? ATTR_DELIM + arr.join(ATTR_DELIM) + ATTR_DELIM : '';
 }
 
 /** `gene-dominant` → `dominant` (the value carried by `data-zygosity`). */

--- a/src/lib/utils/geneGridCells.ts
+++ b/src/lib/utils/geneGridCells.ts
@@ -135,6 +135,27 @@ export function createGeneCellBuilder(ctx: GeneCellContext) {
     return { effectType, attribute, effect, breed };
   }
 
+  /**
+   * Attributes the gene at this locus can affect via *either* allele — the
+   * union of the dominant and recessive effects' attribute names, independent
+   * of which allele a given pet carries. A parent whose current allele is
+   * neutral is still reported here as potentially responsible, so the trio
+   * grid's attribute focus can highlight it (and the offspring) rather than
+   * dimming it out. Names are capitalised to match `data-attr` / filter keys.
+   */
+  function attributesForGene(geneId: string): string[] {
+    const geneData = ctx.effectsDB[geneId];
+    if (!geneData) return [];
+    const set = new Set<string>();
+    for (const eff of [geneData.effectDominant, geneData.effectRecessive]) {
+      if (isNoEffect(eff)) continue;
+      for (const attrName of ctx.attributeNames) {
+        if (eff.includes(attrName)) set.add(attrName);
+      }
+    }
+    return [...set];
+  }
+
   function categorizeAppearance(geneId: string): string {
     const raw = ctx.effectsDB[geneId]?.appearance;
     if (!raw || raw === 'None' || raw.includes('String for me to fill')) return '';
@@ -177,5 +198,5 @@ export function createGeneCellBuilder(ctx: GeneCellContext) {
     };
   }
 
-  return { makeCell, analyzeGene, categorizeAppearance };
+  return { makeCell, analyzeGene, categorizeAppearance, attributesForGene };
 }

--- a/src/lib/utils/trioGrid.ts
+++ b/src/lib/utils/trioGrid.ts
@@ -12,6 +12,7 @@
 
 import { compareBlockLetters } from '$lib/services/genomeParser.js';
 import type { AlleleDistribution, GeneType, OffspringTrioResult, TrioVerdict } from '$lib/types/index.js';
+import { ATTR_DELIM } from '$lib/utils/filterCSS.js';
 import type { GeneCell } from '$lib/utils/geneGridCells.js';
 
 /** Effect tone of an offspring allele outcome — drives the segment colour. */
@@ -39,6 +40,13 @@ export interface TrioLocusCell {
   source: 'father' | 'mother' | 'both' | null;
   lockedIn: boolean;
   attribute?: string;
+  /**
+   * Delimited (`·Attr·Attr·`) set of attributes the locus gene can affect via
+   * *either* allele — drives the attribute focus filter across all three rows
+   * (see `attributePotentialFilterCSS`). Empty string when the gene has no
+   * attribute effect, so it dims under an active selection.
+   */
+  attrs: string;
   pPositive: number;
   pNegative: number;
   fatherEffect?: string;
@@ -62,6 +70,7 @@ export interface TrioGrid {
 interface CellBuilderLike {
   makeCell(gene: { id: string; type: string }): GeneCell;
   analyzeGene(geneId: string, geneType: string): { effectType: string };
+  attributesForGene(geneId: string): string[];
 }
 
 const ALLELE_ORDER: readonly (keyof AlleleDistribution)[] = ['D', 'x', 'R', 'unknown'];
@@ -158,8 +167,10 @@ export function buildTrioGrid(result: OffspringTrioResult, cellBuilder: CellBuil
   const rows: TrioGridRow[] = result.chromosomes.map((chr) => {
     const cells: Record<string, TrioLocusCell> = {};
     for (const g of chr.genes) {
+      const attrList = cellBuilder.attributesForGene(g.geneId);
       cells[`${g.block}${g.position}`] = {
         geneId: g.geneId,
+        attrs: attrList.length ? ATTR_DELIM + attrList.join(ATTR_DELIM) + ATTR_DELIM : '',
         block: g.block,
         position: g.position,
         fatherType: g.fatherType,

--- a/src/lib/utils/trioGrid.ts
+++ b/src/lib/utils/trioGrid.ts
@@ -12,7 +12,7 @@
 
 import { compareBlockLetters } from '$lib/services/genomeParser.js';
 import type { AlleleDistribution, GeneType, OffspringTrioResult, TrioVerdict } from '$lib/types/index.js';
-import { ATTR_DELIM } from '$lib/utils/filterCSS.js';
+import { joinAttrs } from '$lib/utils/filterCSS.js';
 import type { GeneCell } from '$lib/utils/geneGridCells.js';
 
 /** Effect tone of an offspring allele outcome — drives the segment colour. */
@@ -170,7 +170,7 @@ export function buildTrioGrid(result: OffspringTrioResult, cellBuilder: CellBuil
       const attrList = cellBuilder.attributesForGene(g.geneId);
       cells[`${g.block}${g.position}`] = {
         geneId: g.geneId,
-        attrs: attrList.length ? ATTR_DELIM + attrList.join(ATTR_DELIM) + ATTR_DELIM : '',
+        attrs: joinAttrs(attrList),
         block: g.block,
         position: g.position,
         fatherType: g.fatherType,

--- a/tests/unit/filterCSS.test.ts
+++ b/tests/unit/filterCSS.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   attributeFilterCSS,
+  attributePotentialFilterCSS,
   buildFilterCSS,
   buildVisualizerFilterCSS,
   type VisualizerFilterInput,
@@ -10,6 +11,7 @@ const FILTERED = '{ opacity: 0.15 !important; filter: grayscale(1) !important; p
 const HIDDEN = '{ display: none !important; }';
 const INACTIVE = '{ background-color: #e8e8ec !important; border-color: #d0d0d6 !important; opacity: 0.5 !important; }';
 const DIMMED = '{ opacity: 0.2 !important; }';
+const DIFF_CLEARED = '{ background-color: transparent !important; }';
 
 const base = {
   selectedAttributes: [],
@@ -30,21 +32,31 @@ describe('buildFilterCSS', () => {
     expect(buildFilterCSS(base)).toBe('');
   });
 
-  it('dims non-selected attribute cells via a :not() chain', () => {
+  it('dims cells whose gene cannot affect any selected attribute (gene-DB data-attrs match)', () => {
     const css = buildFilterCSS({ ...base, selectedAttributes: ['Toughness', 'Speed'] });
+    const sel = '.gene-cell[data-attrs]:not([data-attrs*="·Toughness·"]):not([data-attrs*="·Speed·"])';
     expect(css).toBe(
-      `.grid-container .gene-cell[data-attr]:not([data-attr="Toughness"]):not([data-attr="Speed"]) ${FILTERED}`,
+      `.grid-container ${sel} ${FILTERED}\n` +
+        `.grid-container .gene-cell-container.diff-cell:has(> ${sel}) ${DIFF_CLEARED}`,
     );
   });
 
-  it('dims a hidden attribute cell directly', () => {
+  it('dims a hidden attribute via delimited data-attrs match', () => {
     const css = buildFilterCSS({ ...base, hiddenAttributes: ['Toughness'] });
-    expect(css).toBe(`.grid-container .gene-cell[data-attr="Toughness"] ${FILTERED}`);
+    const sel = '.gene-cell[data-attrs*="·Toughness·"]';
+    expect(css).toBe(
+      `.grid-container ${sel} ${FILTERED}\n` +
+        `.grid-container .gene-cell-container.diff-cell:has(> ${sel}) ${DIFF_CLEARED}`,
+    );
   });
 
-  it('targets data-appearance in the appearance view', () => {
+  it('targets data-appearance in the appearance view and clears the diff tint on filtered cells', () => {
     const css = buildFilterCSS({ ...base, currentView: 'appearance', selectedAppearances: ['coat'] });
-    expect(css).toBe(`.grid-container .gene-cell[data-appearance]:not([data-appearance="coat"]) ${FILTERED}`);
+    const sel = '.gene-cell[data-appearance]:not([data-appearance="coat"])';
+    expect(css).toBe(
+      `.grid-container ${sel} ${FILTERED}\n` +
+        `.grid-container .gene-cell-container.diff-cell:has(> ${sel}) ${DIFF_CLEARED}`,
+    );
   });
 
   it('hides chromosomes outside an active selection', () => {
@@ -101,6 +113,24 @@ describe('attributeFilterCSS', () => {
   it('dims a hidden attribute directly', () => {
     const css = attributeFilterCSS('.trio-grid-container', '*', [], ['Toughness']);
     expect(css).toBe(`.trio-grid-container *[data-attr="Toughness"] ${FILTERED}`);
+  });
+});
+
+describe('attributePotentialFilterCSS', () => {
+  it('returns an empty string when nothing is selected or hidden', () => {
+    expect(attributePotentialFilterCSS('.trio-grid-container', '*', [], [])).toBe('');
+  });
+
+  it('dims loci whose gene cannot affect the selected attribute via either allele', () => {
+    const css = attributePotentialFilterCSS('.trio-grid-container', '*', ['Toughness'], []);
+    // delimited-substring match keeps a locus lit even when the pet's current
+    // allele is neutral, as long as ·Toughness· is in its both-allele set.
+    expect(css).toBe(`.trio-grid-container *[data-attrs]:not([data-attrs*="·Toughness·"]) ${FILTERED}`);
+  });
+
+  it('dims a hidden attribute via delimited-substring match', () => {
+    const css = attributePotentialFilterCSS('.trio-grid-container', '*', [], ['Speed']);
+    expect(css).toBe(`.trio-grid-container *[data-attrs*="·Speed·"] ${FILTERED}`);
   });
 });
 

--- a/tests/unit/filterCSS.test.ts
+++ b/tests/unit/filterCSS.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-  attributeFilterCSS,
   attributePotentialFilterCSS,
   buildFilterCSS,
   buildVisualizerFilterCSS,
+  joinAttrs,
   type VisualizerFilterInput,
 } from '$lib/utils/filterCSS.js';
 
@@ -100,19 +100,19 @@ describe('buildFilterCSS', () => {
   });
 });
 
-describe('attributeFilterCSS', () => {
-  it('returns an empty string when nothing is selected or hidden', () => {
-    expect(attributeFilterCSS('.trio-grid-container', '*', [], [])).toBe('');
+describe('joinAttrs', () => {
+  it('wraps each value in the delimiter so it matches the [attr*="·v·"] selectors', () => {
+    expect(joinAttrs(['Toughness'])).toBe('·Toughness·');
+    expect(joinAttrs(['Speed', 'Toughness'])).toBe('·Speed·Toughness·');
   });
 
-  it('dims everything but the selected attributes, scoped to the given grid/cell selectors', () => {
-    const css = attributeFilterCSS('.trio-grid-container', '*', ['Speed'], []);
-    expect(css).toBe(`.trio-grid-container *[data-attr]:not([data-attr="Speed"]) ${FILTERED}`);
+  it('returns an empty string for an empty set (so the cell dims under a focus)', () => {
+    expect(joinAttrs([])).toBe('');
+    expect(joinAttrs(new Set<string>())).toBe('');
   });
 
-  it('dims a hidden attribute directly', () => {
-    const css = attributeFilterCSS('.trio-grid-container', '*', [], ['Toughness']);
-    expect(css).toBe(`.trio-grid-container *[data-attr="Toughness"] ${FILTERED}`);
+  it('accepts a Set (GeneVisualizer builds its attribute sets that way)', () => {
+    expect(joinAttrs(new Set(['Speed', 'Toughness']))).toBe('·Speed·Toughness·');
   });
 });
 

--- a/tests/unit/trioGrid.test.ts
+++ b/tests/unit/trioGrid.test.ts
@@ -97,6 +97,14 @@ describe('buildTrioGrid', () => {
     expect(a2.motherCell).toBeNull(); // motherType null → no cell
   });
 
+  it('carries a per-locus both-allele attribute set (potential responsibility, not just the expressed allele)', () => {
+    // 01A1: both alleles affect Speed → ·Speed·
+    expect(grid.rows[0].cells.A1.attrs).toBe('·Speed·');
+    // 01A2: dominant Toughness+, recessive neutral → still ·Toughness· so a
+    // parent carrying the neutral allele stays lit under a Toughness focus.
+    expect(grid.rows[0].cells.A2.attrs).toBe('·Toughness·');
+  });
+
   it('builds offspring segments, omitting zero-mass alleles and toning by expressed effect', () => {
     const segs = grid.rows[0].cells.A1.segments;
     expect(segs).toEqual([
@@ -131,6 +139,7 @@ describe('buildTrioGrid', () => {
         effect: '',
       }),
       analyzeGene: () => ({ effectType: 'totally-made-up' }),
+      attributesForGene: () => [],
     };
     const stubResult = {
       chromosomes: [


### PR DESCRIPTION
## Summary

Improvements to the offspring trio and 2-pet compare genome grids, keeping the two lenses consistent.

**Attribute focus keyed on the gene effect database.** The attribute filter matched each pet's *resolved-allele* attribute, so a parent/pet carrying the neutral allele of a gene that affects the focused attribute via its *other* allele was dimmed out. It now matches the gene's potential attributes (union of both alleles), carried as a delimited `data-attrs` set. A locus stays lit whenever its gene could affect the attribute, and both rows of a locus filter identically (one decision per gene, not per pet).

**Compare diff tint fixes.** The amber diff tint filled the whole cell (border-box), bleeding across the 8px inter-block gap into a continuous band; it's now confined to the gene square (`background-clip: content-box`). Under an active attribute/appearance focus, the tint is cleared on dimmed cells so it doesn't bleed through the faded glyph.

**Two-row chrome, consistent across both lenses.** Each grid now owns its own `DetailOverlay` and hoists its summary pills into the header bar beside the pet names (via a new `headerActions` slot), leaving a single filter row below — two rows instead of three. Cell density unified at 16px.

## Testing
- `pnpm run check` — 0 errors
- `pnpm run lint:ci` — no errors
- `pnpm vitest run` — 909 passing (added coverage for the gene-DB `data-attrs` set and the diff-clear filter rules)
- Verified live in-app: neutral-allele loci stay lit under focus in both views; both rows filter identically; diff tint confined + cleared; trio locked-toggle and compare view-toggle/diffs-only work from the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)