### PR TITLE
Converge remaining segmented controls onto shared .seg chrome

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -222,10 +222,16 @@ textarea {
 }
 
 /* --- Shared segmented control --- */
-/* One chrome for exclusive-choice button groups (FilterBar's species/gender
-   toggles, Breed's species picker, Settings' theme picker): a tinted track
-   with a raised active segment. Components keep scoped size tweaks on their
-   own class alongside `seg-btn`. */
+/* One chrome for flush button groups: a tinted track holding borderless
+   buttons. Mostly exclusive-choice pickers (FilterBar's species/gender
+   toggles, Breed's species picker, Settings' theme picker, the detail
+   header's view switcher) — `.seg-btn.active` is what supplies the raised
+   active segment, so a track of plain actions (the detail header's
+   Share/Edit/Delete cluster) uses the same chrome without it.
+
+   Components keep scoped size tweaks on their own class alongside
+   `seg-btn` (e.g. GenomeGridTrio's `.gain-mode`, GenomeGridDiff's
+   `.view-toggle`) rather than re-declaring the track. */
 .seg {
   display: inline-flex;
   align-items: center;

--- a/src/lib/components/community/CommunityPetVisualization.svelte
+++ b/src/lib/components/community/CommunityPetVisualization.svelte
@@ -162,8 +162,8 @@ function handleBreedChange(fullName: string): void {
         <BreedSelector value={breedFilter} breeds={HORSE_BREEDS} onChange={handleBreedChange} />
       {/if}
       <div class="seg view-controls" role="group" aria-label="Grid view">
-        <button class="seg-btn view-btn" class:active={currentView === 'attribute'} onclick={() => handleViewChange('attribute')}>Attributes</button>
-        <button class="seg-btn view-btn" class:active={currentView === 'appearance'} onclick={() => handleViewChange('appearance')}>Appearance</button>
+        <button class="seg-btn" class:active={currentView === 'attribute'} onclick={() => handleViewChange('attribute')}>Attributes</button>
+        <button class="seg-btn" class:active={currentView === 'appearance'} onclick={() => handleViewChange('appearance')}>Appearance</button>
       </div>
       <button
         class="toggle-btn"
@@ -304,9 +304,6 @@ function handleBreedChange(fullName: string): void {
     flex-wrap: wrap;
     gap: 6px 12px;
   }
-
-  /* Track chrome comes from the global `.seg`; `.view-controls` stays as a
-     semantic hook. */
 
   .toggle-btn {
     padding: 4px 12px;

--- a/src/lib/components/community/CommunityPetVisualization.svelte
+++ b/src/lib/components/community/CommunityPetVisualization.svelte
@@ -161,9 +161,9 @@ function handleBreedChange(fullName: string): void {
       {#if isHorse}
         <BreedSelector value={breedFilter} breeds={HORSE_BREEDS} onChange={handleBreedChange} />
       {/if}
-      <div class="view-controls" role="group" aria-label="Grid view">
-        <button class="view-btn" class:active={currentView === 'attribute'} onclick={() => handleViewChange('attribute')}>Attributes</button>
-        <button class="view-btn" class:active={currentView === 'appearance'} onclick={() => handleViewChange('appearance')}>Appearance</button>
+      <div class="seg view-controls" role="group" aria-label="Grid view">
+        <button class="seg-btn view-btn" class:active={currentView === 'attribute'} onclick={() => handleViewChange('attribute')}>Attributes</button>
+        <button class="seg-btn view-btn" class:active={currentView === 'appearance'} onclick={() => handleViewChange('appearance')}>Appearance</button>
       </div>
       <button
         class="toggle-btn"
@@ -305,14 +305,8 @@ function handleBreedChange(fullName: string): void {
     gap: 6px 12px;
   }
 
-  .view-controls {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    background: var(--bg-tertiary);
-    border-radius: 6px;
-    padding: 3px;
-  }
+  /* Track chrome comes from the global `.seg`; `.view-controls` stays as a
+     semantic hook. */
 
   .toggle-btn {
     padding: 4px 12px;
@@ -340,28 +334,6 @@ function handleBreedChange(fullName: string): void {
   .header-actions {
     display: flex;
     align-items: center;
-  }
-
-  .view-btn {
-    padding: 5px 14px;
-    border: none;
-    border-radius: 4px;
-    background: transparent;
-    color: var(--text-tertiary);
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-
-  .view-btn:hover {
-    color: var(--text-secondary);
-  }
-
-  .view-btn.active {
-    background: var(--bg-primary);
-    color: var(--text-primary);
-    box-shadow: var(--shadow-sm);
   }
 
   .import-btn {

--- a/src/lib/components/comparison/GenomeGridDiff.svelte
+++ b/src/lib/components/comparison/GenomeGridDiff.svelte
@@ -399,9 +399,9 @@ function handleCellLeave() {
             <div class="diff-summary">
                 <span class="similarity-badge">{summary.similarityPercent}% identical</span>
                 <span class="summary-detail">{summary.identicalGenes}/{summary.totalGenes} genes match · {summary.differentGenes} diff</span>
-                <div class="view-toggle">
-                    <button type="button" class="view-btn" class:active={currentView === 'attribute'} onclick={() => { currentView = 'attribute'; }}>Attributes</button>
-                    <button type="button" class="view-btn" class:active={currentView === 'appearance'} onclick={() => { currentView = 'appearance'; }}>Appearance</button>
+                <div class="seg view-toggle" role="group" aria-label="Grid view">
+                    <button type="button" class="seg-btn view-btn" class:active={currentView === 'attribute'} onclick={() => { currentView = 'attribute'; }}>Attributes</button>
+                    <button type="button" class="seg-btn view-btn" class:active={currentView === 'appearance'} onclick={() => { currentView = 'appearance'; }}>Appearance</button>
                 </div>
                 <label class="diff-toggle">
                     <input type="checkbox" checked={showDiffsOnly} onchange={(e) => { showDiffsOnly = (e.target as HTMLInputElement).checked; }} />
@@ -523,11 +523,10 @@ function handleCellLeave() {
     .summary-detail { font-size: 12px; color: var(--text-secondary); }
     .diff-toggle { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); cursor: pointer; }
     .diff-toggle input { cursor: pointer; }
-    .view-toggle { display: inline-flex; border: 1px solid var(--border-primary); border-radius: 4px; overflow: hidden; }
-    .view-btn { padding: 3px 10px; border: none; background: var(--bg-primary); color: var(--text-tertiary); font-size: 11px; font-weight: 500; cursor: pointer; transition: all 0.15s; }
-    .view-btn + .view-btn { border-left: 1px solid var(--border-primary); }
-    .view-btn:hover { color: var(--text-secondary); }
-    .view-btn.active { background: var(--accent); color: white; }
+    /* Same control as the pet-detail view switcher, so it takes the shared
+       `.seg` chrome; only the density differs (this sits in the dense filter
+       row) — same scoped-tweak pattern as GenomeGridTrio's `.gain-mode`. */
+    .view-toggle .view-btn { padding: 3px 10px; font-size: 11px; }
 
     /* --cell-size 18px → 16px gene cells (calc subtracts the 2px border), the
        same density as the trio view. flex:1 makes the grid the single scroll

--- a/src/lib/components/mypets/MyPets.svelte
+++ b/src/lib/components/mypets/MyPets.svelte
@@ -16,6 +16,7 @@ import PetVisualization from '$lib/components/pet/PetVisualization.svelte';
 import DetailOverlay from '$lib/components/shared/DetailOverlay.svelte';
 import EmptyState from '$lib/components/shared/EmptyState.svelte';
 import FilterBar from '$lib/components/shared/FilterBar.svelte';
+import PageHeader from '$lib/components/shared/PageHeader.svelte';
 import { isPlaceholderConfig } from '$lib/firebase.js';
 import { getSupportedSpecies, normalizeSpecies } from '$lib/services/configService.js';
 import { bulkShareJob, startBulkShare } from '$lib/stores/bulkShare.svelte.js';
@@ -181,26 +182,32 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
 <div class="my-pets" data-testid="my-pets">
   <!-- Table layer — always mounted so detail/compare preserve its scroll. -->
   <div class="mp-main" class:hidden={detailPet || comparing}>
-    <div class="mp-head">
-      <FilterBar
-        search={myPetsView.search}
-        onSearch={(v) => { myPetsView.search = v; }}
-        species={speciesOptions}
-        activeSpecies={myPetsView.species}
-        onSpecies={(v) => { myPetsView.species = v; }}
-        breeds={breedsForSpecies}
-        breed={myPetsView.breed}
-        onBreed={(v) => { myPetsView.breed = v; }}
-        genders={['Male', 'Female']}
-        activeGender={myPetsView.gender}
-        onGender={(v) => { myPetsView.gender = v as Gender | ''; }}
-        tagOptions={$allTags}
-        activeTags={myPetsView.tags}
-        onToggleTag={toggleTag}
-        {flags}
-        onToggleFlag={toggleFlag}
-      />
-    </div>
+    <!-- Title omitted: the nav tab already names this destination, so the band
+         carries only the filter row (same shape as BreedView). The heading the
+         header would have provided stays for SR users. -->
+    <h2 class="sr-only">My pets</h2>
+    <PageHeader wide>
+      {#snippet actions()}
+        <FilterBar
+          search={myPetsView.search}
+          onSearch={(v) => { myPetsView.search = v; }}
+          species={speciesOptions}
+          activeSpecies={myPetsView.species}
+          onSpecies={(v) => { myPetsView.species = v; }}
+          breeds={breedsForSpecies}
+          breed={myPetsView.breed}
+          onBreed={(v) => { myPetsView.breed = v; }}
+          genders={['Male', 'Female']}
+          activeGender={myPetsView.gender}
+          onGender={(v) => { myPetsView.gender = v as Gender | ''; }}
+          tagOptions={$allTags}
+          activeTags={myPetsView.tags}
+          onToggleTag={toggleTag}
+          {flags}
+          onToggleFlag={toggleFlag}
+        />
+      {/snippet}
+    </PageHeader>
 
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
@@ -373,8 +380,6 @@ const canShareAll = $derived(!isPlaceholderConfig && $pets.length > 0);
 
   .mp-main { flex: 1; min-height: 0; display: flex; flex-direction: column; }
   .mp-main.hidden { display: none; }
-  .mp-head { padding: 10px 16px; border-bottom: 1px solid var(--border-primary); flex-shrink: 0; }
-
   .mp-table { position: relative; flex: 1; min-height: 0; overflow: auto; }
   .mp-empty { height: 100%; display: flex; align-items: center; justify-content: center; }
 

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -221,23 +221,23 @@ onDestroy(() => {
                     />
                 </div>
             {/if}
-            <div class="view-controls" role="group" aria-label="Grid view">
+            <div class="seg view-controls" role="group" aria-label="Grid view">
                 <button
-                    class="view-btn"
+                    class="seg-btn view-btn"
                     class:active={!galleryOpen && currentView === "attribute"}
                     onclick={() => handleViewChange("attribute")}
                 >
                     Attributes
                 </button>
                 <button
-                    class="view-btn"
+                    class="seg-btn view-btn"
                     class:active={!galleryOpen && currentView === "appearance"}
                     onclick={() => handleViewChange("appearance")}
                 >
                     Appearance
                 </button>
                 <button
-                    class="view-btn"
+                    class="seg-btn view-btn"
                     class:active={!galleryOpen && currentView === "rarity"}
                     data-testid="view-rarity-btn"
                     title="Shade each gene by how rare its value is across your pets"
@@ -251,9 +251,9 @@ onDestroy(() => {
                      look but is a different axis (which pets to measure against,
                      not which view to show), and conflating them would make
                      "the view group" ambiguous to query. -->
-                <div class="rarity-population" role="group" aria-label="Rarity baseline">
+                <div class="seg rarity-population" role="group" aria-label="Rarity baseline">
                     <button
-                        class="view-btn"
+                        class="seg-btn view-btn"
                         class:active={rarityPopulation === "stabled"}
                         data-testid="rarity-pop-stabled"
                         onclick={() => { rarityPopulation = "stabled"; }}
@@ -261,7 +261,7 @@ onDestroy(() => {
                         Stabled
                     </button>
                     <button
-                        class="view-btn"
+                        class="seg-btn view-btn"
                         class:active={rarityPopulation === "all"}
                         data-testid="rarity-pop-all"
                         onclick={() => { rarityPopulation = "all"; }}
@@ -271,7 +271,7 @@ onDestroy(() => {
                     <!-- Deferred, not forgotten: a community baseline needs a
                          precomputed aggregate rather than fetching every genome.
                          Shown disabled so the tiering stays legible. -->
-                    <button class="view-btn" disabled title="Needs a shared aggregate — not yet available">
+                    <button class="seg-btn view-btn" disabled title="Needs a shared aggregate — not yet available">
                         Community · soon
                     </button>
                 </div>
@@ -298,9 +298,9 @@ onDestroy(() => {
                     Gallery
                 </button>
             </div>
-            <div class="header-actions">
+            <div class="seg header-actions">
                 <button
-                    class="view-btn share-btn"
+                    class="seg-btn share-btn"
                     data-testid="share-pet-btn"
                     title="Share this pet to the public community catalogue"
                     onclick={() => { showShare = true; }}
@@ -468,16 +468,8 @@ onDestroy(() => {
         color: var(--bg-primary);
     }
 
-    .view-controls,
-    .rarity-population {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        background: var(--bg-tertiary);
-        border-radius: 6px;
-        padding: 3px;
-    }
-
+    /* Track chrome for .view-controls / .rarity-population / .header-actions
+       comes from the global `.seg`; these classes stay as semantic hooks. */
     .rarity-population .view-btn:disabled {
         opacity: 0.45;
         cursor: not-allowed;
@@ -510,37 +502,6 @@ onDestroy(() => {
         background: var(--accent);
         border-color: var(--accent);
         color: var(--bg-primary);
-    }
-
-    .header-actions {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        background: var(--bg-tertiary);
-        border-radius: 6px;
-        padding: 3px;
-    }
-
-    .view-btn {
-        padding: 5px 14px;
-        border: none;
-        border-radius: 4px;
-        background: transparent;
-        color: var(--text-tertiary);
-        font-size: 12px;
-        font-weight: 600;
-        cursor: pointer;
-        transition: all 0.15s ease;
-    }
-
-    .view-btn:hover {
-        color: var(--text-secondary);
-    }
-
-    .view-btn.active {
-        background: var(--bg-primary);
-        color: var(--text-primary);
-        box-shadow: var(--shadow-sm);
     }
 
     .content-area {

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -300,7 +300,7 @@ onDestroy(() => {
             </div>
             <div class="seg header-actions">
                 <button
-                    class="seg-btn share-btn"
+                    class="seg-btn"
                     data-testid="share-pet-btn"
                     title="Share this pet to the public community catalogue"
                     onclick={() => { showShare = true; }}
@@ -468,8 +468,8 @@ onDestroy(() => {
         color: var(--bg-primary);
     }
 
-    /* Track chrome for .view-controls / .rarity-population / .header-actions
-       comes from the global `.seg`; these classes stay as semantic hooks. */
+    /* Community baseline is deferred (#368) — shown disabled so the tiering
+       stays legible. */
     .rarity-population .view-btn:disabled {
         opacity: 0.45;
         cursor: not-allowed;

--- a/src/lib/components/shared/PageHeader.svelte
+++ b/src/lib/components/shared/PageHeader.svelte
@@ -21,9 +21,15 @@ interface Props {
   icon?: string;
   /** Right-aligned controls (buttons, toggles, badges). */
   actions?: Snippet;
+  /**
+   * Let `actions` take the full band width instead of hugging the right edge.
+   * For destinations whose header *is* a control row (My Pets' FilterBar)
+   * rather than a title with a few buttons beside it.
+   */
+  wide?: boolean;
 }
 
-const { title, subtitle, icon, actions }: Props = $props();
+const { title, subtitle, icon, actions, wide = false }: Props = $props();
 </script>
 
 <header class="page-header" data-testid="page-header">
@@ -41,7 +47,7 @@ const { title, subtitle, icon, actions }: Props = $props();
     </div>
   {/if}
   {#if actions}
-    <div class="ph-actions" data-testid="page-header-actions">
+    <div class="ph-actions" class:ph-actions-wide={wide} data-testid="page-header-actions">
       {@render actions()}
     </div>
   {/if}
@@ -73,4 +79,6 @@ const { title, subtitle, icon, actions }: Props = $props();
   /* Controls can wrap under the title on narrow widths without forcing the band
      taller than needed on wide ones. */
   .ph-actions { display: flex; align-items: center; flex-wrap: wrap; justify-content: flex-end; gap: 8px; flex-shrink: 0; }
+  /* `wide`: the control row IS the band, so it grows and starts at the left. */
+  .ph-actions-wide { flex: 1; min-width: 0; justify-content: flex-start; }
 </style>

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -64,7 +64,7 @@ async function doDelete(): Promise<void> {
   >✕</button>
 {:else}
   <button
-    class="hdr-btn"
+    class="seg-btn hdr-btn"
     title="Edit pet"
     data-testid="pet-edit-btn"
     data-action="edit"
@@ -72,7 +72,7 @@ async function doDelete(): Promise<void> {
     onclick={openEditor}
   >Edit</button>
   <button
-    class="hdr-btn hdr-delete"
+    class="seg-btn hdr-btn hdr-delete"
     title="Delete pet"
     data-testid="pet-delete-btn"
     data-action="delete"
@@ -119,20 +119,8 @@ async function doDelete(): Promise<void> {
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 
-  /* Button variant: self-styled to match the detail header's .view-btn look
-     (a sibling's scoped style won't reach this child component's elements). */
-  .hdr-btn {
-    padding: 5px 14px;
-    border: none;
-    border-radius: var(--radius-sm);
-    background: transparent;
-    color: var(--text-tertiary);
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.15s ease;
-  }
-  .hdr-btn:hover { color: var(--text-secondary); }
+  /* Button variant: the global `.seg-btn` supplies the chrome, so this
+     matches the detail header's segmented track without re-declaring it. */
   .hdr-delete:hover { color: var(--gene-negative); }
 
   .confirm-dialog {

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -119,11 +119,11 @@ async function doDelete(): Promise<void> {
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 
-  /* `.seg-btn.` is load-bearing, not decoration: the global
-     `.seg-btn:hover:not(:disabled)` is (0,3,0), and Svelte compiles a bare
-     `.hdr-delete:hover` to (0,3,0) too — an exact tie broken only by which
-     stylesheet the bundler emits last. Qualifying it to (0,4,0) keeps the
-     destructive action's red hover deterministic. */
+  /* Qualifying this with `.seg-btn` is load-bearing, not decoration: the
+     global `.seg-btn:hover:not(:disabled)` is (0,3,0), and Svelte compiles a
+     bare `.hdr-delete:hover` to (0,3,0) too — an exact tie broken only by
+     which stylesheet the bundler emits last. The extra class takes it to
+     (0,4,0), keeping the destructive action's red hover deterministic. */
   .seg-btn.hdr-delete:hover { color: var(--gene-negative); }
 
   .confirm-dialog {

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -119,7 +119,12 @@ async function doDelete(): Promise<void> {
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 
-  .hdr-delete:hover { color: var(--gene-negative); }
+  /* `.seg-btn.` is load-bearing, not decoration: the global
+     `.seg-btn:hover:not(:disabled)` is (0,3,0), and Svelte compiles a bare
+     `.hdr-delete:hover` to (0,3,0) too — an exact tie broken only by which
+     stylesheet the bundler emits last. Qualifying it to (0,4,0) keeps the
+     destructive action's red hover deterministic. */
+  .seg-btn.hdr-delete:hover { color: var(--gene-negative); }
 
   .confirm-dialog {
     background: var(--bg-primary);

--- a/src/lib/components/shared/PetActions.svelte
+++ b/src/lib/components/shared/PetActions.svelte
@@ -64,7 +64,7 @@ async function doDelete(): Promise<void> {
   >✕</button>
 {:else}
   <button
-    class="seg-btn hdr-btn"
+    class="seg-btn"
     title="Edit pet"
     data-testid="pet-edit-btn"
     data-action="edit"
@@ -72,7 +72,7 @@ async function doDelete(): Promise<void> {
     onclick={openEditor}
   >Edit</button>
   <button
-    class="seg-btn hdr-btn hdr-delete"
+    class="seg-btn hdr-delete"
     title="Delete pet"
     data-testid="pet-delete-btn"
     data-action="delete"
@@ -119,8 +119,6 @@ async function doDelete(): Promise<void> {
   .edit-btn:hover { color: var(--accent); }
   .action-btn.delete-btn:hover { color: var(--gene-negative); }
 
-  /* Button variant: the global `.seg-btn` supplies the chrome, so this
-     matches the detail header's segmented track without re-declaring it. */
   .hdr-delete:hover { color: var(--gene-negative); }
 
   .confirm-dialog {

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -103,6 +103,29 @@ test.describe('Pet Detail View', () => {
     await expect(page.locator('.stats-drawer')).toHaveCount(0);
   });
 
+  // Delete's red hover is the only visual warning on a destructive action, and
+  // it is won on a specificity margin over the shared `.seg-btn:hover` rule
+  // (#407). Asserted in the browser because a :hover colour can't be computed
+  // in jsdom — and the failure mode is silent: the button still works, it just
+  // stops looking dangerous.
+  test('delete keeps its danger colour on hover', async ({ page }) => {
+    const del = page.locator('[data-testid="pet-detail"] [data-testid="pet-delete-btn"]');
+    // Resolve the token to the rgb() the browser will report, via a probe.
+    const danger = await page.evaluate(() => {
+      const probe = document.createElement('span');
+      probe.style.color = getComputedStyle(document.documentElement).getPropertyValue('--gene-negative').trim();
+      document.body.appendChild(probe);
+      const v = getComputedStyle(probe).color;
+      probe.remove();
+      return v;
+    });
+    await del.hover();
+    // `.seg-btn` carries `transition: all 0.15s`, so the first frames after
+    // hover are interpolated colours — poll for the settled value rather than
+    // sampling one mid-transition (that read is what makes this flaky).
+    await expect.poll(() => del.evaluate((el) => getComputedStyle(el).color)).toBe(danger);
+  });
+
   test('back returns to the table', async ({ page }) => {
     await page.locator('[data-testid="pet-detail-back"]').click();
     await expect(page.locator('[data-testid="pet-detail"]')).toHaveCount(0);

--- a/tests/fixtures/PageHeaderHarness.svelte
+++ b/tests/fixtures/PageHeaderHarness.svelte
@@ -4,14 +4,15 @@
 import PageHeader from '$lib/components/shared/PageHeader.svelte';
 
 interface Props {
-  title: string;
+  title?: string;
   subtitle?: string;
   icon?: string;
+  wide?: boolean;
 }
-const { title, subtitle, icon }: Props = $props();
+const { title, subtitle, icon, wide }: Props = $props();
 </script>
 
-<PageHeader {title} {subtitle} {icon}>
+<PageHeader {title} {subtitle} {icon} {wide}>
   {#snippet actions()}
     <button type="button" data-testid="harness-action">Do thing</button>
   {/snippet}

--- a/tests/unit/pageHeader.test.ts
+++ b/tests/unit/pageHeader.test.ts
@@ -51,4 +51,20 @@ describe('PageHeader', () => {
     expect(actions).not.toBeNull();
     expect(actions?.querySelector('[data-testid="harness-action"]')?.textContent).toBe('Do thing');
   });
+
+  it('keeps actions right-hugging by default', () => {
+    const { container } = render(PageHeaderHarness, { title: 'Stable' } as never);
+    expect(container.querySelector('[data-testid="page-header-actions"]')?.classList.contains('ph-actions-wide')).toBe(
+      false,
+    );
+  });
+
+  // `wide` is for destinations whose header IS the control row (My Pets'
+  // FilterBar) rather than a title with buttons beside it.
+  it('lets actions take the full band when wide', () => {
+    const { container } = render(PageHeaderHarness, { wide: true } as never);
+    expect(container.querySelector('[data-testid="page-header-actions"]')?.classList.contains('ph-actions-wide')).toBe(
+      true,
+    );
+  });
 });

--- a/tests/unit/petVisualization.test.ts
+++ b/tests/unit/petVisualization.test.ts
@@ -125,6 +125,21 @@ describe('PetVisualization detail header', () => {
       expect(q(container, '.header-actions [data-testid="pet-delete-btn"]')).not.toBeNull();
     });
 
+    // #407: these tracks used to re-declare the `.seg` chrome locally, which is
+    // how they drifted apart (gap/padding/radius all differed). They now take
+    // the shared classes; a re-implementation would drop them again.
+    it('takes the shared .seg chrome rather than re-declaring it', () => {
+      const { container } = render(PetVisualization, { pet: makePet() });
+      for (const track of ['.view-controls', '.header-actions']) {
+        expect((q(container, track) as HTMLElement).classList.contains('seg')).toBe(true);
+      }
+      const viewButtons = [...(q(container, '.view-controls') as HTMLElement).querySelectorAll('button')];
+      expect(viewButtons.every((b) => b.classList.contains('seg-btn'))).toBe(true);
+      // PetActions renders into .header-actions from a child component — the
+      // case that previously forced the self-styled `.hdr-btn` mimic.
+      expect(q(container, '.header-actions [data-testid="pet-edit-btn"]')?.classList.contains('seg-btn')).toBe(true);
+    });
+
     it('Stats is a pressed toggle, not a sibling view highlight', async () => {
       const { container, getByTestId } = render(PetVisualization, { pet: makePet() });
       const stats = getByTestId('detail-stats-toggle');


### PR DESCRIPTION
Partial #407. Most of that issue was already fixed by the #341 redesign epic; audit below.

## Already done before this PR

| Item | Where it stands |
|---|---|
| `#a855f7` / `#22c55e` / literal white; `--shadow-sm` fallback copies | Tokenised |
| Radius scale | `--radius-sm/md/lg/xl/pill`, documented |
| Four back labels | Now a deliberate convention — name the destination (`DetailOverlay.svelte`) |
| Three title scales (18/15/13) | PageHeader and DetailOverlay both 15px |
| `library` naming leak | No occurrences left |
| EmptyState vs StatusPane | EmptyState is a thin wrapper over StatusPane `hero` |

## What this PR does

**Segmented-control convergence.** `.seg`/`.seg-btn` in `app.css` was already the canonical chrome (6 surfaces). Four holdouts re-declared it with drifted values — `gap: 4px` vs `2px`, `padding: 3px` vs `2px`, `border-radius: 6px` vs `--radius-lg`. That drift is why the two view-toggle looks the issue names diverged in the first place.

- `PetVisualization` — `.view-controls`, `.rarity-population`, `.header-actions`
- `CommunityPetVisualization` — `.view-controls`
- `GenomeGridDiff` — `.view-toggle`
- `PetActions` — `.hdr-btn`

`.hdr-btn` existed only because a sibling's scoped style can't reach a child component's elements. A global class can, so it's gone; Edit/Delete now match Share exactly, which the mimic never quite managed.

The old class names stay in the markup as semantic/test hooks — only the duplicated declarations were removed.

**Stray literals** in those blocks: `border-radius: 4px`, and `color: white` in `GenomeGridDiff` (same defect class as the issue's first bullet, in a file it didn't list).

**My Pets PageHeader.** `.mp-head` was a hand-rolled copy of the PageHeader band (same border, near-same padding). It now uses PageHeader, with a new `wide` prop for destinations whose header *is* a control row rather than a title with buttons beside it. Title omitted — the nav tab already names the destination, same as BreedView — with an `sr-only` heading to keep the region named.

## Deviation from the plan

I said I'd add a `.seg-bordered` variant to preserve GenomeGridDiff's bordered look. I didn't: the issue's complaint is that there are *two styles for the same concept*, and a variant would have preserved both while moving the duplication into `app.css`. It now takes the plain `.seg` with a scoped density tweak, matching GenomeGridTrio's existing `.gain-mode` precedent. **This changes GenomeGridDiff's toggle appearance** — bordered/accent-fill becomes the tinted track. Screenshotted and checked; revert-worthy if you disagree.

## Out of scope

- **Spacing scale** — `--radius-*` exists, `--space-*` doesn't. Deliberately deferred; it's a ~40-file sweep and wants its own decision on values.

## Verification

Lint clean, `svelte-check` 0 errors, 1070 unit + 137 E2E passing. Three affected surfaces checked visually in the running app (My Pets band, pet detail header incl. rarity baseline, compare view).

New tests: `wide` prop behaviour on PageHeader; a regression guard asserting the tracks carry `.seg`/`.seg-btn` rather than re-declaring the chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
