### PR TITLE
Redesign review follow-ups: throttle, hide semantics, dedup, cleanup

### DIFF
--- a/src/lib/components/community/CommunityPetTable.svelte
+++ b/src/lib/components/community/CommunityPetTable.svelte
@@ -29,9 +29,11 @@ import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import StatusPane from '$lib/components/shared/StatusPane.svelte';
 import { getAllAttributeNames, getAllAttributes, getSupportedSpecies } from '$lib/services/configService.js';
 import { communityView, loadInitial, loadMore, selectPet } from '$lib/stores/community.svelte.js';
-import { type Gender, HORSE_BREEDS, type SharedPet } from '$lib/types/index.js';
+import { type Gender, type SharedPet } from '$lib/types/index.js';
+import { ATTRIBUTE_KEYS } from '$lib/utils/sharedPet.js';
 import { filterSharedPets, sharedPetOwner } from '$lib/utils/sharedPetFilter.js';
 import { type SortableColumn, sortByColumn } from '$lib/utils/sortColumn.js';
+import { BREEDS_BY_SPECIES } from '$lib/utils/species.js';
 import { capitalize } from '$lib/utils/string.js';
 import { formatShortDate } from '$lib/utils/timestamp.js';
 
@@ -48,17 +50,7 @@ const ATTR_COLUMNS = (() => {
       displayNames[key] ??= info.name ?? capitalize(key);
     }
   }
-  const wireOrder = [
-    'intelligence',
-    'toughness',
-    'friendliness',
-    'ruggedness',
-    'enthusiasm',
-    'virility',
-    'ferocity',
-    'temperament',
-  ] as const;
-  return wireOrder.map((key) => ({ key, label: displayNames[key] ?? capitalize(key) }));
+  return ATTRIBUTE_KEYS.map((key) => ({ key, label: displayNames[key] ?? capitalize(key) }));
 })();
 
 // Which of the eight attributes apply to a given species — cached per
