### PR TITLE
Fix cutover regressions: notes wipe, stale-tag trap, success-as-error

### DIFF
--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -78,6 +78,16 @@ $effect(() => {
   prevSpecies = species;
 });
 
+// Drop selected tag filters that no longer exist on any pet — e.g. the last
+// pet carrying a tag was deleted or re-tagged. Its pill disappears from the
+// FilterBar (pills come from $allTags), but the filter would stay active and
+// strand the roster on an empty result with no pill left to clear it.
+$effect(() => {
+  const live = $allTags;
+  const pruned = myPetsView.tags.filter((t) => live.includes(t));
+  if (pruned.length !== myPetsView.tags.length) myPetsView.tags = pruned;
+});
+
 // Honour a cross-destination "open this pet" request (e.g. clicking a parent in
 // the Breed pair table switched here). Wait until the pet is actually in the
 // loaded list before consuming the request, so one that arrives before

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -199,9 +199,13 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
   // correction whose identity differs from the base entry
   // (identityMatchesFirstShare), so a locally-renamed pet re-shares its
   // corrected attributes/tags without tripping permission-denied.
+  // Preserve already-published notes when this share carries none (bulk/auto),
+  // so a correction appended for an attribute/tag change can't blank them.
+  const preservedNotes = (pet.notes ?? '') || (latest.notes ?? '');
   const correctionRef = doc(collection(db, META_COLLECTION));
   await setDoc(correctionRef, {
     ...payload,
+    notes: preservedNotes,
     name: base.name,
     character: base.character,
     species: base.species,
@@ -303,7 +307,12 @@ function pickLatestSnapshot(snaps: DocumentSnapshot<DocumentData>[]): DocumentSn
  * old pet backfills its attributes via one correction.
  */
 function metadataMatches(existing: SharedPet, pet: Pet): boolean {
-  if ((existing.notes ?? '') !== (pet.notes ?? '')) return false;
+  // Empty incoming notes carries no opinion: the bulk / auto-share paths always
+  // send notes='' (only per-pet share opts them in), so an empty value must not
+  // count as a change — otherwise re-sharing a pet in bulk would append a
+  // correction that silently wipes notes the user published via per-pet share.
+  const petNotes = pet.notes ?? '';
+  if (petNotes && petNotes !== (existing.notes ?? '')) return false;
   if (!sameStringSet(existing.tags, sanitizeTags(pet.tags))) return false;
   return sameAttributes(existing.attributes, buildAttributes(pet));
 }

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -16,6 +16,12 @@ export const error: Writable<string | null> = writable(null);
 /** Non-error, positive outcome text (e.g. import/auto-share summaries). Rendered
  *  as a success banner, distinct from the destructive `error` channel. */
 export const notice: Writable<string | null> = writable(null);
+// The two channels are mutually exclusive: surfacing an error (from any call
+// site) dismisses a lingering success toast so a stale "shared to community"
+// banner never sits next to a fresh failure.
+error.subscribe((v) => {
+  if (v !== null) notice.set(null);
+});
 export const geneEditingView: Writable<unknown> = writable(null);
 export const activeTab: Writable<Tab> = writable('mypets');
 
@@ -306,6 +312,7 @@ export const appState = {
     selectedPet.set(null);
     geneEditingView.set(null);
     error.set(null);
+    notice.set(null);
     loading.set(false);
     // Drop the back-stack too — its entries point into the pre-reset
     // session and shouldn't survive a full reset (#276 review).

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -13,6 +13,9 @@ export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
 export const loading = writable(false);
 export const error: Writable<string | null> = writable(null);
+/** Non-error, positive outcome text (e.g. import/auto-share summaries). Rendered
+ *  as a success banner, distinct from the destructive `error` channel. */
+export const notice: Writable<string | null> = writable(null);
 export const geneEditingView: Writable<unknown> = writable(null);
 export const activeTab: Writable<Tab> = writable('mypets');
 
@@ -289,6 +292,10 @@ export const appState = {
 
   clearError() {
     error.set(null);
+  },
+
+  clearNotice() {
+    notice.set(null);
   },
 
   setError(message: string) {

--- a/src/lib/utils/genomeUploadController.svelte.ts
+++ b/src/lib/utils/genomeUploadController.svelte.ts
@@ -15,7 +15,7 @@ import { autoShareImportedPets, summarizeAutoShare } from '$lib/services/autoSha
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { refreshPendingImportCount } from '$lib/stores/gameImport.js';
-import { appState, error } from '$lib/stores/pets.js';
+import { appState, error, notice } from '$lib/stores/pets.js';
 import { errorMessage } from '$lib/utils/error.js';
 import type { UploadSource } from '$lib/utils/genomeUpload.js';
 import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
@@ -37,6 +37,7 @@ export function createGenomeUploadController() {
     if (sources.length === 0 || uploading || autoScanning) return;
     uploading = true;
     error.set(null);
+    notice.set(null);
     try {
       const { total, succeeded, failures, createdPetIds } = await runGenomeUpload(sources, {
         upload: (content: string) => appState.uploadPetQuiet(content),
@@ -52,7 +53,7 @@ export function createGenomeUploadController() {
         const base = `${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`;
         error.set(shareNote ? `${base}\n${shareNote}` : base);
       } else if (shareNote) {
-        error.set(shareNote);
+        notice.set(shareNote);
       }
     } catch (err) {
       error.set(`Upload failed: ${errorMessage(err)}`);
@@ -119,6 +120,7 @@ export function createGenomeUploadController() {
     try {
       autoScanning = true;
       error.set(null);
+      notice.set(null);
       const result = await autoScanGameFolder({
         onProgress: (current: number, total: number) => {
           autoScanProgress = { current, total };
@@ -149,7 +151,7 @@ export function createGenomeUploadController() {
         const lines = result.failures.map((f: { file: string; reason: string }) => `${f.file}: ${f.reason}`);
         error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);
       } else if (result.imported > 0 || result.backfilled > 0) {
-        error.set(summary);
+        notice.set(summary);
       }
     } catch (err) {
       error.set(`Auto-import failed: ${errorMessage(err)}`);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,8 @@ import ReferenceView from '$lib/components/gene/ReferenceView.svelte';
 import SettingsView from '$lib/components/layout/SettingsView.svelte';
 import MyPets from '$lib/components/mypets/MyPets.svelte';
 import PetEditor from '$lib/components/pet/PetEditor.svelte';
-import { activeTab, appState, error, loading } from '$lib/stores/pets.js';
+import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
+import { activeTab, appState, error, loading, notice } from '$lib/stores/pets.js';
 import { editingPet, settingsOpen, uiActions } from '$lib/stores/ui.js';
 
 onMount(async () => {
@@ -25,6 +26,10 @@ onMount(async () => {
 				<div class="error-message">⚠️ {$error}</div>
 				<button class="error-close" onclick={() => appState.clearError()} aria-label="Dismiss error">×</button>
 			</div>
+		{/if}
+
+		{#if $notice}
+			<StatusBanner type="success" message={$notice} toast autoDismissMs={8000} onDismiss={() => appState.clearNotice()} />
 		{/if}
 
 		{#if $loading}

--- a/tests/unit/myPets.test.ts
+++ b/tests/unit/myPets.test.ts
@@ -89,3 +89,22 @@ describe('MyPets — selection is scoped to the visible (filtered) pets', () => 
     expect(selection(container)).toBeNull();
   });
 });
+
+describe('MyPets — prunes tag filters that no longer exist on any pet', () => {
+  it('drops a selected tag once its last carrier is gone, keeping live tags', async () => {
+    pets.set([pet({ id: 1, name: 'Dusty', tags: ['keep'] })]);
+    myPetsView.tags = ['keep', 'ghost'];
+    const { rerender } = render(MyPets);
+    await rerender({});
+    expect(myPetsView.tags).toEqual(['keep']);
+  });
+
+  it('clears an all-stale tag filter so the roster is not stranded empty', async () => {
+    pets.set([pet({ id: 1, name: 'Dusty', tags: [] })]);
+    myPetsView.tags = ['ghost'];
+    const { container, rerender } = render(MyPets);
+    await rerender({});
+    expect(myPetsView.tags).toEqual([]);
+    expect(container.querySelector('[data-testid="mypets-count"]')?.textContent).toContain('Showing 1 of 1');
+  });
+});

--- a/tests/unit/petsStore.test.ts
+++ b/tests/unit/petsStore.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { closeDatabase, initDatabase } from '$lib/services/database.js';
 import { runMigrations } from '$lib/services/migrationService.js';
 import * as petService from '$lib/services/petService.js';
-import { activeTab, appState, error, geneEditingView, loading, pets, selectedPet } from '$lib/stores/pets.js';
+import { activeTab, appState, error, geneEditingView, loading, notice, pets, selectedPet } from '$lib/stores/pets.js';
 import type { Pet } from '$lib/types/index.js';
 
 // The store's `selectPet` takes a full `Pet`; these tests only need the
@@ -98,6 +98,13 @@ describe('Pets Store', () => {
       appState.setError('something went wrong');
       appState.clearError();
       expect(get(error)).toBeNull();
+    });
+
+    it('dismisses a lingering success notice when an error is surfaced', () => {
+      notice.set('3 shared to community');
+      appState.setError('boom');
+      expect(get(notice)).toBeNull();
+      appState.clearError();
     });
   });
 

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -330,6 +330,48 @@ describe('shareService.uploadPet — add-only corrections', () => {
     expect(setDoc).toHaveBeenCalledTimes(1);
   });
 
+  it('does not blank published notes when a bulk re-share (notes="") only differs in notes', async () => {
+    // The catalogue entry has notes the user published via per-pet share; a
+    // later bulk/auto share sends notes='' but is otherwise identical.
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ notes: 'hand-written' }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: '' }));
+    expect(result.status).toBe('already-shared');
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it('preserves published notes in a correction appended for a non-notes change', async () => {
+    // Attributes differ (so a correction is warranted), but the bulk pet carries
+    // notes='' — the correction must carry the existing notes, not blank them.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ notes: 'hand-written', attributes: { ...FIXTURE_ATTRS, intelligence: 99 } }), {
+          id: RAW_TEXT_HASH,
+        }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: '' }));
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.notes).toBe('hand-written');
+  });
+
+  it('still publishes non-empty notes from a per-pet share as a correction', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ notes: '' }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: 'freshly typed' }));
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.notes).toBe('freshly typed');
+  });
+
   it('pins the correction identity fields to the first-share doc, not the local pet (issue #393)', async () => {
     // The catalogue entry's identity belongs to the first share — rules
     // reject a correction whose identity differs. The local pet was


### PR DESCRIPTION
Fixes three regressions surfaced by an epic-level review of `redesign/library-workspace` vs `main`. Each was invisible to the per-PR reviews because the effects are cross-PR (the PetList→Roster cutover + the new share-correction mechanism interacting with bulk share).

## #1 — Published notes silently wiped on bulk share (`shareService.ts`)
A user could per-pet share a pet **with notes**, then a later "Share all" / "Share selected" / auto-share (all of which send `notes: ''`) would append a notes-blanking correction, and reads resolve to the latest entry — silently wiping the published notes.
Fix: empty incoming notes carries **no opinion**. It never counts as a change in `metadataMatches`, and a correction appended for an attribute/tag change preserves the existing published notes rather than blanking them. Clearing notes via re-share is no longer possible (add-only catalogue; silently doing it in bulk was the bug).

## #2 — Empty-roster trap from a stale tag filter (`MyPets.svelte`)
Filtering by a tag, then removing that tag from its last carrier (or deleting those pets), dropped the pill from the FilterBar but left the filter active → "Showing 0 of N", no empty state, no clear control. The old `PetList` pruned stale selected tags; the cutover dropped it. Restored as an `$effect` mirroring the existing species/breed prune.

## #6 — Import/auto-share success shown as a red error banner (`genomeUploadController` + `notice` store + `+page.svelte`)
Success summaries ("3 shared to community") were routed through the pets `error` store and rendered as a red ⚠️ `role="alert"` banner. Added a `notice` store surfaced as a `StatusBanner type="success"` toast; genuine failures still use `error`.

## Tests
- shareService: bulk re-share with empty notes is a no-op (no wipe); a correction for a non-notes change preserves notes; a per-pet non-empty notes still publishes.
- myPets: a stale selected tag is pruned (live tags kept); an all-stale filter clears so the roster recovers.
- 917 unit tests pass, svelte-check 0 errors, biome clean.

## Not included (need product decisions — flagged in review)
- Lost persistent drag-reorder (`reorderPets` now dead code).
- Auto-share not passing the bulk throttle/quota-retry options.
- Community `dedupeLatest` identity hardening + the cleanup items (dual gene `data-attr`, triplicated `ATTRIBUTE_KEYS`/filter logic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)