### PR TITLE
Deploy firestore.rules on release when they change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,10 +165,11 @@ This runs `scripts/release.sh` which:
 1. Bumps version in package.json, tauri.conf.json, Cargo.toml, Cargo.lock, docs/index.html
 2. Regenerates docs screenshots via `pnpm screenshots`
 3. Runs lint and E2E tests
-4. Builds changelog from commits since last tag
-5. Commits, creates annotated tag with changelog, pushes
-6. The tag triggers the Release workflow (builds macOS/Windows/Linux binaries)
-7. The Pages workflow deploys docs on release publish
+4. Deploys `firestore.rules` to the live project **if they changed since the last tag** (`firebase deploy --only firestore:rules`). The sharing catalogue has no auth — it's secured entirely by these rules, which CI does not deploy. If the client payload changes without the deployed rules matching, every share fails with `permission-denied`, so rules must never drift behind a release.
+5. Builds changelog from commits since last tag
+6. Commits, creates annotated tag with changelog, pushes
+7. The tag triggers the Release workflow (builds macOS/Windows/Linux binaries)
+8. The Pages workflow deploys docs on release publish
 
 After binaries are built, edit the draft release on GitHub to publish it.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -170,8 +170,29 @@ pnpm run lint:ci
 echo "Running tests..."
 pnpm test:e2e
 
-# --- Assemble release notes ---
+# --- Deploy Firestore rules if they changed ---
+# The public sharing catalogue has NO auth — it is secured entirely by
+# firestore.rules. Those rules live in the repo but are NOT deployed by CI or
+# the app build; they must be pushed to the live project separately. If the
+# client's write payload changes (e.g. a new field) without the deployed rules
+# being updated to match, every share fails with permission-denied. Deploy on
+# release whenever the rules changed since the last tag so they never drift.
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -n "$LAST_TAG" ]] && git diff --quiet "$LAST_TAG" HEAD -- firestore.rules; then
+  echo "Firestore rules unchanged since $LAST_TAG — skipping deploy"
+else
+  echo "Firestore rules changed (or no prior tag) — deploying to gorgonetics..."
+  if command -v firebase >/dev/null 2>&1; then
+    firebase deploy --only firestore:rules --project gorgonetics
+  else
+    echo "Error: firestore.rules need deploying but the firebase CLI is not installed."
+    echo "Install it (npm i -g firebase-tools) and run:"
+    echo "  firebase deploy --only firestore:rules --project gorgonetics"
+    exit 1
+  fi
+fi
+
+# --- Assemble release notes ---
 COMPARE_LINK="**Full Changelog**: https://github.com/gorgonetics/Gorgonetics/compare/${LAST_TAG:-initial}...v$NEW_VERSION"
 
 if [[ -f "$NOTES_FILE" ]]; then


### PR DESCRIPTION
## Why

The public sharing catalogue has no auth — it's secured entirely by `firestore.rules`. Those rules live in the repo but are not deployed by CI or the app build, so a client payload change without a matching rules deploy makes every share fail with `permission-denied` (as just happened in production). Rules must not drift behind a release.

## Change

- `scripts/release.sh`: after tests, deploy `firestore.rules` to the live project **if they changed since the last tag** (`firebase deploy --only firestore:rules --project gorgonetics`). Skipped when unchanged; errors out with instructions if the firebase CLI is missing rather than silently skipping.
- `AGENTS.md`: documented the step in the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)