### PR TITLE
Converge ReferenceView's baseline picker onto the shared .seg chrome

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -280,6 +280,14 @@ textarea {
   color: var(--text-secondary);
 }
 
+/* Both surfaces that disable a segment do it for the same reason — a tier
+   that exists but isn't available yet (the deferred community baseline,
+   #368) — and dimmed the button identically in their own scoped blocks. */
+.seg-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 .seg-btn.active {
   background: var(--bg-primary);
   color: var(--text-primary);

--- a/src/lib/components/gene/ReferenceView.svelte
+++ b/src/lib/components/gene/ReferenceView.svelte
@@ -132,7 +132,7 @@ $effect(() => {
       {/if}
       <div class="ref-field">
         <span>Baseline</span>
-        <div class="ref-segment" role="group" aria-label="Rarity baseline">
+        <div class="seg" role="group" aria-label="Rarity baseline">
           <button
             class="seg-btn"
             class:active={rarityPopulation === 'stabled'}
@@ -211,18 +211,6 @@ $effect(() => {
   /* The map owns its own scrolling (its cell size is measured from that box),
      so the wrapper must not scroll or the two would fight. */
   .ref-body-map { overflow: hidden; display: flex; min-width: 0; }
-
-  .ref-segment {
-    display: flex; align-items: center; gap: var(--space-2xs);
-    background: var(--bg-secondary); border-radius: 6px; padding: 3px;
-  }
-  .seg-btn {
-    padding: 5px var(--space-md); border: none; background: transparent; border-radius: 4px;
-    font-size: 12px; font-weight: 600; color: var(--text-secondary); cursor: pointer;
-  }
-  .seg-btn:hover:not(:disabled) { background: var(--bg-primary); }
-  .seg-btn.active { background: var(--accent); color: var(--text-inverse); }
-  .seg-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
   .edit-toggle {
     margin-left: auto; padding: 7px var(--space-xl); border: 1px solid var(--border-secondary);

--- a/src/lib/components/pet/PetVisualization.svelte
+++ b/src/lib/components/pet/PetVisualization.svelte
@@ -468,13 +468,6 @@ onDestroy(() => {
         color: var(--bg-primary);
     }
 
-    /* Community baseline is deferred (#368) — shown disabled so the tiering
-       stays legible. */
-    .rarity-population .view-btn:disabled {
-        opacity: 0.45;
-        cursor: not-allowed;
-    }
-
     .toggle-controls {
         display: flex;
         align-items: center;


### PR DESCRIPTION
Closes the last `.seg` inconsistency from #407, found by a review pass over #467/#468.

**Stacked on #468** (which is stacked on #467). Kept separate rather than folded into #468 because that PR's headline claim is "provably lossless, nothing moves on screen" — this deliberately changes appearance.

## What was wrong

`ReferenceView` declared its **own scoped `.seg-btn`** while its buttons also carried `class="seg-btn"`, so both rules matched. The local won on properties it set; the global leaked in on the rest (`white-space: nowrap`, `transition`). Unbounded: any property added to global `.seg-btn` later would silently land on a control styled to different rules.

It also rendered the *same control* as `PetVisualization` in a different chrome. Both are `role="group" aria-label="Rarity baseline"` with the same three buttons and the same disabled `title`:

| | PetVisualization | ReferenceView (before) |
|---|---|---|
| track | `--bg-tertiary`, radius 8px, pad 2px | `--bg-secondary`, radius 6px, pad 3px |
| active | raised white + shadow | accent fill + inverse text |
| hover | colour change | background change |

#467 rewrote the `app.css` comment to declare `.seg-btn` the app's single chrome while leaving the one component that contradicted it. This makes the claim true.

## Change

- `ReferenceView`'s picker takes `.seg` / the global `.seg-btn`; its local block is deleted.
- **`.seg-btn:disabled` promoted to `app.css`.** Both surfaces disable a segment for the same reason — the deferred community tier (#368) — and had identical scoped copies. Both are now deleted.

Net −11 lines. The only remaining `.seg-btn`-prefixed scoped rule in the app is `.seg-btn.hdr-delete:hover`, which is the deliberate specificity qualifier from #467, not a shadow.

## Verification

Lint clean, `svelte-check` 0 errors, 1074 unit + 138 E2E passing.

Checked in the running app, since this is a visual change: the Reference picker now matches the pet-detail one, and the disabled "Community · soon" button computes `opacity: 0.45` / `cursor: not-allowed` on **both** surfaces from the new global rule — verified explicitly because this PR deletes both scoped copies.

CI will not run here (workflows trigger only on PRs targeting `main`/`develop`/`redesign/**`); it starts once the stack retargets on merge.

## Not done

The two pickers still duplicate their markup, state and testids (`map-pop-*` vs `rarity-pop-*`). Extracting a shared component is the right fix, but it belongs with the community tier work — when that ships, the disabled button has to be enabled in both places. Worth doing as part of #368 rather than speculatively now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
