### PR TITLE
Don't blank the active view on background reloads

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@ import SettingsView from '$lib/components/layout/SettingsView.svelte';
 import MyPets from '$lib/components/mypets/MyPets.svelte';
 import PetEditor from '$lib/components/pet/PetEditor.svelte';
 import StatusBanner from '$lib/components/shared/StatusBanner.svelte';
-import { activeTab, appState, error, loading, notice } from '$lib/stores/pets.js';
+import { activeTab, appState, error, loading, notice, pets } from '$lib/stores/pets.js';
 import { editingPet, settingsOpen, uiActions } from '$lib/stores/ui.js';
 
 onMount(async () => {
@@ -32,7 +32,13 @@ onMount(async () => {
 			<StatusBanner type="success" message={$notice} toast autoDismissMs={8000} onDismiss={() => appState.clearNotice()} />
 		{/if}
 
-		{#if $loading}
+		{#if $loading && $pets.length === 0}
+			<!-- Full-screen spinner only on the INITIAL load, when there's nothing to
+			     show yet. `$loading` also flips true for background reloads (e.g. an
+			     import/backfill re-running loadPets); gating on those blanked the whole
+			     destination to a spinner and remounted the active view mid-interaction —
+			     tearing down an open overlay (e.g. the breeding trio). With data already
+			     present, keep the current view mounted and let it update in place. -->
 			<div class="center-state">
 				<div class="spinner"></div>
 				<p class="state-text">Loading...</p>


### PR DESCRIPTION
## Symptom

The e2e test `redesign-breed-destination.spec.ts` › "trio can hide locked-in loci to show new gains only" was flaky: it passed in isolation but failed intermittently (~66–89%) in the full-file run.

## Root cause

Not a test issue — a real product bug. In `src/routes/+page.svelte` the global `$loading` flag gated the **entire** destination:

```
{#if $loading}  <spinner>
{:else if $activeTab === 'breed'}  <BreedView />  …
```

Any background `loadPets()` (import, backfill, etc.) flips `$loading` true → the whole active view unmounts to a spinner → `BreedView`'s `onDestroy` nulls `breedingView.selectedPair` → then remounts fresh. When that reload landed after the user opened the offspring trio, the trio closed underneath them. The test failed whenever the background reload happened to land mid-interaction; on a fast/quiet machine it landed before and passed.

This also degrades real use: any background reload blanks whatever you're viewing and tears down open overlays.

I confirmed the mechanism by instrumenting all four `selectedPair = null` sites — only `onDestroy` fired during the failing run (the species-change / candidate-guard theories were red herrings; the observed species-null came from a later, unrelated test switching species).

## Fix

Show the full-screen spinner only on the **initial** load (`$loading && $pets.length === 0`). With data already present, keep the current view mounted and let the stores update in place. One-line behavior change; no test change.

## Verification

- 10/10 green across sequential full-file runs of the previously-flaky spec (was ~1/3 green before).
- `pnpm run lint:ci` clean, `pnpm run check` 0 errors, 916/916 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)