### PR TITLE
fix: decouple genome grid cell size from toolbar height (#436)

### DIFF
--- a/src/lib/components/gene/GeneVisualizer.svelte
+++ b/src/lib/components/gene/GeneVisualizer.svelte
@@ -1260,6 +1260,15 @@ const blockIndices = $derived.by(() => {
         flex: 1;
         min-height: 0;
         overflow: auto;
+        /* Reserve the scrollbar gutter permanently. The responsive cell size is
+           derived from this element's contentRect width (ResizeObserver above);
+           with `overflow: auto` a vertical scrollbar that takes layout space
+           would shrink that width when it appears and restore it when it goes,
+           so any change to toolbar/legend HEIGHT (which decides whether the grid
+           overflows) leaked into cell WIDTH. `stable` keeps the width constant
+           regardless of scrollbar presence — a no-op on overlay-scrollbar
+           platforms, the decoupler on classic-scrollbar ones. See issue #436. */
+        scrollbar-gutter: stable;
         border: 1px solid var(--border-primary);
         border-radius: 6px;
         background: var(--bg-secondary);

--- a/tests/e2e/grid-cellsize-stability.spec.ts
+++ b/tests/e2e/grid-cellsize-stability.spec.ts
@@ -1,0 +1,66 @@
+import { expect, type Page, test } from '@playwright/test';
+import { waitForPets } from './helpers.js';
+
+/**
+ * Guards for #436: the responsive genome grid derives its cell size from the
+ * scroll container's content-box width. Where a scrollbar takes layout space, a
+ * *vertical* scrollbar appearing/disappearing shifts that width, so a change
+ * that only affects the grid box's HEIGHT (toolbar/legend height) leaks into
+ * cell WIDTH. `scrollbar-gutter: stable` reserves the gutter permanently so the
+ * width no longer moves.
+ *
+ * Note on coverage: the width coupling only manifests with space-taking
+ * scrollbars — the shipped Tauri WKWebView with classic scrollbars, or Windows.
+ * Playwright's Chromium renders overlay (zero-width) scrollbars on macOS and
+ * ignores both `::-webkit-scrollbar` styling and the overlay-scrollbar launch
+ * flags, so a before/after cell-size reproduction is not achievable here (it
+ * passes with or without the fix). We therefore guard the fix two ways that
+ * Chromium *can* observe: (1) the decoupling property is actually applied —
+ * removing the fix fails this; (2) cell size does not depend on the selected
+ * view, the user-visible symptom, which also catches non-scrollbar regressions
+ * (e.g. reintroducing a rebuild-on-view-change).
+ */
+
+const WIDTH = 1280;
+const CONTAINER = '.pet-visualization .gene-grid-container';
+
+async function openSampleHorse(page: Page, height: number): Promise<void> {
+  await page.setViewportSize({ width: WIDTH, height });
+  await page.goto('/');
+  await waitForPets(page);
+  await page.locator('button[data-testid="roster-open"]:has-text("Sample Horse")').click();
+  await expect(page.locator('.pet-visualization')).toBeVisible();
+  await expect(page.locator(`${CONTAINER} .gene-cell`).first()).toBeVisible();
+}
+
+async function readCellSize(page: Page): Promise<string> {
+  // Poll so the ResizeObserver-driven recompute has settled before we read.
+  let last = '';
+  await expect
+    .poll(async () => {
+      const next = await page
+        .locator(CONTAINER)
+        .evaluate((el) => getComputedStyle(el).getPropertyValue('--cell-size').trim());
+      const stable = next === last && next !== '';
+      last = next;
+      return stable;
+    })
+    .toBe(true);
+  return last;
+}
+
+test('genome grid reserves a stable scrollbar gutter, decoupling width from height (#436)', async ({ page }) => {
+  await openSampleHorse(page, 700);
+  const gutter = await page.locator(CONTAINER).evaluate((el) => getComputedStyle(el).scrollbarGutter);
+  // Without this the vertical scrollbar toggling would shift the measured width
+  // and resize the cells whenever the toolbar/legend height changes.
+  expect(gutter).toBe('stable');
+});
+
+test('genome grid cell size is identical across Attributes and Appearance views (#436)', async ({ page }) => {
+  await openSampleHorse(page, 700);
+  const sizeAttributes = await readCellSize(page);
+  await page.locator('.pet-visualization .view-btn:has-text("Appearance")').click();
+  const sizeAppearance = await readCellSize(page);
+  expect(sizeAppearance).toBe(sizeAttributes);
+});


### PR DESCRIPTION
Closes #436.

## Change
`scrollbar-gutter: stable` on `.gene-grid-container`. The responsive cell size is derived from the scroll container's `contentRect` width; where a scrollbar takes layout space, a vertical scrollbar toggling (driven by toolbar/legend height) shifted that width and resized the cells. Reserving the gutter keeps the width constant regardless of scrollbar presence — a no-op on overlay-scrollbar platforms, the decoupler on classic-scrollbar ones.

Confirmed the diff/trio grids are unaffected: they use a fixed `--cell-size`, only `GeneVisualizer` sizes responsively from a measured width.

## Tests
`tests/e2e/grid-cellsize-stability.spec.ts`:
- Asserts the container computes `scrollbar-gutter: stable` — fails if the fix is removed.
- Asserts cell size is identical across Attributes/Appearance views.

## Coverage limitation
The width coupling only manifests with **space-taking** scrollbars: the shipped Tauri WKWebView with classic scrollbars, or Windows. Playwright's Chromium renders overlay (zero-width) scrollbars on macOS and ignores `::-webkit-scrollbar` styling and the overlay-scrollbar launch flags, so a before/after cell-size reproduction is not achievable in e2e — verified `clientWidth` stays constant across a vertical-overflow toggle regardless of the fix. The guard therefore asserts the property is applied (which Chromium can see) rather than the resize behaviour.