### PR TITLE
Background bulk-share for selected pets

### DIFF
--- a/src/lib/components/community/BulkSharePetDialog.svelte
+++ b/src/lib/components/community/BulkSharePetDialog.svelte
@@ -1,92 +1,39 @@
 <script lang="ts">
-import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
+/**
+ * Confirm gate for sharing a multi-selection of pets to the community.
+ *
+ * This dialog only *confirms* — the actual upload runs as a background job
+ * (`startBulkShare`), so the app stays interactive and progress surfaces in the
+ * global, non-blocking BulkShareProgress widget. On confirm it hands the pets to
+ * the parent and closes; it never blocks on the network itself.
+ */
 import { isPlaceholderConfig } from '$lib/firebase.js';
-import { type BulkUploadSummary, uploadPets } from '$lib/services/shareService.js';
-import type { DialogResult, Pet } from '$lib/types/index.js';
-import { errorMessage } from '$lib/utils/error.js';
+import type { Pet } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 
 interface Props {
   pets: Pet[];
   onClose: () => void;
-  onResult: (result: DialogResult) => void;
+  /** Called when the user confirms; the parent starts the background job. */
+  onConfirm: (pets: Pet[]) => void;
 }
 
-const { pets, onClose, onResult }: Props = $props();
-
-type Phase = 'confirm' | 'running' | 'done';
-let phase = $state<Phase>('confirm');
-let done = $state(0);
-let summary = $state<BulkUploadSummary | null>(null);
-let runError = $state('');
-let cancelRequested = $state(false);
+const { pets, onClose, onConfirm }: Props = $props();
 
 const total = $derived(pets.length);
-const percent = $derived(total > 0 ? Math.round((done / total) * 100) : 0);
 
