### PR TITLE
fix: honour WHERE IN (...) in the in-memory DB adapter

### DIFF
--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -438,12 +438,34 @@ class InMemoryDatabase implements DatabaseAdapter {
   private matchesWhere(row: Record<string, unknown>, whereClause: string, params: unknown[]): boolean {
     if (!whereClause?.trim()) return true;
 
+    // Split on AND. Safe for the queries this adapter sees: an `IN (…)` list is
+    // comma-separated (no embedded AND) and no clause uses OR.
     const conditions = whereClause.split(/\s+and\s+/i);
     let paramIdx = 0;
-    for (const cond of conditions) {
-      const match = cond.trim().match(/(\w+)\s*=\s*\?/);
-      if (match) {
-        const col = match[1];
+    for (const rawCond of conditions) {
+      const cond = rawCond.trim();
+
+      // `col IN (?, ?, …)`: each `?` slot consumes one positional param in
+      // order. Without this the condition was silently dropped and every row
+      // matched, so a subset query (e.g. rows for a set of ids) leaked the
+      // rest. Literal (quoted/numeric) slots are compared as-is.
+      const inMatch = cond.match(/(\w+)\s+in\s*\(([^)]*)\)/i);
+      if (inMatch) {
+        const col = inMatch[1];
+        const slots = inMatch[2]
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean);
+        const allowed = slots.map((slot) =>
+          slot === '?' ? String(params[paramIdx++]) : String(slot).replace(/^'(.*)'$/, '$1'),
+        );
+        if (!allowed.includes(String(row[col]))) return false;
+        continue;
+      }
+
+      const eqMatch = cond.match(/(\w+)\s*=\s*\?/);
+      if (eqMatch) {
+        const col = eqMatch[1];
         if (String(row[col]) !== String(params[paramIdx])) return false;
         paramIdx++;
       }

--- a/src/lib/services/database.ts
+++ b/src/lib/services/database.ts
@@ -448,7 +448,10 @@ class InMemoryDatabase implements DatabaseAdapter {
       // `col IN (?, ?, …)`: each `?` slot consumes one positional param in
       // order. Without this the condition was silently dropped and every row
       // matched, so a subset query (e.g. rows for a set of ids) leaked the
-      // rest. Literal (quoted/numeric) slots are compared as-is.
+      // rest. In practice every slot is a placeholder (see buildInClauseParams);
+      // a bare numeric literal also works, but a quoted string literal would not
+      // — `select` lowercases the whole query before this runs, so `'Horse'`
+      // arrives as `'horse'` and fails to match a cased value.
       const inMatch = cond.match(/(\w+)\s+in\s*\(([^)]*)\)/i);
       if (inMatch) {
         const col = inMatch[1];

--- a/tests/unit/inMemoryWhere.test.ts
+++ b/tests/unit/inMemoryWhere.test.ts
@@ -20,8 +20,8 @@ describe('InMemoryDatabase — WHERE IN', () => {
     ] as const) {
       await db.execute(
         `INSERT INTO pets (id, name, species, gender, content_hash, genome_data)
-         VALUES ($id, $name, $species, 'Male', $hash, '{}')`,
-        { id, name, species, hash: `h${id}` },
+         VALUES ($id, $name, $species, $gender, $hash, $genome)`,
+        { id, name, species, gender: 'Male', hash: `h${id}`, genome: '{}' },
       );
     }
   });

--- a/tests/unit/inMemoryWhere.test.ts
+++ b/tests/unit/inMemoryWhere.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildInClauseParams, closeDatabase, getDb, initDatabase } from '$lib/services/database.js';
+
+/**
+ * The in-memory adapter's WHERE evaluation. Regression guard for the `IN (…)`
+ * clause: it previously matched only `col = ?` and silently dropped `IN`
+ * conditions, so a subset query returned every row. Real SQLite (Tauri) always
+ * honoured `IN`; these tests keep the fallback in step so dev/test reflect
+ * production.
+ */
+describe('InMemoryDatabase — WHERE IN', () => {
+  beforeEach(async () => {
+    await closeDatabase();
+    await initDatabase();
+    const db = getDb();
+    for (const [id, name, species] of [
+      [1, 'Bee', 'BeeWasp'],
+      [2, 'Horse A', 'Horse'],
+      [3, 'Horse B', 'Horse'],
+    ] as const) {
+      await db.execute(
+        `INSERT INTO pets (id, name, species, gender, content_hash, genome_data)
+         VALUES ($id, $name, $species, 'Male', $hash, '{}')`,
+        { id, name, species, hash: `h${id}` },
+      );
+    }
+  });
+
+  it('returns only the rows whose id is in the list', async () => {
+    const { placeholders, params } = buildInClauseParams([2, 3], 'id');
+    const rows = await getDb().select<{ id: number }[]>(
+      `SELECT id, name FROM pets WHERE id IN (${placeholders})`,
+      params,
+    );
+    expect(rows.map((r) => r.id).sort()).toEqual([2, 3]);
+  });
+
+  it('honours IN in a COUNT query', async () => {
+    const { placeholders, params } = buildInClauseParams([2, 3], 'id');
+    const rows = await getDb().select<{ cnt: number }[]>(
+      `SELECT COUNT(*) as cnt FROM pets WHERE id IN (${placeholders})`,
+      params,
+    );
+    expect(rows[0].cnt).toBe(2);
+  });
+
+  it('combines IN with an equality condition, consuming params in order', async () => {
+    const { placeholders, params } = buildInClauseParams([1, 2, 3], 'id');
+    const rows = await getDb().select<{ id: number }[]>(
+      `SELECT id FROM pets WHERE species = $species AND id IN (${placeholders})`,
+      { species: 'Horse', ...params },
+    );
+    expect(rows.map((r) => r.id).sort()).toEqual([2, 3]);
+  });
+
+  it('matches nothing when no id is in the list', async () => {
+    const { placeholders, params } = buildInClauseParams([99], 'id');
+    const rows = await getDb().select<{ id: number }[]>(`SELECT id FROM pets WHERE id IN (${placeholders})`, params);
+    expect(rows).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #433

`InMemoryDatabase.matchesWhere` only handled `col = ?`; `IN (...)` conditions were silently dropped, so the clause matched every row. Only the non-Tauri fallback (dev/Playwright/vitest) was affected — production SQLite handles `IN` correctly.

## Change
- Parse `col IN (?, ?, ...)` in `matchesWhere`, consuming one positional param per `?` in order.
- Unit test: IN, IN + equality (param ordering), COUNT with IN, empty match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)