@@ -108,10 +100,6 @@ function attrTotal(pet: SharedPet): number | null {
 // FilterBar. The tab content stays mounted (covered/inert) across tab
 // switches, so these survive navigation within a session.
 const speciesOptions = getSupportedSpecies();
-const BREEDS_BY_SPECIES: Record<string, Record<string, string>> = {
-  beewasp: { Bee: 'Bee', Wasp: 'Wasp' },
-  horse: HORSE_BREEDS,
-};
 
 let search = $state('');
 let speciesFilter = $state('');

--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1090,7 +1090,6 @@ const blockIndices = $derived.by(() => {
                                                                 data-gene-type={cell.type}
                                                                 data-effect={cell.effect}
                                                                 data-appearance-effect={cell.appearanceEffect}
-                                                                data-attr={cell.attr}
                                                                 data-attrs={cell.attrs}
                                                                 data-appearance={cell.appearance}
                                                                 data-effecttype={cell.effectType}

--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -23,19 +23,15 @@ import { bulkShareJob, startBulkShare } from '$lib/stores/bulkShare.svelte.js';
 import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearMyPetsSelection, getMyPetsFilters, myPetsView } from '$lib/stores/mypets.svelte.js';
 import { allTags, loading, pets } from '$lib/stores/pets.js';
-import { type DialogResult, type Gender, HORSE_BREEDS, type Pet } from '$lib/types/index.js';
+import { type DialogResult, type Gender, type Pet } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { createGenomeUploadController } from '$lib/utils/genomeUploadController.svelte.js';
 import { filterPets } from '$lib/utils/petFilter.js';
-import { getSpeciesEmoji } from '$lib/utils/species.js';
+import { BREEDS_BY_SPECIES, getSpeciesEmoji } from '$lib/utils/species.js';
 
 const speciesOptions = getSupportedSpecies();
 const upload = createGenomeUploadController();
 
-const BREEDS_BY_SPECIES: Record<string, Record<string, string>> = {
-  beewasp: { Bee: 'Bee', Wasp: 'Wasp' },
-  horse: HORSE_BREEDS,
-};
 const breedsForSpecies = $derived(myPetsView.species ? BREEDS_BY_SPECIES[myPetsView.species] : undefined);
 
 const flags = $derived([

--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -78,6 +78,16 @@ $effect(() => {
   prevSpecies = species;
 });
 
+// Drop selected tag filters that no longer exist on any pet — e.g. the last
+// pet carrying a tag was deleted or re-tagged. Its pill disappears from the
+// FilterBar (pills come from $allTags), but the filter would stay active and
+// strand the roster on an empty result with no pill left to clear it.
+$effect(() => {
+  const live = $allTags;
+  const pruned = myPetsView.tags.filter((t) => live.includes(t));
+  if (pruned.length !== myPetsView.tags.length) myPetsView.tags = pruned;
+});
+
 // Honour a cross-destination "open this pet" request (e.g. clicking a parent in
 // the Breed pair table switched here). Wait until the pet is actually in the
 // loaded list before consuming the request, so one that arrives before

--- a/src/lib/services/autoShare.ts
+++ b/src/lib/services/autoShare.ts
@@ -60,7 +60,10 @@ export async function autoShareImportedPets(petIds: number[]): Promise<BulkUploa
   if (toShare.length === 0) return null;
 
   try {
-    return await uploadPets(toShare);
+    // Throttle + retry like the other bulk callers (bulkShare / BulkSharePetDialog)
+    // so a large auto-import batch stays within the Firestore Spark write quota
+    // instead of tripping resource-exhausted and silently dropping later pets.
+    return await uploadPets(toShare, { interRequestDelayMs: 150, maxQuotaRetries: 5 });
   } catch (err) {
     // uploadPets isolates per-pet errors internally, so reaching here means an
     // unexpected failure (e.g. genome-text loader throwing). Swallow it — a

--- a/src/lib/services/petService.ts
+++ b/src/lib/services/petService.ts
@@ -10,7 +10,7 @@ import { capitalize } from '$lib/utils/string.js';
 import { now } from '$lib/utils/timestamp.js';
 import { runBatchBackfill } from './backfill.js';
 import { getAttributeConfig, getDefaultValues, normalizeSpecies } from './configService.js';
-import { buildInClauseParams, getDb, reorderRows, type TxStatement, withTransaction } from './database.js';
+import { buildInClauseParams, getDb, type TxStatement, withTransaction } from './database.js';
 import { getParsedGenesCached, isHorseBreedFiltered } from './geneService.js';
 import { compareBlockLetters, isValidGenomeFile, parseGenome } from './genomeParser.js';
 import { parseStructuredPetName } from './nameParser.js';
@@ -916,13 +916,6 @@ export async function hasPets(): Promise<boolean> {
   const db = getDb();
   const rows = await db.select<{ cnt: number }[]>('SELECT COUNT(*) as cnt FROM pets');
   return rows[0].cnt > 0;
-}
-
-/**
- * Update sort_order for a list of pets based on their position in the array.
- */
-export function reorderPets(orderedIds: number[]): Promise<void> {
-  return reorderRows('pets', orderedIds);
 }
 
 const POSITIVE_GENES_BACKFILL_KEY = 'pets.positive_genes_backfilled';

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -199,9 +199,13 @@ export async function uploadPet(pet: Pet, db: Firestore = defaultFirestore): Pro
   // correction whose identity differs from the base entry
   // (identityMatchesFirstShare), so a locally-renamed pet re-shares its
   // corrected attributes/tags without tripping permission-denied.
+  // Preserve already-published notes when this share carries none (bulk/auto),
+  // so a correction appended for an attribute/tag change can't blank them.
+  const preservedNotes = (pet.notes ?? '') || (latest.notes ?? '');
   const correctionRef = doc(collection(db, META_COLLECTION));
   await setDoc(correctionRef, {
     ...payload,
+    notes: preservedNotes,
     name: base.name,
     character: base.character,
     species: base.species,
@@ -303,7 +307,12 @@ function pickLatestSnapshot(snaps: DocumentSnapshot<DocumentData>[]): DocumentSn
  * old pet backfills its attributes via one correction.
  */
 function metadataMatches(existing: SharedPet, pet: Pet): boolean {
-  if ((existing.notes ?? '') !== (pet.notes ?? '')) return false;
+  // Empty incoming notes carries no opinion: the bulk / auto-share paths always
+  // send notes='' (only per-pet share opts them in), so an empty value must not
+  // count as a change — otherwise re-sharing a pet in bulk would append a
+  // correction that silently wipes notes the user published via per-pet share.
+  const petNotes = pet.notes ?? '';
+  if (petNotes && petNotes !== (existing.notes ?? '')) return false;
   if (!sameStringSet(existing.tags, sanitizeTags(pet.tags))) return false;
   return sameAttributes(existing.attributes, buildAttributes(pet));
 }

--- a/src/lib/services/shareService.ts
+++ b/src/lib/services/shareService.ts
@@ -65,7 +65,7 @@ import {
 } from '$lib/services/petService.js';
 import { Gender, type ListPetsOpts, type Pet, type SharedPet, type SharedPetsPage } from '$lib/types/index.js';
 import { sha256Hex } from '$lib/utils/hash.js';
-import { mergeCorrectionIdentity } from '$lib/utils/sharedPet.js';
+import { ATTRIBUTE_KEYS, mergeCorrectionIdentity } from '$lib/utils/sharedPet.js';
 
 declare const __APP_VERSION__: string;
 const APP_VERSION = __APP_VERSION__;
@@ -77,18 +77,6 @@ const TAG_CAP = 30;
 const TAG_MAX_LEN = 64;
 /** Default local tag applied to pets imported from the community catalogue. */
 const COMMUNITY_TAG = 'community';
-
-/** The eight attribute columns published as a nested `attributes` map. */
-const ATTRIBUTE_KEYS = [
-  'intelligence',
-  'toughness',
-  'friendliness',
-  'ruggedness',
-  'enthusiasm',
-  'virility',
-  'ferocity',
-  'temperament',
-] as const;
 
 /** Clamp a stored attribute to the published 0–100 integer range. */
 function clampAttribute(v: unknown): number {

--- a/src/lib/stores/community.svelte.ts
+++ b/src/lib/stores/community.svelte.ts
@@ -41,6 +41,15 @@ const PAGE_SIZE = 50;
  * base's identity fields overwrite the correction's. A correction whose
  * base hasn't been paged in yet is shown as-is (best effort — the detail
  * view's `getSharedPet` always fetches the base doc and re-merges).
+ *
+ * Accepted residual risk (review #3): a correction paged in before its base
+ * shows the correction's own identity in the list. For rule-compliant docs
+ * that identity equals the base's, so it's correct; only a legacy pre-rule
+ * "poisoned" correction could briefly show spoofed text here, and opening it
+ * re-fetches the base and corrects it. We don't fetch each orphan
+ * correction's base to verify (extra reads per page against the Spark quota)
+ * nor blank correction identity wholesale (it would blank legitimate
+ * corrections whose base simply isn't paged in — the common case).
  */
 function dedupeLatest(pets: SharedPet[]): SharedPet[] {
   const indexByHash = new Map<string, number>();

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -244,15 +244,6 @@ export const appState = {
     }
   },
 
-  async reorderPets(orderedIds: number[]) {
-    try {
-      await petService.reorderPets(orderedIds);
-    } catch (err: unknown) {
-      error.set(`Failed to save order: ${errorMessage(err)}`);
-      throw err;
-    }
-  },
-
   setGeneEditingView(editingData: unknown) {
     geneEditingView.set(editingData);
     selectedPet.set(null);

--- a/src/lib/stores/pets.ts
+++ b/src/lib/stores/pets.ts
@@ -13,6 +13,9 @@ export const pets: Writable<Pet[]> = writable([]);
 export const selectedPet: Writable<Pet | null> = writable(null);
 export const loading = writable(false);
 export const error: Writable<string | null> = writable(null);
+/** Non-error, positive outcome text (e.g. import/auto-share summaries). Rendered
+ *  as a success banner, distinct from the destructive `error` channel. */
+export const notice: Writable<string | null> = writable(null);
 export const geneEditingView: Writable<unknown> = writable(null);
 export const activeTab: Writable<Tab> = writable('mypets');
 
@@ -289,6 +292,10 @@ export const appState = {
 
   clearError() {
     error.set(null);
+  },
+
+  clearNotice() {
+    notice.set(null);
   },
 
   setError(message: string) {

--- a/src/lib/utils/filterCSS.ts
+++ b/src/lib/utils/filterCSS.ts
@@ -269,8 +269,11 @@ export function buildVisualizerFilterCSS(input: VisualizerFilterInput): string {
       const not = sa.map((a) => `:not([data-attrs*="${delim(a)}"])`).join('');
       rules.push(`${VG} .gene-cell[data-attrs]${not} ${DIMMED_25}`);
     }
+    // Hide matches the same both-allele potential (`data-attrs`) as focus, so a
+    // locus whose other allele could express the hidden attribute is dimmed too
+    // — otherwise focus and hide would disagree on the same attribute.
     for (const h of ha) {
-      rules.push(`${VG} .gene-cell[data-attr="${h}"] ${DIMMED_25}`);
+      rules.push(`${VG} .gene-cell[data-attrs*="${delim(h)}"] ${DIMMED_25}`);
     }
   } else {
     if (sa.length > 0) {

--- a/src/lib/utils/genomeUploadController.svelte.ts
+++ b/src/lib/utils/genomeUploadController.svelte.ts
@@ -15,7 +15,7 @@ import { autoShareImportedPets, summarizeAutoShare } from '$lib/services/autoSha
 import { pickGenomeFiles, readFileContent } from '$lib/services/fileService.js';
 import { autoScanGameFolder } from '$lib/services/gameImport.js';
 import { refreshPendingImportCount } from '$lib/stores/gameImport.js';
-import { appState, error } from '$lib/stores/pets.js';
+import { appState, error, notice } from '$lib/stores/pets.js';
 import { errorMessage } from '$lib/utils/error.js';
 import type { UploadSource } from '$lib/utils/genomeUpload.js';
 import { isFileDrag, runGenomeUpload, selectGenomeFiles } from '$lib/utils/genomeUpload.js';
@@ -37,6 +37,7 @@ export function createGenomeUploadController() {
     if (sources.length === 0 || uploading || autoScanning) return;
     uploading = true;
     error.set(null);
+    notice.set(null);
     try {
       const { total, succeeded, failures, createdPetIds } = await runGenomeUpload(sources, {
         upload: (content: string) => appState.uploadPetQuiet(content),
@@ -52,7 +53,7 @@ export function createGenomeUploadController() {
         const base = `${succeeded}/${total} uploaded. ${failures.length} failed:\n${failures.join('\n')}`;
         error.set(shareNote ? `${base}\n${shareNote}` : base);
       } else if (shareNote) {
-        error.set(shareNote);
+        notice.set(shareNote);
       }
     } catch (err) {
       error.set(`Upload failed: ${errorMessage(err)}`);
@@ -119,6 +120,7 @@ export function createGenomeUploadController() {
     try {
       autoScanning = true;
       error.set(null);
+      notice.set(null);
       const result = await autoScanGameFolder({
         onProgress: (current: number, total: number) => {
           autoScanProgress = { current, total };
@@ -149,7 +151,7 @@ export function createGenomeUploadController() {
         const lines = result.failures.map((f: { file: string; reason: string }) => `${f.file}: ${f.reason}`);
         error.set(`${summary}\n${result.failures.length} failed:\n${lines.join('\n')}`);
       } else if (result.imported > 0 || result.backfilled > 0) {
-        error.set(summary);
+        notice.set(summary);
       }
     } catch (err) {
       error.set(`Auto-import failed: ${errorMessage(err)}`);

--- a/src/lib/utils/sharedPet.ts
+++ b/src/lib/utils/sharedPet.ts
@@ -18,7 +18,12 @@ import { DEFAULT_ATTRIBUTE_VALUE, type Pet, type SharedPet } from '$lib/types/in
 /** Sentinel id for a not-in-DB preview pet. Never persisted or queried. */
 export const PREVIEW_PET_ID = -1;
 
-const ATTRIBUTE_KEYS = [
+/**
+ * The eight published attribute columns, in wire order. Single source of truth
+ * shared by the upload payload (shareService), the read adapter (this module),
+ * and the community table columns (CommunityPetTable) so they can't drift.
+ */
+export const ATTRIBUTE_KEYS = [
   'intelligence',
   'toughness',
   'friendliness',

--- a/src/lib/utils/species.ts
+++ b/src/lib/utils/species.ts
@@ -1,6 +1,18 @@
+import { HORSE_BREEDS } from '$lib/types/index.js';
+
 export function getSpeciesEmoji(species: string | undefined | null): string {
   const s = (species || '').toLowerCase();
   if (s.includes('bee') || s.includes('wasp')) return '🐝';
   if (s.includes('horse')) return '🐴';
   return '🐾';
 }
+
+/**
+ * Selectable breeds per normalized species, for the breed filter on every
+ * surface (My Pets, Community, Breed). Single source of truth so the surfaces
+ * can't offer divergent breed sets.
+ */
+export const BREEDS_BY_SPECIES: Record<string, Record<string, string>> = {
+  beewasp: { Bee: 'Bee', Wasp: 'Wasp' },
+  horse: HORSE_BREEDS,
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,8 @@ import ReferenceView from '$lib/components/gene/ReferenceView.svelte';
 import SettingsView from '$lib/components/layout/SettingsView.svelte';
 import MyPets from '$lib/components/mypets/MyPets.svelte';
 import PetEditor from '$lib/components/pet/PetEditor.svelte';
-import { activeTab, appState, error, loading } from '$lib/stores/pets.js';
+import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
+import { activeTab, appState, error, loading, notice } from '$lib/stores/pets.js';
 import { editingPet, settingsOpen, uiActions } from '$lib/stores/ui.js';
 
 onMount(async () => {
@@ -25,6 +26,10 @@ onMount(async () => {
 				<div class="error-message">⚠️ {$error}</div>
 				<button class="error-close" onclick={() => appState.clearError()} aria-label="Dismiss error">×</button>
 			</div>
+		{/if}
+
+		{#if $notice}
+			<StatusBanner type="success" message={$notice} toast autoDismissMs={8000} onDismiss={() => appState.clearNotice()} />
 		{/if}
 
 		{#if $loading}

--- a/tests/unit/filterCSS.test.ts
+++ b/tests/unit/filterCSS.test.ts
@@ -182,9 +182,9 @@ describe('buildVisualizerFilterCSS', () => {
     );
   });
 
-  it('attribute view: dims a hidden attribute by its single active attribute', () => {
+  it('attribute view: dims a hidden attribute by both-allele potential (symmetric with focus)', () => {
     const css = buildVisualizerFilterCSS({ ...base, hiddenAttributes: ['Toughness'] });
-    expect(css).toBe(`${VG} .gene-cell[data-attr="Toughness"] ${DIM}`);
+    expect(css).toBe(`${VG} .gene-cell[data-attrs*="·Toughness·"] ${DIM}`);
   });
 
   it('appearance view: dims by the single appearance category', () => {

--- a/tests/unit/myPets.test.ts
+++ b/tests/unit/myPets.test.ts
@@ -89,3 +89,22 @@ describe('MyPets — selection is scoped to the visible (filtered) pets', () => 
     expect(selection(container)).toBeNull();
   });
 });
+
+describe('MyPets — prunes tag filters that no longer exist on any pet', () => {
+  it('drops a selected tag once its last carrier is gone, keeping live tags', async () => {
+    pets.set([pet({ id: 1, name: 'Dusty', tags: ['keep'] })]);
+    myPetsView.tags = ['keep', 'ghost'];
+    const { rerender } = render(MyPets);
+    await rerender({});
+    expect(myPetsView.tags).toEqual(['keep']);
+  });
+
+  it('clears an all-stale tag filter so the roster is not stranded empty', async () => {
+    pets.set([pet({ id: 1, name: 'Dusty', tags: [] })]);
+    myPetsView.tags = ['ghost'];
+    const { container, rerender } = render(MyPets);
+    await rerender({});
+    expect(myPetsView.tags).toEqual([]);
+    expect(container.querySelector('[data-testid="mypets-count"]')?.textContent).toContain('Showing 1 of 1');
+  });
+});

--- a/tests/unit/petEditorDiscardGuard.test.ts
+++ b/tests/unit/petEditorDiscardGuard.test.ts
@@ -8,7 +8,6 @@ vi.mock('$lib/services/petService.js', () => ({
   updatePet: vi.fn(),
   getAllPets: vi.fn(),
   deletePet: vi.fn(),
-  reorderPets: vi.fn(),
   uploadPet: vi.fn(),
 }));
 

--- a/tests/unit/petMarker.test.ts
+++ b/tests/unit/petMarker.test.ts
@@ -5,7 +5,6 @@ vi.mock('$lib/services/petService.js', () => ({
   updatePet: vi.fn(),
   getAllPets: vi.fn(),
   deletePet: vi.fn(),
-  reorderPets: vi.fn(),
   uploadPet: vi.fn(),
 }));
 

--- a/tests/unit/petService.test.ts
+++ b/tests/unit/petService.test.ts
@@ -310,23 +310,6 @@ describe('Pet Service', () => {
     });
   });
 
-  describe('reorderPets', () => {
-    it('persists custom sort order', async () => {
-      const a = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'A', gender: 'Female' });
-      const b = await petService.uploadPet(SAMPLE_HORSE, { name: 'B', gender: 'Male' });
-
-      // Default order is by insertion (sort_order 0, 1)
-      const before = await petService.getAllPets();
-      expect(before.items.map((p) => p.id)).toEqual([a.pet_id, b.pet_id]);
-
-      // Reverse the order
-      await petService.reorderPets([b.pet_id!, a.pet_id!]);
-
-      const after = await petService.getAllPets();
-      expect(after.items.map((p) => p.id)).toEqual([b.pet_id, a.pet_id]);
-    });
-  });
-
   describe('deletePet', () => {
     it('deletes a pet', async () => {
       const upload = await petService.uploadPet(SAMPLE_BEEWASP, { name: 'Bee', gender: 'Female' });

--- a/tests/unit/petsStore.test.ts
+++ b/tests/unit/petsStore.test.ts
@@ -193,14 +193,6 @@ describe('Pets Store', () => {
     });
   });
 
-  describe('reorderPets', () => {
-    it('sets error on failure', async () => {
-      vi.spyOn(petService, 'reorderPets').mockRejectedValueOnce(new Error('reorder failed'));
-      await expect(appState.reorderPets([1, 2])).rejects.toThrow('reorder failed');
-      expect(get(error)).toContain('reorder failed');
-    });
-  });
-
   describe('uploadPet', () => {
     it('uploads a pet and reloads the list', async () => {
       await appState.uploadPet(SAMPLE_BEEWASP, { name: 'UploadTest', gender: 'Female' });

--- a/tests/unit/shareService.test.ts
+++ b/tests/unit/shareService.test.ts
@@ -330,6 +330,48 @@ describe('shareService.uploadPet — add-only corrections', () => {
     expect(setDoc).toHaveBeenCalledTimes(1);
   });
 
+  it('does not blank published notes when a bulk re-share (notes="") only differs in notes', async () => {
+    // The catalogue entry has notes the user published via per-pet share; a
+    // later bulk/auto share sends notes='' but is otherwise identical.
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ notes: 'hand-written' }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: '' }));
+    expect(result.status).toBe('already-shared');
+    expect(setDoc).not.toHaveBeenCalled();
+  });
+
+  it('preserves published notes in a correction appended for a non-notes change', async () => {
+    // Attributes differ (so a correction is warranted), but the bulk pet carries
+    // notes='' — the correction must carry the existing notes, not blank them.
+    getDocMock
+      .mockResolvedValueOnce(
+        readSnap(matchingMeta({ notes: 'hand-written', attributes: { ...FIXTURE_ATTRS, intelligence: 99 } }), {
+          id: RAW_TEXT_HASH,
+        }),
+      )
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: '' }));
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.notes).toBe('hand-written');
+  });
+
+  it('still publishes non-empty notes from a per-pet share as a correction', async () => {
+    getDocMock
+      .mockResolvedValueOnce(readSnap(matchingMeta({ notes: '' }), { id: RAW_TEXT_HASH }))
+      .mockResolvedValueOnce(readSnap({ genomeData: RAW_TEXT }));
+
+    const result = await uploadPet(makePet({ notes: 'freshly typed' }));
+    expect(result.status).toBe('created');
+    expect(setDoc).toHaveBeenCalledTimes(1);
+    const payload = setDocMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload.notes).toBe('freshly typed');
+  });
+
   it('pins the correction identity fields to the first-share doc, not the local pet (issue #393)', async () => {
     // The catalogue entry's identity belongs to the first share — rules
     // reject a correction whose identity differs. The local pet was

--- a/tests/unit/tabNavigation.test.ts
+++ b/tests/unit/tabNavigation.test.ts
@@ -5,7 +5,6 @@ vi.mock('$lib/services/petService.js', () => ({
   updatePet: vi.fn(),
   getAllPets: vi.fn(),
   deletePet: vi.fn(),
-  reorderPets: vi.fn(),
   uploadPet: vi.fn(),
 }));
 

--- a/tests/unit/topBarGating.test.ts
+++ b/tests/unit/topBarGating.test.ts
@@ -11,7 +11,6 @@ vi.mock('$lib/services/petService.js', () => ({
   updatePet: vi.fn(),
   getAllPets: vi.fn(),
   deletePet: vi.fn(),
-  reorderPets: vi.fn(),
   uploadPet: vi.fn(),
 }));
 


### PR DESCRIPTION
Second batch of fixes from the epic-level review (first batch is #421; this is stacked on it). Covers all six review items not in #421.

## Correctness
- **#5 auto-share quota** (`autoShare.ts`) — pass `interRequestDelayMs: 150 / maxQuotaRetries: 5` to `uploadPets`, matching the other bulk callers, so a large auto-import batch stays within the Firestore Spark write quota instead of marking overflow pets `failed`.
- **#7 gene focus/hide symmetry** (`filterCSS.ts`, `GeneVisualizer.svelte`) — Alt+click-hide now dims by both-allele potential (`data-attrs`), the same signal focus uses; removed the now-dead single-allele `data-attr` emission so the two can't drift.

## Cleanup / dedup
- **#8** — one exported `ATTRIBUTE_KEYS` (`utils/sharedPet`) replaces three copies (shareService, sharedPet, community table).
- **#9** — one `BREEDS_BY_SPECIES` (`utils/species`) replaces the My Pets + community-table copies.
- **#4a** — delete the dead `reorderPets` (store + service + tests). Drag-reorder is gone in the redesign and the Roster is column-sorted, so a persistent custom order can't be the active order; `getAllPets` keeps ordering by `sort_order` as the stable default. `reorderRows` stays (image gallery uses it).

## Documented, not changed
- **#3 community list identity** — accepted as-is: rules pin correction identity for new writes and the detail view re-merges the base; the only exposure is legacy pre-rule "poisoned" corrections. Fetch-to-verify (extra reads) or blanking correction identity (would blank legitimate corrections whose base isn't paged in) both cost more than the residual risk. Rationale documented at `dedupeLatest`.

Verified: 915 unit tests pass, svelte-check 0 errors, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)