-// Pets whose problems (skipped/failed) are worth listing back to the user.
-const problems = $derived((summary?.items ?? []).filter((i) => i.status === 'skipped' || i.status === 'failed'));
-
-async function handleShare() {
-  if (isPlaceholderConfig || phase === 'running') return;
-  phase = 'running';
-  done = 0;
-  runError = '';
-  cancelRequested = false;
-  try {
-    // Notes are intentionally excluded from bulk shares: there's no per-pet
-    // review step, so we never publish the local notes field. Per-pet sharing
-    // remains the way to opt notes in.
-    const petsToShare = pets.map((p) => ({ ...p, notes: '' }));
-    summary = await uploadPets(petsToShare, {
-      onProgress: (d) => {
-        done = d;
-      },
-      shouldCancel: () => cancelRequested,
-    });
-    phase = 'done';
-  } catch (err) {
-    // uploadPets captures per-pet errors itself; reaching here means a
-    // batch-wide failure (e.g. the genome loader threw unexpectedly).
-    runError = errorMessage(err);
-    phase = 'done';
-  }
-}
-
-function finish() {
-  if (summary) {
-    const { created, alreadyShared, skipped, failed } = summary;
-    const parts = [`${created} shared`];
-    if (alreadyShared) parts.push(`${alreadyShared} already in catalogue`);
-    if (skipped) parts.push(`${skipped} skipped`);
-    if (failed) parts.push(`${failed} failed`);
-    const msg = `Bulk share complete — ${parts.join(', ')}.`;
-    onResult({ type: failed > 0 ? 'error' : created > 0 ? 'success' : 'info', message: msg });
-  } else if (runError) {
-    // Batch-wide failure (no per-pet summary). Surface it to the parent so the
-    // error survives the dialog closing as a StatusBanner, not just in-dialog.
-    onResult({ type: 'error', message: `Bulk share failed: ${runError}` });
-  }
-  onClose();
-}
-
-function handleClose() {
-  // Don't let a backdrop/Escape close abandon an in-flight run silently.
-  if (phase === 'running') {
-    cancelRequested = true;
-    return;
-  }
-  if (phase === 'done') finish();
-  else onClose();
+function handleConfirm() {
+  if (isPlaceholderConfig || total === 0) return;
+  onConfirm(pets);
 }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
 <div
   class="modal-backdrop"
-  onclick={handleClose}
+  onclick={onClose}
   onkeydown={(e) => {
-    if (e.key === 'Escape') handleClose();
+    if (e.key === 'Escape') onClose();
   }}
   role="presentation"
   data-testid="bulk-share-backdrop"
@@ -102,12 +49,12 @@ function handleClose() {
     data-testid="bulk-share-dialog"
     onclick={(e) => e.stopPropagation()}
     onkeydown={(e) => {
-      if (e.key === 'Escape') handleClose();
+      if (e.key === 'Escape') onClose();
     }}
   >
     <div class="dialog-header">
       <h3>Share {total} {total === 1 ? 'pet' : 'pets'} to the community</h3>
-      <button class="close-btn" onclick={handleClose}>×</button>
+      <button class="close-btn" onclick={onClose}>×</button>
     </div>
 
     <div class="dialog-body">
@@ -118,79 +65,29 @@ function handleClose() {
         </div>
       {/if}
 
-      {#if phase === 'confirm'}
-        <p class="dialog-desc">
-          The genome and public fields (name, character, species, gender, breed, tags) of
-          each selected pet will be uploaded to the public catalogue, where other players
-          can import them. Uploads cannot be edited or deleted from within the app.
-        </p>
-        <ul class="confirm-notes">
-          <li><strong>Notes stay local</strong> — bulk share never uploads the notes field.</li>
-          <li>Pets already in the catalogue are detected and skipped automatically.</li>
-          <li>Pets imported before genome-text was stored will be skipped (re-import to share).</li>
-        </ul>
-      {:else if phase === 'running'}
-        <p class="dialog-desc">Sharing pets… you can cancel; pets already uploaded stay shared.</p>
-        <div
-          class="progress"
-          role="progressbar"
-          aria-valuemin="0"
-          aria-valuemax={total}
-          aria-valuenow={done}
-          data-testid="bulk-share-progress"
-        >
-          <div class="progress-fill" style="width: {percent}%"></div>
-        </div>
-        <p class="progress-label">{done} / {total}{cancelRequested ? ' (finishing current…)' : ''}</p>
-      {:else if phase === 'done'}
-        {#if runError}
-          <StatusBanner type="error" message={runError} />
-        {/if}
-        {#if summary}
-          <div class="summary" data-testid="bulk-share-summary">
-            <div class="summary-row"><span class="pill pill-ok">{summary.created}</span> shared</div>
-            {#if summary.alreadyShared > 0}
-              <div class="summary-row"><span class="pill">{summary.alreadyShared}</span> already in catalogue</div>
-            {/if}
-            {#if summary.skipped > 0}
-              <div class="summary-row"><span class="pill pill-warn">{summary.skipped}</span> skipped</div>
-            {/if}
-            {#if summary.failed > 0}
-              <div class="summary-row"><span class="pill pill-err">{summary.failed}</span> failed</div>
-            {/if}
-          </div>
-          {#if problems.length > 0}
-            <details class="problems">
-              <summary>Details ({problems.length})</summary>
-              <ul>
-                {#each problems as p (p.petId)}
-                  <li><strong>{p.petName}</strong> — {p.status}: {p.error}</li>
-                {/each}
-              </ul>
-            </details>
-          {/if}
-        {/if}
-      {/if}
+      <p class="dialog-desc">
+        The genome and public fields (name, character, species, gender, breed, tags) of
+        each selected pet will be uploaded to the public catalogue, where other players
+        can import them. Uploads cannot be edited or deleted from within the app.
+      </p>
+      <ul class="confirm-notes">
+        <li><strong>Notes stay local</strong> — bulk share never uploads the notes field.</li>
+        <li>Pets already in the catalogue are detected and skipped automatically.</li>
+        <li>Pets imported before genome-text was stored will be skipped (re-import to share).</li>
+        <li>Sharing runs in the background — you can keep using the app and cancel any time.</li>
+      </ul>
     </div>
 
     <div class="dialog-footer">
-      {#if phase === 'confirm'}
-        <button class="btn btn-secondary" onclick={onClose}>Cancel</button>
-        <button
-          class="btn btn-primary"
-          data-testid="bulk-share-confirm"
-          onclick={handleShare}
-          disabled={isPlaceholderConfig || total === 0}
-        >
-          Share {total} {total === 1 ? 'pet' : 'pets'}
-        </button>
-      {:else if phase === 'running'}
-        <button class="btn btn-secondary" data-testid="bulk-share-cancel" onclick={() => { cancelRequested = true; }} disabled={cancelRequested}>
-          {cancelRequested ? 'Cancelling…' : 'Cancel'}
-        </button>
-      {:else}
-        <button class="btn btn-primary" data-testid="bulk-share-done" onclick={finish}>Done</button>
-      {/if}
+      <button class="btn btn-secondary" onclick={onClose}>Cancel</button>
+      <button
+        class="btn btn-primary"
+        data-testid="bulk-share-confirm"
+        onclick={handleConfirm}
+        disabled={isPlaceholderConfig || total === 0}
+      >
+        Share {total} {total === 1 ? 'pet' : 'pets'}
+      </button>
     </div>
   </div>
 </div>
@@ -214,79 +111,5 @@ function handleClose() {
   }
   .confirm-notes li {
     margin-bottom: 4px;
-  }
-
-  .progress {
-    height: 10px;
-    background: var(--bg-tertiary);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-  .progress-fill {
-    height: 100%;
-    background: var(--accent);
-    transition: width 0.2s ease;
-  }
-  .progress-label {
-    margin: 8px 0 0;
-    font-size: 13px;
-    color: var(--text-secondary);
-    font-variant-numeric: tabular-nums;
-  }
-
-  .summary {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    font-size: 14px;
-    margin-bottom: 12px;
-  }
-  .summary-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    color: var(--text-secondary);
-  }
-  .pill {
-    display: inline-flex;
-    min-width: 22px;
-    justify-content: center;
-    padding: 1px 8px;
-    border-radius: 10px;
-    background: var(--bg-tertiary);
-    color: var(--text-primary);
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-  }
-  .pill-ok {
-    background: color-mix(in srgb, var(--gene-positive) 20%, transparent);
-    color: var(--gene-positive);
-  }
-  .pill-warn {
-    background: color-mix(in srgb, var(--warning-text, #d97706) 20%, transparent);
-    color: var(--warning-text, #d97706);
-  }
-  .pill-err {
-    background: color-mix(in srgb, var(--gene-negative) 20%, transparent);
-    color: var(--gene-negative);
-  }
-
-  .problems {
-    font-size: 13px;
-    color: var(--text-secondary);
-  }
-  .problems summary {
-    cursor: pointer;
-    color: var(--text-tertiary);
-  }
-  .problems ul {
-    margin: 8px 0 0;
-    padding-left: 18px;
-    max-height: 180px;
-    overflow: auto;
-  }
-  .problems li {
-    margin-bottom: 4px;
-    word-break: break-word;
   }
 </style>

--- a/src/lib/components/community/BulkShareProgress.svelte
+++ b/src/lib/components/community/BulkShareProgress.svelte
@@ -20,6 +20,10 @@ const summaryText = $derived.by(() => {
 });
 
 const tone = $derived(job.error || (job.summary?.failed ?? 0) > 0 ? 'warn' : 'ok');
+
+// Per-pet problems (skipped/failed) worth listing back to the user — the detail
+// the old blocking dialog surfaced, now shown inline in the global widget.
+const problems = $derived((job.summary?.items ?? []).filter((i) => i.status === 'skipped' || i.status === 'failed'));
 </script>
 
 {#if job.status !== 'idle'}
@@ -44,6 +48,16 @@ const tone = $derived(job.error || (job.summary?.failed ?? 0) > 0 ? 'warn' : 'ok
         <span class="bsp-title" data-testid="bulk-share-done">{summaryText}</span>
         <button type="button" class="bsp-btn" data-testid="bulk-share-dismiss" onclick={dismissBulkShare} aria-label="Dismiss">×</button>
       </div>
+      {#if problems.length > 0}
+        <details class="bsp-problems" data-testid="bulk-share-problems">
+          <summary>Details ({problems.length})</summary>
+          <ul>
+            {#each problems as p (p.petId)}
+              <li><strong>{p.petName}</strong> — {p.status}: {p.error}</li>
+            {/each}
+          </ul>
+        </details>
+      {/if}
     {/if}
   </section>
 {/if}
@@ -96,4 +110,14 @@ const tone = $derived(job.error || (job.summary?.failed ?? 0) > 0 ? 'warn' : 'ok
     cursor: pointer;
   }
   .bsp-btn:hover { color: var(--text-primary); background: var(--bg-hover); }
+
+  .bsp-problems { font-size: 12px; color: var(--text-secondary); }
+  .bsp-problems summary { cursor: pointer; color: var(--text-tertiary); }
+  .bsp-problems ul {
+    margin: 6px 0 0;
+    padding-left: 16px;
+    max-height: 160px;
+    overflow: auto;
+  }
+  .bsp-problems li { margin-bottom: 4px; word-break: break-word; }
 </style>

--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -16,14 +16,13 @@ import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import FilterBar from '$lib/components/shared/FilterBar.svelte';
-import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
 import { isPlaceholderConfig } from '$lib/firebase.js';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { bulkShareJob, startBulkShare } from '$lib/stores/bulkShare.svelte.js';
 import { pendingImportCount } from '$lib/stores/gameImport.js';
 import { clearMyPetsSelection, getMyPetsFilters, myPetsView } from '$lib/stores/mypets.svelte.js';
 import { allTags, loading, pets } from '$lib/stores/pets.js';
-import { type DialogResult, type Gender, type Pet } from '$lib/types/index.js';
+import { type Gender, type Pet } from '$lib/types/index.js';
 import { focusTrap } from '$lib/utils/focusTrap.js';
 import { createGenomeUploadController } from '$lib/utils/genomeUploadController.svelte.js';
 import { filterPets } from '$lib/utils/petFilter.js';
@@ -159,13 +158,16 @@ function closeCompare(): void {
   comparing = false;
 }
 
-// --- Bulk share -------------------------------------------------------------
+// --- Bulk share (selected pets, background job) -----------------------------
+// The dialog is a confirm gate only; the upload runs as the same background job
+// as "Share all" (startBulkShare), so the app stays interactive and progress
+// surfaces in the global BulkShareProgress widget.
 let bulkShareOpen = $state(false);
-let shareStatus = $state<DialogResult | null>(null);
 
-function handleBulkShareResult(result: DialogResult): void {
-  shareStatus = result;
-  if (result.type !== 'error') clearMyPetsSelection();
+function confirmBulkShare(toShare: Pet[]): void {
+  startBulkShare(toShare);
+  clearMyPetsSelection();
+  bulkShareOpen = false;
 }
 
 // --- Share all (whole collection, background job) ---------------------------
@@ -199,17 +201,6 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
         onToggleFlag={toggleFlag}
       />
     </div>
-
-    {#if shareStatus}
-      <div class="mp-share-status">
-        <StatusBanner
-          type={shareStatus.type}
-          message={shareStatus.message}
-          autoDismissMs={8000}
-          onDismiss={() => { shareStatus = null; }}
-        />
-      </div>
-    {/if}
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
@@ -303,7 +294,10 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
             type="button"
             class="act-btn"
             data-testid="mypets-share"
-            title="Share the selected pets to the community catalogue"
+            disabled={bulkShareJob.status === 'running'}
+            title={bulkShareJob.status === 'running'
+              ? 'A bulk share is already running'
+              : 'Share the selected pets to the community catalogue'}
             onclick={() => { bulkShareOpen = true; }}
           >🌐 Share</button>
           <button type="button" class="act-btn ghost" data-testid="mypets-clear" onclick={clearMyPetsSelection}>Clear</button>
@@ -329,7 +323,7 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
   <BulkSharePetDialog
     pets={selectedPets}
     onClose={() => { bulkShareOpen = false; }}
-    onResult={handleBulkShareResult}
+    onConfirm={confirmBulkShare}
   />
 {/if}
 
@@ -380,7 +374,6 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
   .mp-main { flex: 1; min-height: 0; display: flex; flex-direction: column; }
   .mp-main.hidden { display: none; }
   .mp-head { padding: 10px 16px; border-bottom: 1px solid var(--border-primary); flex-shrink: 0; }
-  .mp-share-status { padding: 8px 16px 0; }
 
   .mp-table { position: relative; flex: 1; min-height: 0; overflow: auto; }
   .mp-empty { height: 100%; display: flex; align-items: center; justify-content: center; }

--- a/tests/e2e/redesign-mypets.spec.ts
+++ b/tests/e2e/redesign-mypets.spec.ts
@@ -176,7 +176,7 @@ test.describe('Redesign — My Pets (table-first)', () => {
     await expect(page.locator('[data-testid="mypets-compare"]')).toBeDisabled();
   });
 
-  test('a multi-selection can be bulk-shared to the community', async ({ page }) => {
+  test('a multi-selection opens a confirm gate that Cancel dismisses', async ({ page }) => {
     await openMyPets(page);
     const checks = page.locator('[data-testid="roster-row-select"]');
     await checks.nth(0).check();
@@ -188,6 +188,8 @@ test.describe('Redesign — My Pets (table-first)', () => {
     const dialog = page.getByTestId('bulk-share-dialog');
     await expect(dialog).toBeVisible();
     await expect(dialog).toContainText('Share 2 pets to the community');
+    // The dialog only confirms — the upload itself runs as a background job.
+    await expect(dialog).toContainText('runs in the background');
     await dialog.getByRole('button', { name: 'Cancel' }).click();
     await expect(page.getByTestId('bulk-share-dialog')).toHaveCount(0);
   });

--- a/tests/e2e/shareAll.spec.ts
+++ b/tests/e2e/shareAll.spec.ts
@@ -42,4 +42,27 @@ test.describe('Share all pets', () => {
     await gotoDestination(page, 'My Pets');
     await expect(progress).toBeVisible();
   });
+
+  test('sharing a selection runs in the background via the global widget', async ({ page }) => {
+    // Select two pets and share them. Like "Share all", the selected-pets flow
+    // now delegates to the background job: the confirm dialog closes and the
+    // global, non-blocking widget takes over — no in-modal progress bar.
+    const checks = page.locator('[data-testid="roster-row-select"]');
+    await checks.nth(0).check();
+    await checks.nth(1).check();
+    await expect(page.locator('[data-testid="mypets-selection"]')).toContainText('2 selected');
+
+    await page.locator('[data-testid="mypets-share"]').click();
+    await page.locator('[data-testid="bulk-share-confirm"]').click();
+
+    // Confirm dialog is gone; the background widget is running.
+    await expect(page.getByTestId('bulk-share-dialog')).toHaveCount(0);
+    const progress = page.locator('[data-testid="bulk-share-progress-global"]');
+    await expect(progress).toBeVisible();
+    await expect(progress.locator('[role="progressbar"]')).toBeVisible();
+
+    // The selection is cleared and the Share button is disabled while it runs.
+    await expect(page.locator('[data-testid="mypets-selection"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="mypets-share-all"]')).toBeDisabled();
+  });
 });


### PR DESCRIPTION
Closes #429.

## Problem

Sharing a multi-selection of pets (My Pets → select rows → 🌐 Share) opened `BulkSharePetDialog`, a modal that ran `uploadPets` in-place behind a blocking progress bar — the app was unusable until the upload finished. "Share all" already ran in the background; selected-pet sharing did not.

## Change

- `BulkSharePetDialog` is now a confirm gate only. On confirm it starts the background job (`startBulkShare`, same path as "Share all") and closes.
- Progress and the final summary surface in the global, non-blocking `BulkShareProgress` widget at the layout root, so the app stays interactive and progress survives navigation.
- Selected shares inherit the background path's throttle + quota-retry.
- The per-pet problem breakdown (skipped/failed reasons) the modal used to show is now rendered in the global widget — no information lost.
- The "Share" button is disabled while a bulk-share job is already running.

## Tests

- Updated the multi-selection e2e in `redesign-mypets.spec.ts` (confirm gate + background copy).
- Added a background-flow e2e in `shareAll.spec.ts`: confirm closes the dialog, the global widget takes over, selection clears, Share-all disabled while running.
- Lint, svelte-check (0 errors), 916 unit tests, 12 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)